### PR TITLE
Add Lenovo LOQ 2024 Model (NECN)

### DIFF
--- a/kernel_module/legion-laptop.c
+++ b/kernel_module/legion-laptop.c
@@ -964,6 +964,26 @@ static const struct model_config model_lzcn = {
 	.ramio_size = 0x600
 };
 
+// LOQ Model 2024
+static const struct model_config model_necn = {
+	.registers = &ec_register_offsets_loq_v0,
+	.check_embedded_controller_id = true,
+	.embedded_controller_id = 0x8227,
+	.memoryio_physical_ec_start = 0xC400,
+	.memoryio_size = 0x300,
+	.has_minifancurve = true,
+	.has_custom_powermode = true,
+	.access_method_powermode = ACCESS_METHOD_WMI,
+	.access_method_keyboard = ACCESS_METHOD_WMI2,
+	.access_method_fanspeed = ACCESS_METHOD_WMI3,
+	.access_method_temperature = ACCESS_METHOD_WMI3,
+	.access_method_fancurve = ACCESS_METHOD_EC3,
+	.access_method_fanfullspeed = ACCESS_METHOD_WMI3,
+	.acpi_check_dev = false,
+	.ramio_physical_start = 0xFE0B0400,
+	.ramio_size = 0x600
+};
+
 static const struct dmi_system_id denylist[] = { {} };
 
 static const struct dmi_system_id optimistic_allowlist[] = {
@@ -1311,6 +1331,15 @@ static const struct dmi_system_id optimistic_allowlist[] = {
 			DMI_MATCH(DMI_BIOS_VERSION, "LZCN"),
 		},
 		.driver_data = (void *)&model_lzcn
+	},
+	{
+		// e.g. LOQ 15IRX9
+		.ident = "NECN",
+		.matches = {
+			DMI_MATCH(DMI_SYS_VENDOR, "LENOVO"),
+			DMI_MATCH(DMI_BIOS_VERSION, "NECN"),
+		},
+		.driver_data = (void *)&model_necn
 	},
 	{}
 };


### PR DESCRIPTION
OS: Manjaro 
Model name: LOQ 15IRX9
CPU model: Intel® Core™ i7-13650HX
GPU model: NVIDIA GeForce RTX 3050 6GB
Keyboard backlight:  single color with off/medium/bright


[dmidecode.bios.log](https://github.com/user-attachments/files/16337342/dmidecode.bios.log)
[dmidecode.system.log](https://github.com/user-attachments/files/16337344/dmidecode.system.log)
[fancurve.log](https://github.com/user-attachments/files/16337345/fancurve.log)
