### PR TITLE
Fixes LOQ model fancurves

### DIFF
--- a/kernel_module/legion-laptop.c
+++ b/kernel_module/legion-laptop.c
@@ -2454,7 +2454,7 @@ static ssize_t fancurve_print_seqfile(const struct fancurve *fancurve,
 		const struct fancurve_point *point = &fancurve->points[i];
 
 		fancurve_get_speed_pwm(fancurve, i, 0, &speed_pwm1);
-		fancurve_get_speed_pwm(fancurve, i, 0, &speed_pwm2);
+		fancurve_get_speed_pwm(fancurve, i, 1, &speed_pwm2);
 
 		seq_printf(
 			s,


### PR DESCRIPTION
Hi me again :), tldr of this PR :
- Fix for fancurves for LOQ Model (Tested on LZCN model),  reads and sets values when in Custom Mode for CPU Fan (min temp, max temp, rpm), GPU Fan (min temp, max temp, rpm), IC (min temp, max temp), and works!.
- WMI methods to read/write current Fan Indices (read details)

Now the details :

When using the Lenovo Vantage Application when setting the custom mode and modifying its levels (points) :
* Only changes position indices in an array that has the same size of the Fancurve.
* Each element value of that array points to the element that contains the speed in the current Fancurve selected.
* The Fancurve is selected depending on the thermal mode (quiet/balanced/performance/custom), the dGPU (by vendor id) and a PRID (value in DSDT) that I think is the mode of the laptop (hybrid, iGPU, dGPU, and another that wakes up the dGPU when used according to the Vantage app)

It can be queried with the following powershell script : 
```powershell
$classInstance = Get-CimInstance -Namespace root/wmi -ClassName LENOVO_FAN_METHOD
$classInstance | Invoke-CimMethod -MethodName Fan_Get_Table -Arguments @{FanID=0;SensorID=0}
```

```txt
FanTable        : {2, 2, 3, 4, 5, 6, 7, 8 ,9 ,9}
FanTableSize    : 10
SensorTable     : {2, 2, 3, 4, 5, 6 ,7, 8, 9 ,9}
SensorTableSize : 10
ReturnValue     : True
```
In this output the value 2 is repeated because I changed the first point of the fancurve to the same level as the second point (1400, 1400). This method is implemented now in function `wmi_read_fancurve_idx`. FanId and SensorId parameters doesnt make any difference. 

There are many Fan Curves defined and can be queried with the following powershell :
```powershell
$classInstance = Get-CimInstance -Namespace root/wmi -ClassName LENOVO_FAN_TABLE_DATA
$classInstance
```

```text
Active                      : True
CurrentFanMaxSpeed          : 3900
CurrentFanMinSpeed          : 0
DesignMaxFanSpeedNumber     : 10
EndOnlyUpwardAdjustNumber   : 10
Fan_Id                      : 1
FanSpeedStep                : 100
FanTable_Data               : {1400, 1700, 1900, 2200, 2500, 2700, 2900, 3100, 3500, 3900}
FanTable_Len                : 10
InstanceName                : ACPI\PNP0C14\GMZN_0
MaxSensorTemperature        : 100
MinSensorTemperature        : 0
Mode                        : 3
Reserved                    : 0
Sensor_ID                   : 4
SensorTable_Data            : {60, 64, 68, 72, 76, 80, 84, 93, 99, 100}
SensorTable_Len             : 10
SensorTemperatureStep       : 1
StartOnlyUpwardAdjustNumber : 0
PSComputerName              :
...
```
This output is just one example, In Windows it shows 15 I assume it gets only the Fan Table specific for the laptop model, In the ACPI DSDT there are 4 Tables of 15 each one.  Also the temps here are not used there are other tables with temps selected also by the thermal mode, dgpu and PRID logic.

We dont care too much about the Fan Curves predefined, maybe as a reference, however Vantage app doesnt use the 10th one that has the highest temp 120 for the IC sensor (the index doesnt start at 0 as C arrays it starts at 1), you can see in the output of `Get_Fan_Table` uses index 9 for the 10th position. This can be a warning when changing those values.  

The WMI call that the Vantage App uses `LENOVO_FAN_METHOD.Fan_Set_Table` related to the ACPI/DSDT SFAN Method only works with the indices mapping, doesnt set directly RPM's it obtains them from its internal tables. This method is implemented in `wmi_write_fancurve_idx`.

The  function `wmi_read/write_fancurve_idx` can be used as new feature on the variables exposed by the driver in hwmon or acpi/firmware (maybe) and also on the python client, if someone wants to develop it. 

Besides the modes Quiet (1), Balanced (2), Performance (3) and Custom (255) there is a Extreme Mode (224).

So following the DSDT code as a guide of how to obtain the rpm's, I replaced the old `ec_read/write_fancurve_loq` to reset the index mapping to an ordered list (1-10) that represent the speed RPM's that are being passed as arguments (via cmd line, legion.py, legion_gui.py), sets the correct values on the offsets on the 3 groups (cpu, gpu, ic), and activates a flag to tell the device/ec to use the new values.

Note:
- When changing the Power Profile to quiet/normal/performance with Fn+Q or `echo "balanced" > /sys/firmware/acpi/platform_profile`, the values are reset to the bios/dsdt defaults and the 3 sets of custom values are not changed, so when querying `cat /sys/kernel/debug/legion/fancurve` it will appear the custom values but not the current ones, I think that when changing powermodes also we have to call `wmi_write_fancurve_idx`  so we reset the indices, and the acpi/dsdt set the default speeds and temps of the current powermode. 

Test Output of Fancurve (Custom Mode, modes set in Vantage App):
```text
Fan curve points size: 10
u(speed_of_unit)|speed1[u]|speed2[u]|speed1[pwm]|speed2[pwm]|acceleration|deceleration|cpu_min_temp|cpu_max_temp|gpu_min_temp|gpu_max_temp|ic_min_temp|ic_max_temp
3        14      14      35      35      0       0       0       70      0       48      0       42
3        14      14      35      35      0       0       60      73      45      55      38      63
3        17      17      43      43      0       0       70      77      57      60      59      70
3        19      19      48      48      0       0       75      80      59      65      60      72
3        22      22      56      56      0       0       78      84      62      77      60      72
3        25      25      63      63      0       0       80      84      70      82      60      72
3        29      29      73      73      0       0       82      92      80      87      60      78
3        31      31      79      79      0       0       87      95      80      87      76      90
3        35      35      89      89      0       0       92      99      80      87      89      105
3        35      35      89      89      0       0       94      100     85      100     90      120
```

Changing the CPU and GPU fans
```bash
# cpu
export HWMONPATH=/sys/class/hwmon/hwmon5
echo 65 >$HWMONPATH/pwm1_auto_point2_temp_hyst
echo 72 >$HWMONPATH/pwm1_auto_point2_temp
echo 35 >$HWMONPATH/pwm1_auto_point2_pwm

# gpu
echo 46 >$HWMONPATH/pwm2_auto_point2_temp_hyst
echo 56 >$HWMONPATH/pwm2_auto_point2_temp
echo 35 >$HWMONPATH/pwm2_auto_point2_pwm

```
output of fancurve
```text
u(speed_of_unit)|speed1[u]|speed2[u]|speed1[pwm]|speed2[pwm]|acceleration|deceleration|cpu_min_temp|cpu_max_temp|gpu_min_temp|gpu_max_temp|ic_min_temp|ic_max_temp
3        14      14      35      35      0       0       0       60      0       45      0       42
3        13      13      33      33      0       0       65      72      46      56      38      63
3        17      17      43      43      0       0       70      77      57      60      59      70
3        19      19      48      48      0       0       75      80      59      65      60      72
3        22      22      56      56      0       0       78      84      62      77      60      72
3        25      25      63      63      0       0       80      84      70      82      60      72
3        29      29      73      73      0       0       82      92      80      87      60      78
3        31      31      79      79      0       0       87      95      80      87      76      90
3        35      35      89      89      0       0       92      99      80      87      89      105
3        35      35      89      89      0       0       94      100     85      100     90      120

```
* because of the issue with pwm rounding/truncation: 35 is converted to 33 🤷‍♂️