### PR TITLE
Fix DKMS build fail when updating kernel

### DIFF
--- a/kernel_module/dkms.conf
+++ b/kernel_module/dkms.conf
@@ -1,6 +1,6 @@
 PACKAGE_NAME="LenovoLegionLinux"
 PACKAGE_VERSION="1.0.0"
-MAKE[0]="make KERNEL_VERSION=${kernelver}"
+MAKE[0]="make KERNELVERSION=${kernelver}"
 BUILT_MODULE_NAME[0]="legion-laptop"
 AUTOINSTALL="yes"
 DEST_MODULE_LOCATION[0]="/kernel/drivers/platform/x86"


### PR DESCRIPTION
There is a variable name mismatch between dkms.conf and Makefile.
When updating kernel, DKMS try to build on old kernel which does not exist. 