### PR TITLE
Fix: Typos for echo messages on install

### DIFF
--- a/README.md
+++ b/README.md
@@ -686,7 +686,7 @@ These are the profiles avaiable:
 - balanced-performance-ac - Fan Profile on custom mode on charger
 - performance-ac - Fan Profile on performance mode on charger
 
-Exemple profiles are [here](extra/service/profiles) can also be set via the gui for easy set up:
+Example profiles are [here](extra/service/profiles) can also be set via the gui for easy set up:
 1 - Set the `Fan Curve` you like to use
 2 - Chose on the profile above in `Fancurve Preset` and hit Sate to Preset (will ask for you password)
 3 - Set all the profiles

--- a/deploy/build_packages/lenovolegionlinux.spec
+++ b/deploy/build_packages/lenovolegionlinux.spec
@@ -92,8 +92,8 @@ rm -rf %{buildroot}/usr/lib/debug
 %exclude /usr/lib/debug
 
 %post
-echo "Frist install?! Pls copy /usr/share/legion_linux folder to /etc/legion_linux.\n"
-echo "Command: sudo cp /usr/share/legion_linux /etc/legion_linux"
+echo "If first install, copy /usr/share/legion_linux folder to /etc/legion_linux.\n"
+echo "Command: sudo cp -r /usr/share/legion_linux /etc/legion_linux"
 
 %preun
 echo "After uninstall you can remover /etc/legion_linux to get rid of the configuration file!"


### PR DESCRIPTION
Note: I assume you didn't commit the real v0.0.20 echo script, as it doesn't match the output when you install:

Current live output:
```
Default config files are present in /usr/share/legion_linux
Frist install: Pls copy folder /usr/share/legion_linux to /etc/legion_linux
Is also provided acpi exemple on /usr/share/legion_linux/acpi
```
