### PR TITLE
add restrict-profiles when use battery

### DIFF
--- a/extra/service/restrict-profiles
+++ b/extra/service/restrict-profiles
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+daemon=$(systemctl is-active power-profiles-daemon.service)
+
+if [[ $daemon == "inactive" ]]; then
+	printf "power-profiles-daemon is not running.\n"
+	return 0
+fi
+
+profile=$(powerprofilesctl get)
+
+battery=$(cat /sys/class/power_supply/BAT*/status | grep -c Discharging)
+
+if [[ $profile == "performance" && battery -gt 0 ]]; then
+	powerprofilesctl set balanced
+fi

--- a/extra/service/restrict-profiles.service
+++ b/extra/service/restrict-profiles.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Restrict Power Profiles On Battery
+StartLimitIntervalSec=0
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/restrict-profiles
+
+[Install]
+RequiredBy=legion-linux.service


### PR DESCRIPTION
close #77
With this service enabled, if the user tries to switch to performance mode with power-profiles-daemon while using the battery, he will be forced to switch back to balanced-mode