### PR TITLE
Fix value for speed_pwm2

### DIFF
--- a/kernel_module/legion-laptop.c
+++ b/kernel_module/legion-laptop.c
@@ -2424,7 +2424,7 @@ static ssize_t fancurve_print_seqfile(const struct fancurve *fancurve,
 		const struct fancurve_point *point = &fancurve->points[i];
 
 		fancurve_get_speed_pwm(fancurve, i, 0, &speed_pwm1);
-		fancurve_get_speed_pwm(fancurve, i, 0, &speed_pwm2);
+		fancurve_get_speed_pwm(fancurve, i, 1, &speed_pwm2);
 
 		seq_printf(
 			s,


### PR DESCRIPTION
Function fancurve-print-seqfile currently is showing the same values from speed1 in speed2 column. This PR fixes it when calling function fancurve_get_speed_pwm using the corresponding id 1.