### PR TITLE
update setup.cfg

### DIFF
--- a/python/legion_linux/setup.cfg
+++ b/python/legion_linux/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = legion_linux
-version = _VERSION
+version = 0.0.5
 author = johnfan
 author_email = johnfan@example.org
 description = Control Lenovo Legion laptop


### PR DESCRIPTION
to prevent `InvalidVersion` error with new version of setuptools

If you use the newer setuptools-68.1.2, you will run into this problem, the setuptools on gentoo ~amd64 are newer, and the original VERSION will result in a failure to compile successfully