### PR TITLE
Fix: Prevent crash in get_boot_logo_status if file is missing

### DIFF
--- a/python/legion_linux/legion_linux/legion.py
+++ b/python/legion_linux/legion_linux/legion.py
@@ -1506,7 +1506,12 @@ class LegionModelFacade:
             return img_width, img_height, img_format
 
     def get_boot_logo_status(self):
-        data = self._read_file(LBLDESP_FILE)
+        try:
+            data = self._read_file(LBLDESP_FILE)
+        except (IOError, OSError) as e:
+            log.warning(f"Could not read LBLDESP_FILE ({LBLDESP_FILE}): {e}")
+            return False, 0, 0
+
         if len(data) < 13:
             log.warning("LBLDESP data is unexpectedly short.")
             return False, 0, 0


### PR DESCRIPTION
This PR prevents the legion_gui application from crashing on startup by gracefully handling a missing LBLDESP_FILE.

It introduces a try...except (IOError, OSError) block within the get_boot_logo_status() function. If the file read fails, it now logs a warning and returns a default state (False, 0, 0) instead of raising an unhandled exception.

On some older Legion devices, the LBLDESP_FILE (located at /sys/firmware/efi/efivars/LBLDESP-871455d0-5576-4fb8-9865-af0824463b9e) does not seem to exist.

This causes get_boot_logo_status() to fail, which in turn prevents the legion_gui from starting at all. This patch resolves the crash and allows the application to run.

I am not entirely sure if this LBLDESP_FILE is supposed to be present on all devices, or which component is responsible for creating it. However, given that its absence breaks the application, adding this check seems to be the safest solution to ensure compatibility.