### PR TITLE
Fix typo in comment in legion-laptop.c

### DIFF
--- a/kernel_module/legion-laptop.c
+++ b/kernel_module/legion-laptop.c
@@ -33,7 +33,7 @@
  *        have to be reconfigured if needed.
  *
  *  It implements the usual hwmon interface to monitor fan speed and temmperature
- *  and allows to set the fan curve inside the firware.
+ *  and allows to set the fan curve inside the firmware.
  *
  *    - /sys/class/hwmon/X/fan1_input or /sys/class/hwmon/X/fan2_input  (ro)
  *        Current fan speed of fan1/fan2.


### PR DESCRIPTION
Correct the spelling of "firmware" in the comment describing the hwmon interface for monitoring fan
speed and temperature and setting the fan curve.