### PR TITLE
Add support for Legion Pro 7 16IAX10H (Q7CN, EC 0x5508)

### DIFF
--- a/kernel_module/legion-laptop.c
+++ b/kernel_module/legion-laptop.c
@@ -1026,9 +1026,9 @@ static const struct model_config model_nrcn = {
 	.ramio_size = 0x600
 };
 
-// Legion Pro 7 16IAX10H (2025) - Model 83F5
-// Intel Core Ultra 9 275HX, RTX 5090 Laptop, 3 fans
-// EC ID 0x5508 (ITE IT5508) verified on hardware
+/* Legion Pro 7 16IAX10H (2025) - Model 83F5 */
+/* Intel Core Ultra 9 275HX, RTX 5090 Laptop, 3 fans */
+/* EC ID 0x5508 (ITE IT5508) verified on hardware */
 static const struct model_config model_q7cn = {
 	.registers = &ec_register_offsets_v0,
 	.check_embedded_controller_id = true,
@@ -1038,7 +1038,7 @@ static const struct model_config model_q7cn = {
 	.has_minifancurve = false,
 	.has_custom_powermode = true,
 	.access_method_powermode = ACCESS_METHOD_WMI,
-	// RGB keyboard controlled via USB, not WMI
+	/* RGB keyboard controlled via USB, not WMI */
 	.access_method_keyboard = ACCESS_METHOD_NO_ACCESS,
 	.access_method_fanspeed = ACCESS_METHOD_WMI3,
 	.access_method_temperature = ACCESS_METHOD_WMI3,
@@ -1444,8 +1444,8 @@ static const struct dmi_system_id optimistic_allowlist[] = {
 		.driver_data = (void *)&model_nrcn
 	},
 	{
-		// Legion Pro 7 16IAX10H (83F5)
-		// Intel Core Ultra 9 275HX, RTX 5090 Laptop
+		/* Legion Pro 7 16IAX10H (83F5) */
+		/* Intel Core Ultra 9 275HX, RTX 5090 Laptop */
 		.ident = "Q7CN",
 		.matches = {
 			DMI_MATCH(DMI_SYS_VENDOR, "LENOVO"),


### PR DESCRIPTION
Add model_q7cn config for the 2025 Legion Pro 7 16IAX10H (83F5):
- EC chip: ITE IT5508 (0x5508), verified on hardware
- BIOS code: Q7CN
- Fan curve/speed/temperature via WMI3
- Power mode and fan full speed via WMI
- RGB keyboard is USB-controlled (ACCESS_METHOD_NO_ACCESS)
- Based on model_nscn (Legion 7 16IAX9) as closest match

Also fix minor line-length formatting in platform_profile_probe and platform_profile_init to comply with 80-column kernel style.