### PR TITLE
Fix rounding for conversion of PWM/RPM values.

### DIFF
--- a/kernel_module/legion-laptop.c
+++ b/kernel_module/legion-laptop.c
@@ -2248,7 +2248,7 @@ static bool fancurve_set_speed_pwm(struct fancurve *fancurve, int point_id,
 		*speed = clamp_t(u8, value, 0, 255);
 		return true;
 	case FAN_SPEED_UNIT_RPM_HUNDRED:
-		*speed = clamp_t(u8, value * MAX_RPM / 100 / 255, 0, 255);
+		*speed = clamp_t(u8, (value * MAX_RPM + (100 * 255) - 1) / (100 * 255), 0, 255);
 		return true;
 	default:
 		pr_info("No method to set for fan_speed_unit %d.",
@@ -2424,7 +2424,7 @@ static ssize_t fancurve_print_seqfile(const struct fancurve *fancurve,
 		const struct fancurve_point *point = &fancurve->points[i];
 
 		fancurve_get_speed_pwm(fancurve, i, 0, &speed_pwm1);
-		fancurve_get_speed_pwm(fancurve, i, 0, &speed_pwm2);
+		fancurve_get_speed_pwm(fancurve, i, 1, &speed_pwm2);
 
 		seq_printf(
 			s,

--- a/python/legion_linux/legion_linux/legion.py
+++ b/python/legion_linux/legion_linux/legion.py
@@ -816,10 +816,10 @@ class FanCurveIO(Feature):
         self._write_file(file_path, value)
 
     def set_fan_1_speed_rpm(self, point_id, value):
-        return self.set_fan_1_speed_pwm(point_id, round(value/self.get_fan_1_max_rpm()*255.0))
+        return self.set_fan_1_speed_pwm(point_id, int(value // 100 * (100 * 255) / self.get_fan_1_max_rpm()))
 
     def set_fan_2_speed_rpm(self, point_id, value):
-        return self.set_fan_2_speed_pwm(point_id, round(value/self.get_fan_2_max_rpm()*255.0))
+        return self.set_fan_2_speed_pwm(point_id, int(value // 100 * (100 * 255) / self.get_fan_2_max_rpm()))
 
     def set_lower_cpu_temperature(self, point_id, value):
         point_id = self._validate_point_id(point_id)
@@ -872,10 +872,10 @@ class FanCurveIO(Feature):
         return self._read_file(file_path)
 
     def get_fan_1_speed_rpm(self, point_id):
-        return round(self.get_fan_1_speed_pwm(point_id)/255.0*self.get_fan_1_max_rpm(), ndigits=2)
+        return round(((self.get_fan_1_speed_pwm(point_id) * self.get_fan_1_max_rpm() + (100 * 255) - 1) // (100 * 255)) * 100 , ndigits=2)
 
     def get_fan_2_speed_rpm(self, point_id):
-        return round(self.get_fan_2_speed_pwm(point_id)/255.0*self.get_fan_2_max_rpm(), ndigits=2)
+        return round(((self.get_fan_2_speed_pwm(point_id) * self.get_fan_2_max_rpm()  + (100 * 225) - 1) // (100 * 255)) * 100, ndigits=2)
 
     def get_lower_cpu_temperature(self, point_id):
         point_id = self._validate_point_id(point_id)


### PR DESCRIPTION
Test :
 - Changing from quiet mode to balanced-performance (custom) mode. The hardware values show the values from the previous mode 
```
u(speed_of_unit)|speed1[u]|speed2[u]|speed1[pwm]|speed2[pwm]|acceleration|deceleration|cpu_min_temp|cpu_max_temp|gpu_min_temp|gpu_max_temp|ic_min_temp|ic_max_temp
3	 0	 0	 0	 0	 0	 0	 0	 80	 0	 68	 0	 0
3	 25	 25	 63	 63	 0	 0	 0	 86	 0	 84	 0	 0
3	 25	 25	 63	 63	 0	 0	 0	 92	 0	 84	 0	 0
3	 25	 25	 63	 63	 0	 0	 0	 92	 0	 84	 0	 0
3	 25	 25	 63	 63	 0	 0	 0	 92	 0	 84	 0	 0
3	 25	 25	 63	 63	 0	 0	 0	 92	 0	 84	 0	 0
3	 25	 25	 63	 63	 0	 0	 0	 92	 0	 84	 0	 0
3	 25	 25	 63	 63	 0	 0	 0	 92	 0	 88	 0	 0
3	 25	 25	 63	 63	 0	 0	 0	 99	 0	 94	 0	 0
3	 25	 25	 63	 63	 0	 0	 0	 100	 0	 0	 0	 0
```

- Read values from python client
<img width="1247" height="497" alt="pwm_screen_1" src="https://github.com/user-attachments/assets/4456b7cc-4747-4c8e-8208-b5e84197b198" />

- Modifying cpu rpm's via sysfs hwmon
```bash
echo 35 > pwm1_auto_point1_pwm
echo 40 > pwm1_auto_point2_pwm
echo 43 > pwm1_auto_point3_pwm
echo 48 > pwm1_auto_point4_pwm
echo 53 > pwm1_auto_point5_pwm
echo 61 > pwm1_auto_point6_pwm
echo 63 > pwm1_auto_point7_pwm
echo 71 > pwm1_auto_point8_pwm
echo 76 > pwm1_auto_point9_pwm
echo 89 > pwm1_auto_point10_pwm
```
- Checking values`sudo cat /sys/kernel/debug/legion/fancurve`
```
u(speed_of_unit)|speed1[u]|speed2[u]|speed1[pwm]|speed2[pwm]|acceleration|deceleration|cpu_min_temp|cpu_max_temp|gpu_min_temp|gpu_max_temp|ic_min_temp|ic_max_temp
3	 14	 0	 35	 0	 0	 0	 0	 80	 0	 68	 0	 0
3	 16	 25	 40	 63	 0	 0	 0	 86	 0	 84	 0	 0
3	 17	 25	 43	 63	 0	 0	 0	 92	 0	 84	 0	 0
3	 19	 25	 48	 63	 0	 0	 0	 92	 0	 84	 0	 0
3	 21	 25	 53	 63	 0	 0	 0	 92	 0	 84	 0	 0
3	 24	 25	 61	 63	 0	 0	 0	 92	 0	 84	 0	 0
3	 25	 25	 63	 63	 0	 0	 0	 92	 0	 84	 0	 0
3	 28	 25	 71	 63	 0	 0	 0	 92	 0	 88	 0	 0
3	 30	 25	 76	 63	 0	 0	 0	 99	 0	 94	 0	 0
3	 35	 25	 89	 63	 0	 0	 0	 100	 0	 0	 0	 0
```
- Reading again from python client
<img width="1244" height="511" alt="pwm_screen_2" src="https://github.com/user-attachments/assets/99f66b40-58ae-4dce-9700-8e72fcaf5406" />


- Modifying gpu rpm's in python client and applying to hardware
<img width="1251" height="515" alt="pwm_screen_3" src="https://github.com/user-attachments/assets/d0aed5b7-afbd-4dfe-a899-d6cdf31ef3ab" />


- Reading values `sudo cat /sys/kernel/debug/legion/fancurve`
```
u(speed_of_unit)|speed1[u]|speed2[u]|speed1[pwm]|speed2[pwm]|acceleration|deceleration|cpu_min_temp|cpu_max_temp|gpu_min_temp|gpu_max_temp|ic_min_temp|ic_max_temp
3	 14	 15	 35	 38	 0	 0	 0	 80	 0	 68	 0	 0
3	 16	 17	 40	 43	 0	 0	 0	 86	 0	 84	 0	 0
3	 17	 18	 43	 45	 0	 0	 0	 92	 0	 84	 0	 0
3	 19	 19	 48	 48	 0	 0	 0	 92	 0	 84	 0	 0
3	 21	 20	 53	 51	 0	 0	 0	 92	 0	 84	 0	 0
3	 24	 21	 61	 53	 0	 0	 0	 92	 0	 84	 0	 0
3	 25	 22	 63	 56	 0	 0	 0	 92	 0	 84	 0	 0
3	 28	 23	 71	 58	 0	 0	 0	 92	 0	 88	 0	 0
3	 30	 24	 76	 61	 0	 0	 0	 99	 0	 94	 0	 0
3	 35	 26	 89	 66	 0	 0	 0	 100	 0	 0	 0	 0
=====================
```