### PR TITLE
fix: Y-Logo LED GET/SET byte mismatch and IO-Port init on Gen 10

### DIFF
--- a/kernel_module/legion-laptop.c
+++ b/kernel_module/legion-laptop.c
@@ -3788,6 +3788,14 @@ static int legion_wmi_light_get(struct legion_private *priv, u8 light_id,
 		return -EIO;
 	}
 
+	if (light_id == LIGHT_ID_YLOGO) {
+		/* Y-Logo: DSDT returns on/off state in byte 0 (LCST).
+		 * EC convention: 1 = ON, 2 = OFF.
+		 * Map to sysfs brightness: 1 or 0.
+		 */
+		return (result[0] == 1) ? 1 : 0;
+	}
+
 	value = result[1];
 	if (!(value >= min_value && value <= max_value)) {
 		pr_info("Error WMI call for reading brightness: expected a value between %u and %u, but got %d\n",
@@ -3810,9 +3818,17 @@ static int legion_wmi_light_set(struct legion_private *priv, u8 light_id,
 	buffer.length = 3;
 	buffer.pointer = &in_buffer_param[0];
 	in_buffer_param[0] = light_id;
-	in_buffer_param[1] = 0x01;
-	in_buffer_param[2] =
-		clamp(brightness + min_value, min_value, max_value);
+	if (light_id == LIGHT_ID_YLOGO) {
+		/* Y-Logo: DSDT checks SCST (byte 1) for on/off.
+		 * EC convention: 1 = ON, 2 = OFF.
+		 */
+		in_buffer_param[1] = brightness ? 1 : 2;
+		in_buffer_param[2] = 0;
+	} else {
+		in_buffer_param[1] = 0x01;
+		in_buffer_param[2] =
+			clamp(brightness + min_value, min_value, max_value);
+	}
 
 	err = wmi_exec_int(LEGION_WMI_KBBACKLIGHT_GUID, 0,
 			   WMI_METHOD_ID_KBBACKLIGHTSET, &buffer, &result);
@@ -6331,7 +6347,7 @@ static int legion_add(struct platform_device *pdev)
 	}
 
 	pr_info("Init IO-Port LED driver\n");
-	err = legion_light_init(priv, &priv->iport_light, LIGHT_ID_IOPORT, 1, 2,
+	err = legion_light_init(priv, &priv->iport_light, LIGHT_ID_IOPORT, 0, 2,
 				"platform::ioport");
 	if (err) {
 		dev_info(&pdev->dev,


### PR DESCRIPTION
## Summary

- **Y-Logo LED GET**: DSDT puts on/off state in `result[0]` (LCST) for `LIGHT_ID_YLOGO`, but driver reads `result[1]` (LCBL) which is hardcoded to 0. Fixed by reading `result[0]` when `light_id == LIGHT_ID_YLOGO`.
- **Y-Logo LED SET**: DSDT checks byte 1 (SCST) for Y-Logo on/off control, but driver hardcodes `byte[1] = 0x01` and puts the brightness in `byte[2]` (SCBL). Fixed by placing the on/off value in byte 1 with EC convention (1=ON, 2=OFF).
- **IO-Port LED init**: On BIOS Q7CN45WW, DSDT WMAF doesn't handle `LIGHT_ID_IOPORT` (0x05) — GET returns 0 from the default GLCS buffer. The `lower_limit=1` validation rejects 0, failing init. Changed to `lower_limit=0`.

### DSDT Analysis (Q7CN45WW)

The WMAF method handles light IDs differently:

| Light ID | GET return byte | SET control byte | EC encoding |
|----------|----------------|-----------------|-------------|
| 0x00 (Keyboard) | result[1] (LCBL) | byte 2 (SCBL) | 1/2/3 = brightness levels |
| 0x03 (Y-Logo) | result[0] (LCST) | byte 1 (SCST) | 1=ON, 2=OFF |
| 0x05 (IO-Port) | Not handled (returns 0) | Not handled | N/A |

The driver previously treated all light IDs the same as the keyboard backlight.

### Hardware note

On Spectrum-equipped Gen 10 models (like the 16IAX10H / 83F5), the physical lid logo LED is controlled by the ITE 8258 USB HID controller (048d:c197) via the Spectrum protocol (`OP_LOGO_STATUS`), not the WMI/ACPI path. The WMI Y-Logo interface may only be relevant for non-Spectrum models.

## Test plan

- [x] Tested on Lenovo Legion Pro 7 16IAX10H (83F5), BIOS Q7CN45WW
- [x] `echo 1 > /sys/class/leds/platform::ylogo/brightness` — writes without error, reads back 1
- [x] `echo 0 > /sys/class/leds/platform::ylogo/brightness` — writes without error, reads back 0
- [x] IO-Port LED init no longer fails (no "expected brightness 1-2, got 0" in dmesg)
- [x] Keyboard backlight unaffected (still uses existing byte 2 path)
- [ ] Needs testing on non-Spectrum models to verify Y-Logo WMI physically toggles the LED
