### PR TITLE
Create legion-linux-onresume.service

### DIFF
--- a/extra/service/legion-linux-onresume.service
+++ b/extra/service/legion-linux-onresume.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Restart legion-linux on resume
+Before=sleep.target
+StopWhenUnneeded=yes
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStop=/usr/bin/systemctl restart legion-linux.service
+TimeoutStopSec=infinity
+
+[Install]
+WantedBy=sleep.target


### PR DESCRIPTION
Some modifications, such as the changes made by ryzenadj, cannot be preserved after the machine goes through the suspend-resume cycle. Therefore, we can create a file to allow the Legion service to automatically start once the machine resumes.