### PR TITLE
Change beaviour of dracut

### DIFF
--- a/deploy/LenovoLegionLinux
+++ b/deploy/LenovoLegionLinux
@@ -8,7 +8,7 @@ Main() {
     elif [[ "$installed" =~ eos-dracut ]] ; then
         dracut-rebuild
     elif [[ "$installed" =~ dracut ]] ; then
-        dracut -f --regenerate-all --uefi
+        dracut-rebuild
     elif [[ "$installed" =~ mkinitcpio ]] ; then
         # Pevents mkinitcpio of run twices
         # mkinitcpio -P


### PR DESCRIPTION
It would be better to use 'dracut-rebuild' instead of 'dracut -f --regenerate-all --uefi' because it creates multiple voices for each kernel and, when there is no space left, it will not create the EFI.

Find out I had a couple of EFI voices of old kernel and not the latest.