### PR TITLE
use `size_t` instead of `int` when iterating through `fancurve->points`

### DIFF
--- a/kernel_module/legion-laptop.c
+++ b/kernel_module/legion-laptop.c
@@ -2087,7 +2087,7 @@ static bool fancurve_set_size(struct fancurve *fancurve, int size,
 	}
 	if (init_values && size > fancurve->size) {
 		// fancurve increased, so new entries need valid values
-		int i;
+		size_t i;
 		int last = fancurve->size > 0 ? fancurve->size - 1 : 0;
 
 		for (i = fancurve->size; i < size; ++i)
@@ -2099,7 +2099,7 @@ static bool fancurve_set_size(struct fancurve *fancurve, int size,
 static ssize_t fancurve_print_seqfile(const struct fancurve *fancurve,
 				      struct seq_file *s)
 {
-	int i;
+	size_t i;
 
 	seq_printf(
 		s,


### PR DESCRIPTION
While `MAXFANCURVESIZE` wont be greater than `MAX_INT`, it's much better to use the same type of `fancurve->size` when iterating.