### PR TITLE
Add LOQ 15AHP9

### DIFF
--- a/kernel_module/legion-laptop.c
+++ b/kernel_module/legion-laptop.c
@@ -986,6 +986,26 @@ static const struct model_config model_necn = {
 	.ramio_size = 0x600
 };
 
+// LOQ 15AHP9
+static const struct model_config model_nzcn = {
+	.registers = &ec_register_offsets_loq_v0,
+	.check_embedded_controller_id = true,
+	.embedded_controller_id = 0x8227,
+	.memoryio_physical_ec_start = 0xC400,
+	.memoryio_size = 0x300,
+	.has_minifancurve = true,
+	.has_custom_powermode = true,
+	.access_method_powermode = ACCESS_METHOD_WMI,
+	.access_method_keyboard = ACCESS_METHOD_WMI2,
+	.access_method_fanspeed = ACCESS_METHOD_WMI3,
+	.access_method_temperature = ACCESS_METHOD_WMI3,
+	.access_method_fancurve = ACCESS_METHOD_EC3,
+	.access_method_fanfullspeed = ACCESS_METHOD_WMI3,
+	.acpi_check_dev = false,
+	.ramio_physical_start = 0xFE0B0400,
+	.ramio_size = 0x600
+};
+
 static const struct dmi_system_id denylist[] = { {} };
 
 static const struct dmi_system_id optimistic_allowlist[] = {
@@ -1351,6 +1371,15 @@ static const struct dmi_system_id optimistic_allowlist[] = {
 			DMI_MATCH(DMI_BIOS_VERSION, "NECN"),
 		},
 		.driver_data = (void *)&model_necn
+	},
+	{
+		// e.g. LOQ 15AHP9 (AMD Ryzen 7 8845HS + RTX 4060)
+		.ident = "NZCN",
+		.matches = {
+			DMI_MATCH(DMI_SYS_VENDOR, "LENOVO"),
+			DMI_MATCH(DMI_BIOS_VERSION, "NZCN"),
+		},
+		.driver_data = (void *)&model_nzcn
 	},
 	{}
 };


### PR DESCRIPTION
OS: Gentoo
Model name: LOQ 15AHP9
CPU model: AMD Ryzen 7 8845HS
GPU model: NVIDIA GeForce RTX 4060 8GB
Keyboard backlight: single color with off/medium/bright

[dmibios.log](https://github.com/user-attachments/files/20204914/dmibios.log)
[dmisystem.log](https://github.com/user-attachments/files/20204915/dmisystem.log)
[fancurve.log](https://github.com/user-attachments/files/20204916/fancurve.log)

