### PR TITLE
Restore `legiond` compatibility with kernel 6.14.6

### DIFF
--- a/extra/service/legiond/legiond.c
+++ b/extra/service/legiond/legiond.c
@@ -29,7 +29,7 @@ void term_handler(int signum)
 	exit(0);
 }
 
-void timer_handler()
+void timer_handler(union sigval sigev_value)
 {
 	pretty("config reload start");
 	parseconf(&config);


### PR DESCRIPTION
Linux kernel v6.14.6 (at least; possibly earlier) requires that `sigevent.sigev_notify_function` handlers accept a `union sigval` argument. This PR adds such an argument, although it is currently unused.

***Maintainer feedback needed:*** Is that appropriate, or do we want to actually use `sigev_value` somewhere?

Fixes #318