### PR TITLE
Improve GPU mode change support in kernel module

### DIFF
--- a/kernel_module/legion-laptop.c
+++ b/kernel_module/legion-laptop.c
@@ -4351,6 +4351,39 @@ static ssize_t igpumode_store(struct device *dev, struct device_attribute *attr,
 
 static DEVICE_ATTR_RW(igpumode);
 
+static ssize_t notify_dgpu_store(struct device *dev,
+				 struct device_attribute *attr, const char *buf,
+				 size_t count)
+{
+	return store_simple_wmi_attribute(dev, attr, buf, count,
+					  LEGION_WMI_GAMEZONE_GUID, 0,
+					  WMI_METHOD_ID_NOTIFYDGPUSTATUS, false,
+					  1);
+}
+
+static DEVICE_ATTR_WO(notify_dgpu);
+
+static ssize_t issupportigpumode_show(struct device *dev,
+				      struct device_attribute *attr, char *buf)
+{
+	return show_simple_wmi_attribute(dev, attr, buf,
+					 LEGION_WMI_GAMEZONE_GUID, 0,
+					 WMI_METHOD_ID_ISSUPPORTIGPUMODE, false,
+					 1);
+}
+
+static DEVICE_ATTR_RO(issupportigpumode);
+
+static ssize_t issupportgsync_show(struct device *dev,
+				   struct device_attribute *attr, char *buf)
+{
+	return show_simple_wmi_attribute(dev, attr, buf,
+					 LEGION_WMI_GAMEZONE_GUID, 0,
+					 WMI_METHOD_ID_ISSUPPORTGSYNC, false, 1);
+}
+
+static DEVICE_ATTR_RO(issupportgsync);
+
 static ssize_t cpu_oc_show(struct device *dev, struct device_attribute *attr,
 			   char *buf)
 {
@@ -4742,6 +4775,9 @@ static struct attribute *legion_sysfs_attributes[] = {
 	&dev_attr_issupportgpuoc.attr,
 	&dev_attr_aslcodeversion.attr,
 	&dev_attr_igpumode.attr,
+	&dev_attr_notify_dgpu.attr,
+	&dev_attr_issupportigpumode.attr,
+	&dev_attr_issupportgsync.attr,
 	NULL
 };
 


### PR DESCRIPTION
Add some missing functions that are necessary for a proper GPU mode change.

| Mode          | gsync (inverted) | igpumode |
|---------------|:----------------:|:--------:|
| dGPU          |         0        |     0    |
| Hybrid        |         1        |     0    |
| iGPU-only     |         1        |     1    |
| Hybrid (auto) |         1        |     2    |

To enable iGPU-only mode:

```bash
echo 1 > /sys/module/legion_laptop/drivers/platform\:legion/PNP0C09\:00/igpumode

# Wait for GPU to disappear
while lspci | grep -i nvidia &> /dev/null ; do
  echo 1 > /sys/module/legion_laptop/drivers/platform\:legion/PNP0C09\:00/notify_dgpu
  sleep 5
  # echo 1 > /sys/bus/pci/rescan
done
echo 0 > /sys/module/legion_laptop/drivers/platform\:legion/PNP0C09\:00/notify_dgpu
```

To go back to Hybrid mode:

```bash
echo 0 > /sys/module/legion_laptop/drivers/platform\:legion/PNP0C09\:00/igpumode

# Wait for GPU to appear
while ! lspci | grep -i nvidia &> /dev/null ; do
  echo 0 > /sys/module/legion_laptop/drivers/platform\:legion/PNP0C09\:00/notify_dgpu
  sleep 5
  echo 1 > /sys/bus/pci/rescan
done
echo 1 > /sys/module/legion_laptop/drivers/platform\:legion/PNP0C09\:00/notify_dgpu
```

Caveats:
- `prime-select` should be set up correctly before changing modes
- brightness in iGPU mode should be controlled by `acpi_backlight=video`, but in dGPU mode it does not work
- changing modes requires reboot to fully work
- hybrid-auto requires `notify_dgpu` to wake dGPU up and also requires rebooting the system