### PR TITLE
Add support for Lenovo Legion Slim 5 16AHP9 (NRCN) and fix legiond segfault

### DIFF
--- a/extra/service/legiond/modules/powerstate.c
+++ b/extra/service/legiond/modules/powerstate.c
@@ -14,18 +14,30 @@ POWER_STATE get_powerstate()
 	fp = fopen(ac_path, "r");
 	if (fp == NULL)
 		fp = fopen(ac_path_alt, "r");
+	
+	if (fp == NULL) {
+		printf("failed to open AC power status file\n");
+		return P_ERROR_AC;
+	}
 
 	int ac_state;
 	if (fscanf(fp, "%d", &ac_state) != 1) {
 		printf("failed to get AC status\n");
+		fclose(fp);
 		return P_ERROR_AC;
 	}
 	fclose(fp);
 
 	fp = fopen(profile_path, "r");
+	if (fp == NULL) {
+		printf("failed to open power profile file\n");
+		return P_ERROR_PROFILE;
+	}
+	
 	char profile[30];
 	if (fscanf(fp, "%s", profile) != 1) {
 		printf("failed to get power_profile\n");
+		fclose(fp);
 		return P_ERROR_PROFILE;
 	}
 	fclose(fp);

--- a/kernel_module/legion-laptop.c
+++ b/kernel_module/legion-laptop.c
@@ -1006,6 +1006,27 @@ static const struct model_config model_nzcn = {
 	.ramio_size = 0x600
 };
 
+// Legion Slim 5 16AHP9 (2024) - Model 83DH
+static const struct model_config model_nrcn = {
+	.registers = &ec_register_offsets_v0,
+	.check_embedded_controller_id = true,
+	.embedded_controller_id = 0x8227,
+	.memoryio_physical_ec_start = 0xC400,
+	.memoryio_size = 0x300,
+	.has_minifancurve = true,
+	.has_custom_powermode = true,
+	.access_method_powermode = ACCESS_METHOD_WMI,
+	.access_method_keyboard = ACCESS_METHOD_WMI,
+	.access_method_fanspeed = ACCESS_METHOD_WMI3,
+	.access_method_temperature = ACCESS_METHOD_WMI3,
+	.access_method_fancurve = ACCESS_METHOD_WMI3,
+	.access_method_fanfullspeed = ACCESS_METHOD_WMI,
+	.acpi_check_dev = false,
+	.ramio_physical_start = 0xFE0B0400,
+	.ramio_size = 0x600
+};
+
+
 static const struct dmi_system_id denylist[] = { {} };
 
 static const struct dmi_system_id optimistic_allowlist[] = {
@@ -1389,6 +1410,16 @@ static const struct dmi_system_id optimistic_allowlist[] = {
 			DMI_MATCH(DMI_BIOS_VERSION, "N0CN"),
 		},
 		.driver_data = (void *)&model_g8cn
+	},
+	{
+		// e.g. Legion Slim 5 16AHP9 (2024) - Model 83DH
+		// AMD Ryzen 7 8845HS with RTX 4060/4070
+		.ident = "NRCN",
+		.matches = {
+			DMI_MATCH(DMI_SYS_VENDOR, "LENOVO"),
+			DMI_MATCH(DMI_BIOS_VERSION, "NRCN"),
+		},
+		.driver_data = (void *)&model_nrcn
 	},
 	{}
 };


### PR DESCRIPTION
## Summary
This PR adds support for the **Lenovo Legion Slim 5 16AHP9** (BIOS: NRCN) and fixes a critical segmentation fault in the `legiond` daemon caused by NULL pointer dereference when reading power supply status.

## Changes

### 1. Add Legion Slim 5 16AHP9 Support
**Commit:** `46939a7`  
**File:** `kernel_module/legion-laptop.c`

Adds `model_nrcn` configuration for Legion Slim 5 16AHP9 (Model 83DH).

**Hardware Details:**
- Model: 83DH
- BIOS: NRCN17WW
- CPU: AMD Ryzen 7 8845HS
- EC Chip ID: 0x8227
- EC Version: 0x2a4

**Features Verified Working:**
- ✅ Temperature monitoring (CPU, GPU via WMI3)
- ✅ Fan speed monitoring (1900-3500+ RPM range observed)
- ✅ Automatic BIOS fan control
- ✅ Power mode switching (quiet/balanced/performance/balanced-performance)
- ✅ Toggle features (G-Sync, Overdrive, keyboard backlight)
- ✅ Fn+Q hardware button integration
- ✅ Platform profile support

**Known Hardware Limitations:**
- Manual fan control not supported (BIOS-locked by design on this model)
- Fan curve reading/writing not available
- These are expected hardware behaviors, not software issues

**Closes:** #218

### 2. Fix legiond Segmentation Fault
**Commit:** `66c1ba3`  
**File:** `extra/service/legiond/modules/powerstate.c`

Fixed NULL pointer dereference in `get_powerstate()` causing immediate daemon crash on startup.

**Problem:**
The function called `fscanf()` on NULL file pointers when AC power supply paths failed to open. This occurred when both `/sys/class/power_supply/ADP0/online` and `/sys/class/power_supply/ACAD/online` don't exist on the system.

**Stack trace of crash:**
Process legiond (PID 101198) dumped core
#0 0x00007fad7a4423fb __vfscanf_internal (libc.so.6 + 0x423fb)
#1 0x00007fad7a435d3f __isoc99_fscanf (libc.so.6 + 0x35d3f)
#2 0x0000000000401f86 get_powerstate (/usr/bin/legiond + 0x1f86)
#3 0x00000000004025eb timer_handler (/usr/bin/legiond + 0x25eb)


**Solution:**
// Added NULL check after fopen attempts
fp = fopen(ac_path, "r");
if (fp == NULL)
fp = fopen(ac_path_alt, "r");

+if (fp == NULL) {

printf("failed to open AC power status file\n");

return P_ERROR_AC;
+}

// Similar checks added for platform_profile path
