### PR TITLE
fix CI containers tests

### DIFF
--- a/deploy/dependencies/install_dependencies_ubuntu_24_04.sh
+++ b/deploy/dependencies/install_dependencies_ubuntu_24_04.sh
@@ -2,4 +2,4 @@
 set -ex
 sudo apt-get update
 sudo apt-get install -y make gcc clang linux-headers-$(uname -r) build-essential git lm-sensors wget python3-pyqt6 python3-yaml python3-venv python3-pip python3-wheel python3-argcomplete policykit-1
-sudo apt-get install -y dkms openssl mokutil
+sudo apt-get install -y dkms openssl mokutil python3-pillow

--- a/deploy/dependencies/install_test_dependencies_arch.sh
+++ b/deploy/dependencies/install_test_dependencies_arch.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 set -ex
-sudo pacman -S --noconfirm --disable-download-timeout linux-headers git xorg-server-xvfb libxcb base-devel dkms i2c-tools dmidecode fakeroot
+sudo pacman -S --noconfirm --disable-download-timeout linux-headers git xorg-server-xvfb libxcb base-devel dkms i2c-tools dmidecode fakeroot python-pillow
+

--- a/deploy/package_testing/Dockerfile.fedora
+++ b/deploy/package_testing/Dockerfile.fedora
@@ -1,4 +1,4 @@
-FROM fedora:39
+FROM fedora:41
 
 # does not work
 # FROM redhat/ubi9

--- a/deploy/package_testing/Dockerfile.ubuntu
+++ b/deploy/package_testing/Dockerfile.ubuntu
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 ARG DEBIAN_FRONTEND=noninteractive
 
 # Install sudo (used in scripts that are tested)

--- a/deploy/package_testing/download_install_debian.sh
+++ b/deploy/package_testing/download_install_debian.sh
@@ -1,10 +1,9 @@
 sudo apt install -y curl
 
-sudo curl --insecure https://ftp.de.debian.org/debian/pool/contrib/l/lenovolegionlinux/lenovolegionlinux-dkms_0.0.10+ds-2_amd64.deb -o /tmp/lenovolegionlinux-dkms_0.0.10+ds-2_amd64.deb
-sudo curl --insecure https://ftp.de.debian.org/debian/pool/contrib/l/lenovolegionlinux/python3-legion-linux_0.0.10+ds-2_all.deb -o /tmp/python3-legion-linux_0.0.10+ds-2_all.deb
-sudo curl --insecure https://ftp.de.debian.org/debian/pool/contrib/l/lenovolegionlinux/lenovolegionlinux-dkms_0.0.10+ds-2_amd64.deb -o /tmp/legiond_0.0.10+ds-2_amd64.deb
+sudo curl --insecure https://ftp.de.debian.org/debian/pool/main/l/lenovolegionlinux/lenovolegionlinux-dkms_0.0.20+ds-1.1_amd64.deb -o /tmp/lenovolegionlinux-dkms_0.0.20+ds-1.1_amd64.deb
+sudo curl --insecure https://ftp.de.debian.org/debian/pool/main/l/lenovolegionlinux/python3-legion-linux_0.0.20+ds-1.1_all.deb -o /tmp/python3-legion-linux_0.0.20+ds-1.1_all.deb
+sudo curl --insecure https://ftp.de.debian.org/debian/pool/main/l/lenovolegionlinux/legiond_0.0.20+ds-1.1_amd64.deb -o /tmp/legiond_0.0.20+ds-1.1_amd64.deb
 
-sudo apt install -y /tmp/lenovolegionlinux-dkms_0.0.10+ds-2_amd64.deb
-sudo apt install -y /tmp/python3-legion-linux_0.0.10+ds-2_all.deb
-sudo apt install -y /tmp/legiond_0.0.10+ds-2_amd64.deb
-
+sudo apt install -y /tmp/lenovolegionlinux-dkms_0.0.20+ds-1.1_amd64.deb
+sudo apt install -y /tmp/python3-legion-linux_0.0.20+ds-1.1_all.deb
+sudo apt install -y /tmp/legiond_0.0.20+ds-1.1_amd64.deb


### PR DESCRIPTION
- adds archlinux pillow dependency
- updates fedora container version to minimum version supported by package in copr : https://copr.fedorainfracloud.org/coprs/mrduarte/LenovoLegionLinux/
- updates links of package in debian package repository (was moved from contrib to main)
- updates ubuntu container version to 24:04 because packages on updated links have dependency on dkms and glibc versions
- updates ubuntu container pillow dependency