### PR TITLE
Add support for Legion Pro 7i Gen 10 (83F5, BIOS Q7CN, EC chip 0x5508)

### DIFF
--- a/kernel_module/legion-laptop.c
+++ b/kernel_module/legion-laptop.c
@@ -1026,6 +1026,31 @@ static const struct model_config model_nrcn = {
 	.ramio_size = 0x600
 };
 
+// Legion Pro 7i Gen 10 (83F5) - EC chip 0x5508
+// Intel Core Ultra 9 275HX + RTX 5080 Laptop
+// EC fans/temp/curve accessed via WMI3 (GameZone), same as 5507 family.
+// ramio confirmed at 0xFE00D400 from force-loaded dmesg on live hardware.
+// Fan curve WMI path returns 10 points but all zeros - needs firmware investigation.
+// UNTESTED write paths - use ec_readonly=1 during initial validation.
+static const struct model_config model_q7cn = {
+	.registers = &ec_register_offsets_v0,
+	.check_embedded_controller_id = true,
+	.embedded_controller_id = 0x5508,
+	.memoryio_physical_ec_start = 0xC400,
+	.memoryio_size = 0x300,
+	.has_minifancurve = true,
+	.has_custom_powermode = true,
+	.access_method_powermode = ACCESS_METHOD_WMI,
+	.access_method_keyboard = ACCESS_METHOD_WMI,
+	.access_method_fanspeed = ACCESS_METHOD_WMI3,
+	.access_method_temperature = ACCESS_METHOD_WMI3,
+	.access_method_fancurve = ACCESS_METHOD_WMI3,
+	.access_method_fanfullspeed = ACCESS_METHOD_WMI,
+	.acpi_check_dev = true,
+	.ramio_physical_start = 0xFE00D400,
+	.ramio_size = 0x600
+};
+
 
 static const struct dmi_system_id denylist[] = { {} };
 
@@ -1420,6 +1445,20 @@ static const struct dmi_system_id optimistic_allowlist[] = {
 			DMI_MATCH(DMI_BIOS_VERSION, "NRCN"),
 		},
 		.driver_data = (void *)&model_nrcn
+	},
+	{
+		// Release year: 2025
+		// Generation: 10
+		// Name: Legion Pro 7i Gen 10
+		// Family: 83F5 (Intel Core Ultra 9 275HX + RTX 5080 Laptop)
+		// EC chip ID: 0x5508 (next gen after 0x5507)
+		// Matches any Q7CN BIOS version (Q7CN40WW, etc.)
+		.ident = "Q7CN",
+		.matches = {
+			DMI_MATCH(DMI_SYS_VENDOR, "LENOVO"),
+			DMI_MATCH(DMI_BIOS_VERSION, "Q7CN"),
+		},
+		.driver_data = (void *)&model_q7cn
 	},
 	{}
 };


### PR DESCRIPTION
## Hardware

| Field | Value |
|---|---|
| DMI Product Name | 83F5 (Legion Pro 7i Gen 10) |
| DMI BIOS Version | Q7CN40WW |
| DMI Vendor | LENOVO |
| EC Chip ID | 0x5508 |
| EC Chip Version | 0x2b0 |
| CPU | Intel Core Ultra 9 275HX |
| GPU | NVIDIA RTX 5080 Laptop |

## Problem

Without this patch the module falls back to the GKCN config and only loads with `force=1`:

```
legion PNP0C09:00: Using configuration for system: GKCN   ← wrong fallback
legion PNP0C09:00: Read embedded controller ID 0x5508
legion PNP0C09:00: Skipped checking embedded controller id
```

The GKCN fallback (model_v0) uses `ACCESS_METHOD_EC` for fan speed, which reads the wrong registers for chip 5508 and produces garbage values:

```
Fan 1: 23165 RPM   ← EC path, raw register junk
Fan 2: 18023 RPM   ← EC path, raw register junk
```

Correct values confirmed from WMI3 path:
```
1 fanspeed WMI3: 2200   ← correct
2 fanspeed WMI3: 2100   ← correct
```

## Fix

Adds `model_q7cn` modeled after the 5507 family configs (e.g. `model_g8cn`):

- **Fan speed / temperature / fan curve**: `ACCESS_METHOD_WMI3` — same as all 5507 models. EC registers 0xC5E0–0xC5E3 (RPM) and 0xC535 (fan curve point count) don't map to chip 5508.
- **Power mode**: `ACCESS_METHOD_WMI` — EC register `EXT_POWERMODE` (0xC420) returns `0x51` which has no defined meaning; WMI correctly returns `3` (performance).
- **ramio**: `0xFE00D400` — confirmed by `force=1` dmesg on live hardware.
- **EC ID check**: `check_embedded_controller_id = true`, `embedded_controller_id = 0x5508`.
- **Minifancurve**: `true` — EC minifancurve feature bit is set in hardware.

The allowlist entry uses `DMI_BIOS_VERSION = "Q7CN"` as a prefix match, covering any future Q7CN* BIOS update (Q7CN40WW, Q7CN50WW, etc.).

## Known remaining issue

The WMI fan curve read (`WMI_METHOD_ID_FAN_GET_TABLE`) returns 10 points but all values are zero on this firmware version. The access path is now correct (WMI3 vs EC), but the `WMIFanTableRead` struct field offsets may differ between Gen 9 and Gen 10 firmware. A hex dump of the 88-byte WMI response from this hardware is needed to confirm. **Fan curve writes are untested — please use `ec_readonly=1` during initial testing.**

## Test plan

- [ ] Load module without `force=1` — confirm `Using configuration for system: Q7CN`
- [ ] Verify `sensors` shows ~2200 / ~2100 RPM at idle (not 23000+)
- [ ] Verify CPU/GPU temperatures are accurate
- [ ] Verify power mode reads correctly (3 = performance)
- [ ] Dump WMI fan curve response to determine field layout
- [ ] All EC write paths tested with `ec_readonly=1` first

## Related

- Closes / related to #337 (83LU model, BIOS Q6CN, also EC chip 0x5508 — same root cause)

🤖 Generated with [Claude Code](https://claude.com/claude-code)