### PR TITLE
Add support for Legion 5 16IRX9 (Model 83DG, BIOS NMCN)

### DIFF
--- a/kernel_module/legion-laptop.c
+++ b/kernel_module/legion-laptop.c
@@ -1421,6 +1421,15 @@ static const struct dmi_system_id optimistic_allowlist[] = {
 		},
 		.driver_data = (void *)&model_nrcn
 	},
+	{
+		// e.g. Legion 5 16IRX9 (83DG)
+		.ident = "NMCN",
+		.matches = {
+			DMI_MATCH(DMI_SYS_VENDOR, "LENOVO"),
+			DMI_MATCH(DMI_BIOS_VERSION, "NMCN"),
+		},
+		.driver_data = (void *)&model_g8cn
+	},
 	{}
 };
 


### PR DESCRIPTION
Tested on Legion 5 16IRX9 with BIOS NMCN31WW.
Uses model_g8cn configuration (EC ID 0x5507, ACCESS_METHOD_WMI3).

**Tested working:**
- Temperature sensors (CPU/GPU via WMI3)
- Fan speed sensors (via WMI3)
- Fan curve reading from EC
- Power mode control