### PR TITLE
Add support for Legion Pro 7 16IAX10H (Q7CN, Arrow Lake 2025)

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ It allows you to control features like the fan curve, power mode, power limits, 
 
 # If you have a light in the lid (Y-logo) or at the IO-ports (all Legion 7), please help testing controlling it  [here](https://github.com/johnfanv2/LenovoLegionLinux/issues/54).
 
-**Other Lenovo Legion models from 2020 to 2023 probably also work. The following models were confirmed. If you have a model with a BIOS version with the same leading letters, e.g. EFCN (like EFCN54WW) then it will probably work. If you want to confirm that your model works or if it does not work, please raise a issue.**
+**Other Lenovo Legion models from 2020 to 2025 probably also work. The following models were confirmed. If you have a model with a BIOS version with the same leading letters, e.g. EFCN (like EFCN54WW) then it will probably work. If you want to confirm that your model works or if it does not work, please raise a issue.**
 
 - Lenovo Legion 5 15IMH05, 15IMH05H (BIOS EFCN54WW): sensors, fan curve, power profile
 - Lenovo Legion 5 15ACH6H (BIOS GKCN58WW or GKCN57WW), Gen 6: sensors, fan curve, power profile
@@ -127,6 +127,7 @@ It allows you to control features like the fan curve, power mode, power limits, 
 - Lenovo Legion 5 17ACH6 (BIOS HHCN31WW): sensors, fan curve, power profile
 - Lenovo Legion 7i 16ITHG6 (BIOS H1CN35WW): sensors, fan curve, power profile
 - Lenovo Legion 7 Pro 16ARX8H (BIOS LPCN47WW): sensors, fan curve, power profile
+- Lenovo Legion Pro 7 16IAX10H (BIOS Q7CN38WW), Arrow Lake 2025: sensors, fan speed, power profile, power limits (CPU PL1/PL2, GPU PPAB/cTGP), fan fullspeed toggle. Keyboard backlight is USB HID (ITE 048d:c193), not controlled by this driver.
 
 *Note:* Features that are not confirmed probably also work. They were just not tested.
 

--- a/fan_control.sh
+++ b/fan_control.sh
@@ -9,7 +9,6 @@ case "$1" in
         echo 1 | sudo tee /sys/module/legion_laptop/drivers/platform:legion/PNP0C09:00/fan_fullspeed > /dev/null
         echo 1 | sudo tee /sys/module/legion_laptop/drivers/platform:legion/PNP0C09:00/fan_maxspeed > /dev/null
         echo 2 | sudo tee /sys/module/legion_laptop/drivers/platform:legion/PNP0C09:00/powermode > /dev/null
-        sudo /home/xuananh/Downloads/LenovoLegionLinux/.venv/bin/legion_cli maximumfanspeed-enable
         echo "✅ High-performance fan mode enabled!"
         echo "📊 Current fan speeds:"
         sensors legion_hwmon-isa-0000
@@ -19,7 +18,6 @@ case "$1" in
         echo 0 | sudo tee /sys/module/legion_laptop/drivers/platform:legion/PNP0C09:00/fan_fullspeed > /dev/null
         echo 0 | sudo tee /sys/module/legion_laptop/drivers/platform:legion/PNP0C09:00/fan_maxspeed > /dev/null
         echo 3 | sudo tee /sys/module/legion_laptop/drivers/platform:legion/PNP0C09:00/powermode > /dev/null
-        sudo /home/xuananh/Downloads/LenovoLegionLinux/.venv/bin/legion_cli maximumfanspeed-disable
         echo "✅ Automatic fan mode restored!"
         echo "📊 Current fan speeds:"
         sensors legion_hwmon-isa-0000

--- a/fan_control.sh
+++ b/fan_control.sh
@@ -6,9 +6,9 @@
 case "$1" in
     "enable")
         echo "🔥 Enabling high-performance fan mode..."
+        # fan_fullspeed is only honored by the EC in custom power mode (255)
+        echo 255 | sudo tee /sys/module/legion_laptop/drivers/platform:legion/PNP0C09:00/powermode > /dev/null
         echo 1 | sudo tee /sys/module/legion_laptop/drivers/platform:legion/PNP0C09:00/fan_fullspeed > /dev/null
-        echo 1 | sudo tee /sys/module/legion_laptop/drivers/platform:legion/PNP0C09:00/fan_maxspeed > /dev/null
-        echo 2 | sudo tee /sys/module/legion_laptop/drivers/platform:legion/PNP0C09:00/powermode > /dev/null
         echo "✅ High-performance fan mode enabled!"
         echo "📊 Current fan speeds:"
         sensors legion_hwmon-isa-0000
@@ -16,7 +16,6 @@ case "$1" in
     "disable")
         echo "🌡️ Disabling high-performance fan mode..."
         echo 0 | sudo tee /sys/module/legion_laptop/drivers/platform:legion/PNP0C09:00/fan_fullspeed > /dev/null
-        echo 0 | sudo tee /sys/module/legion_laptop/drivers/platform:legion/PNP0C09:00/fan_maxspeed > /dev/null
         echo 3 | sudo tee /sys/module/legion_laptop/drivers/platform:legion/PNP0C09:00/powermode > /dev/null
         echo "✅ Automatic fan mode restored!"
         echo "📊 Current fan speeds:"
@@ -29,7 +28,6 @@ case "$1" in
         echo ""
         echo "🎛️ Current Settings:"
         echo "Fan Full Speed: $(cat /sys/module/legion_laptop/drivers/platform:legion/PNP0C09:00/fan_fullspeed)"
-        echo "Fan Max Speed:  $(cat /sys/module/legion_laptop/drivers/platform:legion/PNP0C09:00/fan_maxspeed)"
         echo "Power Mode:     $(cat /sys/module/legion_laptop/drivers/platform:legion/PNP0C09:00/powermode)"
         ;;
     *)

--- a/kernel_module/Makefile
+++ b/kernel_module/Makefile
@@ -2,6 +2,13 @@ SHELL := /bin/bash
 KERNELVERSION  ?= $(shell uname --kernel-release)
 KSRC := /lib/modules/$(KERNELVERSION)/build
 
+DKMS_VERSION ?= 1.0.0
+PKG_NAME := lenovolegionlinux-dkms
+PKG_ARCH := all
+PKG_BUILD_DIR := /tmp/lenovolegionlinux-dkms-deb
+PKG_OUTPUT_DIR := ../deploy/packages
+PKG_DST := $(PKG_BUILD_DIR)/usr/src/LenovoLegionLinux-$(DKMS_VERSION)
+
 #install dir for kernel drivers
 INSTALLDIR := /lib/modules/$(KERNELVERSION)/kernel/drivers/platform/x86
 MODDESTDIR := /lib/modules/$(KERNELVERSION)/kernel/drivers/platform/x86
@@ -83,3 +90,49 @@ dkms: all
 	modprobe legion_laptop
 	dmesg --ctime | grep legion_laptop
 	bash -c "./issue-warning.sh"
+
+deb:
+	@command -v dpkg-deb >/dev/null 2>&1 || { \
+		echo "dpkg-deb not found; install dpkg-dev first"; \
+		exit 1; \
+	}
+	@rm -rf $(PKG_BUILD_DIR)
+	@mkdir -p $(PKG_BUILD_DIR)/DEBIAN $(PKG_DST) $(PKG_OUTPUT_DIR)
+	@rsync -a --delete \
+		--exclude='*.ko' \
+		--exclude='*.mod' \
+		--exclude='*.mod.c' \
+		--exclude='*.o' \
+		--exclude='Module.symvers' \
+		--exclude='modules.order' \
+		. $(PKG_DST)/
+	@sed -i 's/PACKAGE_VERSION="DKMS_VERSION"/PACKAGE_VERSION="$(DKMS_VERSION)"/' $(PKG_DST)/dkms.conf
+	@printf '%s\n' \
+		"Package: $(PKG_NAME)" \
+		"Version: $(DKMS_VERSION)" \
+		"Section: kernel" \
+		"Priority: optional" \
+		"Architecture: $(PKG_ARCH)" \
+		"Maintainer: Lenovo Legion Linux Team <noreply@example.com>" \
+		"Depends: dkms" \
+		"Description: LenovoLegionLinux DKMS package" \
+		" DKMS wrapper for Lenovo Legion kernel module." \
+		> $(PKG_BUILD_DIR)/DEBIAN/control
+	@printf '%s\n' \
+		"#!/bin/sh" \
+		"set -e" \
+		"dkms add -m LenovoLegionLinux -v $(DKMS_VERSION) -q || true" \
+		"dkms build -m LenovoLegionLinux -v $(DKMS_VERSION) -q || true" \
+		"dkms install -m LenovoLegionLinux -v $(DKMS_VERSION) -q --force || true" \
+		"exit 0" \
+		> $(PKG_BUILD_DIR)/DEBIAN/postinst
+	@printf '%s\n' \
+		"#!/bin/sh" \
+		"set -e" \
+		"dkms remove -m LenovoLegionLinux -v $(DKMS_VERSION) -q --all || true" \
+		"exit 0" \
+		> $(PKG_BUILD_DIR)/DEBIAN/prerm
+	@chmod 0755 $(PKG_BUILD_DIR)/DEBIAN/postinst $(PKG_BUILD_DIR)/DEBIAN/prerm
+	@dpkg-deb --build $(PKG_BUILD_DIR) $(PKG_OUTPUT_DIR)/$(PKG_NAME)_$(DKMS_VERSION)_$(PKG_ARCH).deb
+	@rm -rf $(PKG_BUILD_DIR)
+	@printf "Built %s\n" "$(PKG_OUTPUT_DIR)/$(PKG_NAME)_$(DKMS_VERSION)_$(PKG_ARCH).deb"

--- a/kernel_module/legion-laptop.c
+++ b/kernel_module/legion-laptop.c
@@ -1043,7 +1043,8 @@ static const struct model_config model_q7cn = {
 	.has_minifancurve = false,
 	.has_custom_powermode = true,
 	.access_method_powermode = ACCESS_METHOD_WMI,
-	.access_method_keyboard = ACCESS_METHOD_WMI,
+	// Keyboard backlight is USB HID (ITE 048d:c193), not WMI-controlled
+	.access_method_keyboard = ACCESS_METHOD_NO_ACCESS,
 	.access_method_fanspeed = ACCESS_METHOD_WMI3,
 	.access_method_temperature = ACCESS_METHOD_WMI3,
 	.access_method_fancurve = ACCESS_METHOD_WMI3,

--- a/kernel_module/legion-laptop.c
+++ b/kernel_module/legion-laptop.c
@@ -4103,6 +4103,44 @@ static void legion_debugfs_exit(struct legion_private *priv)
 /* sysfs interface                */
 /* ============================   */
 
+// WMAE-based show/store helpers for models that route power limits
+// through the OtherMethod (WMAE Get/SetFeatureValue) interface
+static int show_other_method_attribute(struct device *dev,
+				       struct device_attribute *attr, char *buf,
+				       enum OtherMethodFeature feature_id)
+{
+	int value = 0;
+	int err;
+	struct legion_private *priv = dev_get_drvdata(dev);
+
+	mutex_lock(&priv->fancurve_mutex);
+	err = wmi_other_method_get_value(feature_id, &value);
+	mutex_unlock(&priv->fancurve_mutex);
+	if (err)
+		return -EINVAL;
+	return sysfs_emit(buf, "%d\n", value);
+}
+
+static int store_other_method_attribute(struct device *dev,
+					struct device_attribute *attr,
+					const char *buf, size_t count,
+					enum OtherMethodFeature feature_id)
+{
+	int value;
+	int err;
+	struct legion_private *priv = dev_get_drvdata(dev);
+
+	err = kstrtoint(buf, 0, &value);
+	if (err)
+		return err;
+	mutex_lock(&priv->fancurve_mutex);
+	err = wmi_other_method_set_value(feature_id, value);
+	mutex_unlock(&priv->fancurve_mutex);
+	if (err)
+		return -EINVAL;
+	return count;
+}
+
 static int show_simple_wmi_attribute(struct device *dev,
 				     struct device_attribute *attr, char *buf,
 				     const char *guid, u8 instance,
@@ -4448,18 +4486,30 @@ static ssize_t cpu_shortterm_powerlimit_show(struct device *dev,
 					     struct device_attribute *attr,
 					     char *buf)
 {
-	return show_simple_wmi_attribute_from_buffer(
+	ssize_t ret;
+
+	ret = show_simple_wmi_attribute_from_buffer(
 		dev, attr, buf, WMI_GUID_LENOVO_CPU_METHOD, 0,
 		WMI_METHOD_ID_CPU_GET_SHORTTERM_POWERLIMIT, 16, 0, 1);
+	if (ret < 0)
+		ret = show_other_method_attribute(dev, attr, buf,
+			OtherMethodFeature_CPU_SHORT_TERM_POWER_LIMIT);
+	return ret;
 }
 
 static ssize_t cpu_shortterm_powerlimit_store(struct device *dev,
 					      struct device_attribute *attr,
 					      const char *buf, size_t count)
 {
-	return store_simple_wmi_attribute(
+	ssize_t ret;
+
+	ret = store_simple_wmi_attribute(
 		dev, attr, buf, count, WMI_GUID_LENOVO_CPU_METHOD, 0,
 		WMI_METHOD_ID_CPU_SET_SHORTTERM_POWERLIMIT, false, 1);
+	if (ret < 0)
+		ret = store_other_method_attribute(dev, attr, buf, count,
+			OtherMethodFeature_CPU_SHORT_TERM_POWER_LIMIT);
+	return ret;
 }
 
 static DEVICE_ATTR_RW(cpu_shortterm_powerlimit);
@@ -4468,18 +4518,30 @@ static ssize_t cpu_longterm_powerlimit_show(struct device *dev,
 					    struct device_attribute *attr,
 					    char *buf)
 {
-	return show_simple_wmi_attribute_from_buffer(
+	ssize_t ret;
+
+	ret = show_simple_wmi_attribute_from_buffer(
 		dev, attr, buf, WMI_GUID_LENOVO_CPU_METHOD, 0,
 		WMI_METHOD_ID_CPU_GET_LONGTERM_POWERLIMIT, 16, 0, 1);
+	if (ret < 0)
+		ret = show_other_method_attribute(dev, attr, buf,
+			OtherMethodFeature_CPU_LONG_TERM_POWER_LIMIT);
+	return ret;
 }
 
 static ssize_t cpu_longterm_powerlimit_store(struct device *dev,
 					     struct device_attribute *attr,
 					     const char *buf, size_t count)
 {
-	return store_simple_wmi_attribute(
+	ssize_t ret;
+
+	ret = store_simple_wmi_attribute(
 		dev, attr, buf, count, WMI_GUID_LENOVO_CPU_METHOD, 0,
 		WMI_METHOD_ID_CPU_SET_LONGTERM_POWERLIMIT, false, 1);
+	if (ret < 0)
+		ret = store_other_method_attribute(dev, attr, buf, count,
+			OtherMethodFeature_CPU_LONG_TERM_POWER_LIMIT);
+	return ret;
 }
 
 static DEVICE_ATTR_RW(cpu_longterm_powerlimit);
@@ -4541,18 +4603,30 @@ static ssize_t cpu_cross_loading_powerlimit_show(struct device *dev,
 						 struct device_attribute *attr,
 						 char *buf)
 {
-	return show_simple_wmi_attribute(
+	ssize_t ret;
+
+	ret = show_simple_wmi_attribute(
 		dev, attr, buf, WMI_GUID_LENOVO_GPU_METHOD, 0,
 		WMI_METHOD_ID_CPU_GET_CROSS_LOADING_POWERLIMIT, false, 1);
+	if (ret < 0)
+		ret = show_other_method_attribute(dev, attr, buf,
+			OtherMethodFeature_CPU_CROSS_LOAD_POWER_LIMIT);
+	return ret;
 }
 
 static ssize_t cpu_cross_loading_powerlimit_store(struct device *dev,
 						  struct device_attribute *attr,
 						  const char *buf, size_t count)
 {
-	return store_simple_wmi_attribute(
+	ssize_t ret;
+
+	ret = store_simple_wmi_attribute(
 		dev, attr, buf, count, WMI_GUID_LENOVO_GPU_METHOD, 0,
 		WMI_METHOD_ID_CPU_SET_CROSS_LOADING_POWERLIMIT, false, 1);
+	if (ret < 0)
+		ret = store_other_method_attribute(dev, attr, buf, count,
+			OtherMethodFeature_CPU_CROSS_LOAD_POWER_LIMIT);
+	return ret;
 }
 
 static DEVICE_ATTR_RW(cpu_cross_loading_powerlimit);
@@ -4581,19 +4655,31 @@ static ssize_t gpu_ppab_powerlimit_show(struct device *dev,
 					struct device_attribute *attr,
 					char *buf)
 {
-	return show_simple_wmi_attribute_from_buffer(
+	ssize_t ret;
+
+	ret = show_simple_wmi_attribute_from_buffer(
 		dev, attr, buf, WMI_GUID_LENOVO_GPU_METHOD, 0,
 		WMI_METHOD_ID_GPU_GET_PPAB_POWERLIMIT, 16, 0, 1);
+	if (ret < 0)
+		ret = show_other_method_attribute(dev, attr, buf,
+			OtherMethodFeature_GPU_POWER_BOOST);
+	return ret;
 }
 
 static ssize_t gpu_ppab_powerlimit_store(struct device *dev,
 					 struct device_attribute *attr,
 					 const char *buf, size_t count)
 {
-	return store_simple_wmi_attribute(dev, attr, buf, count,
+	ssize_t ret;
+
+	ret = store_simple_wmi_attribute(dev, attr, buf, count,
 					  WMI_GUID_LENOVO_GPU_METHOD, 0,
 					  WMI_METHOD_ID_GPU_SET_PPAB_POWERLIMIT,
 					  false, 1);
+	if (ret < 0)
+		ret = store_other_method_attribute(dev, attr, buf, count,
+			OtherMethodFeature_GPU_POWER_BOOST);
+	return ret;
 }
 
 static DEVICE_ATTR_RW(gpu_ppab_powerlimit);
@@ -4602,19 +4688,31 @@ static ssize_t gpu_ctgp_powerlimit_show(struct device *dev,
 					struct device_attribute *attr,
 					char *buf)
 {
-	return show_simple_wmi_attribute_from_buffer(
+	ssize_t ret;
+
+	ret = show_simple_wmi_attribute_from_buffer(
 		dev, attr, buf, WMI_GUID_LENOVO_GPU_METHOD, 0,
 		WMI_METHOD_ID_GPU_GET_CTGP_POWERLIMIT, 16, 0, 1);
+	if (ret < 0)
+		ret = show_other_method_attribute(dev, attr, buf,
+			OtherMethodFeature_GPU_cTGP);
+	return ret;
 }
 
 static ssize_t gpu_ctgp_powerlimit_store(struct device *dev,
 					 struct device_attribute *attr,
 					 const char *buf, size_t count)
 {
-	return store_simple_wmi_attribute(dev, attr, buf, count,
+	ssize_t ret;
+
+	ret = store_simple_wmi_attribute(dev, attr, buf, count,
 					  WMI_GUID_LENOVO_GPU_METHOD, 0,
 					  WMI_METHOD_ID_GPU_SET_CTGP_POWERLIMIT,
 					  false, 1);
+	if (ret < 0)
+		ret = store_other_method_attribute(dev, attr, buf, count,
+			OtherMethodFeature_GPU_cTGP);
+	return ret;
 }
 
 static DEVICE_ATTR_RW(gpu_ctgp_powerlimit);
@@ -4714,20 +4812,32 @@ static DEVICE_ATTR_RW(fan_fullspeed);
 static ssize_t fan_maxspeed_show(struct device *dev,
 				 struct device_attribute *attr, char *buf)
 {
-	return show_simple_wmi_attribute(dev, attr, buf,
+	ssize_t ret;
+
+	ret = show_simple_wmi_attribute(dev, attr, buf,
 					 WMI_GUID_LENOVO_FAN_METHOD, 0,
 					 WMI_METHOD_ID_FAN_GET_MAXSPEED, false,
 					 1);
+	if (ret < 0)
+		ret = show_other_method_attribute(dev, attr, buf,
+			OtherMethodFeature_FAN_FULLSPEED);
+	return ret;
 }
 
 static ssize_t fan_maxspeed_store(struct device *dev,
 				  struct device_attribute *attr,
 				  const char *buf, size_t count)
 {
-	return store_simple_wmi_attribute(dev, attr, buf, count,
+	ssize_t ret;
+
+	ret = store_simple_wmi_attribute(dev, attr, buf, count,
 					  WMI_GUID_LENOVO_FAN_METHOD, 0,
 					  WMI_METHOD_ID_FAN_SET_MAXSPEED, false,
 					  1);
+	if (ret < 0)
+		ret = store_other_method_attribute(dev, attr, buf, count,
+			OtherMethodFeature_FAN_FULLSPEED);
+	return ret;
 }
 
 static DEVICE_ATTR_RW(fan_maxspeed);

--- a/kernel_module/legion-laptop.c
+++ b/kernel_module/legion-laptop.c
@@ -3507,6 +3507,24 @@ static ssize_t wmi_write_fanfullspeed(struct legion_private *priv, bool state)
 					1, state);
 }
 
+static ssize_t wmi3_read_fanfullspeed(bool *state)
+{
+	int value = 0;
+	int err;
+
+	err = wmi_other_method_get_value(OtherMethodFeature_FAN_FULLSPEED,
+					 &value);
+	if (!err)
+		*state = !!value;
+	return err;
+}
+
+static ssize_t wmi3_write_fanfullspeed(bool state)
+{
+	return wmi_other_method_set_value(OtherMethodFeature_FAN_FULLSPEED,
+					  state ? 1 : 0);
+}
+
 static ssize_t read_fanfullspeed(struct legion_private *priv, bool *state)
 {
 	// TODO: use enums or function pointers?
@@ -3515,6 +3533,8 @@ static ssize_t read_fanfullspeed(struct legion_private *priv, bool *state)
 		return ec_read_fanfullspeed(&priv->ecram, priv->conf, state);
 	case ACCESS_METHOD_WMI:
 		return wmi_read_fanfullspeed(priv, state);
+	case ACCESS_METHOD_WMI3:
+		return wmi3_read_fanfullspeed(state);
 	default:
 		pr_info("No access method for fan full speed: %d\n",
 			priv->conf->access_method_fanfullspeed);
@@ -3532,6 +3552,8 @@ static ssize_t write_fanfullspeed(struct legion_private *priv, bool state)
 		return res;
 	case ACCESS_METHOD_WMI:
 		return wmi_write_fanfullspeed(priv, state);
+	case ACCESS_METHOD_WMI3:
+		return wmi3_write_fanfullspeed(state);
 	default:
 		pr_info("No access method for fan full speed: %d\n",
 			priv->conf->access_method_fanfullspeed);

--- a/kernel_module/legion-laptop.c
+++ b/kernel_module/legion-laptop.c
@@ -1526,20 +1526,20 @@ static int acpi_process_buffer_to_ints(const char *id_name, int id_nr,
 	int error = 0;
 
 	if (ACPI_FAILURE(status)) {
-		pr_info("ACPI evaluation error for: %s:%d\n", id_name, id_nr);
+		pr_debug("ACPI evaluation error for: %s:%d\n", id_name, id_nr);
 		error = -EFAULT;
 		goto err;
 	}
 
 	out = out_buffer->pointer;
 	if (!out) {
-		pr_info("Unexpected ACPI result for %s:%d\n", id_name, id_nr);
+		pr_debug("Unexpected ACPI result for %s:%d\n", id_name, id_nr);
 		error = -AE_ERROR;
 		goto err;
 	}
 
 	if (out->type != ACPI_TYPE_BUFFER || out->buffer.length != ressize) {
-		pr_info("Unexpected ACPI result for %s:%d: expected type %d but got %d; expected length %lu but got %u;\n",
+		pr_debug("Unexpected ACPI result for %s:%d: expected type %d but got %d; expected length %lu but got %u;\n",
 			id_name, id_nr, ACPI_TYPE_BUFFER, out->type, ressize,
 			out->buffer.length);
 		error = -AE_ERROR;
@@ -1598,20 +1598,20 @@ static int wmi_exec_int(const char *guid, u8 instance, u32 method_id,
 				     &out_buffer);
 
 	if (ACPI_FAILURE(status)) {
-		pr_info("WMI evaluation error for: %s:%d\n", guid, method_id);
+		pr_debug("WMI evaluation error for: %s:%d\n", guid, method_id);
 		error = -EFAULT;
 		goto err;
 	}
 
 	out = out_buffer.pointer;
 	if (!out) {
-		pr_info("Unexpected ACPI result for %s:%d", guid, method_id);
+		pr_debug("Unexpected ACPI result for %s:%d", guid, method_id);
 		error = -AE_ERROR;
 		goto err;
 	}
 
 	if (out->type != ACPI_TYPE_INTEGER) {
-		pr_info("Unexpected ACPI result for %s:%d: expected type %d but got %d\n",
+		pr_debug("Unexpected ACPI result for %s:%d: expected type %d but got %d\n",
 			guid, method_id, ACPI_TYPE_INTEGER, out->type);
 		error = -AE_ERROR;
 		goto err;
@@ -2599,7 +2599,7 @@ static int get_simple_wmi_attribute(struct legion_private *priv,
 		return -EINVAL;
 
 	// TODO: remove later
-	pr_info("%swith raw value: %ld\n", __func__, state);
+	pr_debug("%s with raw value: %ld\n", __func__, state);
 
 	state = state * scale;
 

--- a/kernel_module/legion-laptop.c
+++ b/kernel_module/legion-laptop.c
@@ -217,10 +217,19 @@ struct model_config {
 	enum access_method access_method_fanspeed;
 	enum access_method access_method_fancurve;
 	enum access_method access_method_fanfullspeed;
+	// ACCESS_METHOD_WMI3 routes CPU/GPU power limits through the WMAE
+	// OtherMethod (Get/SetFeatureValue) interface; any other value uses
+	// the legacy CPU/GPU method GUIDs. Do not rely on the legacy GUIDs
+	// failing: some firmware (e.g. Q7CN) keeps them as stubs that
+	// return success without applying anything.
+	enum access_method access_method_powerlimit;
 	bool three_state_keyboard;
 	// set to true to skip registering non-functional LED controls
 	bool no_ylogo_light;
 	bool no_ioport_light;
+	// set to true if the legacy fan maxspeed WMI method is a stub that
+	// does not reflect fan state; hides the fan_maxspeed attribute
+	bool no_fan_maxspeed;
 
 	bool acpi_check_dev;
 
@@ -1048,9 +1057,19 @@ static const struct model_config model_q7cn = {
 	.access_method_fanspeed = ACCESS_METHOD_WMI3,
 	.access_method_temperature = ACCESS_METHOD_WMI3,
 	.access_method_fancurve = ACCESS_METHOD_WMI3,
+	// WMAE 0x04020000; the legacy FAN GUID fullspeed methods are
+	// complete stubs on this firmware (set is ignored, get returns 0).
+	// The EC only acts on this flag in custom power mode (255); in
+	// other power modes the flag is stored but fans do not ramp.
 	.access_method_fanfullspeed = ACCESS_METHOD_WMI3,
+	// Legacy CPU method GUID exists but its setters are no-op stubs;
+	// power limits only work via WMAE (verified on Q7CN45WW)
+	.access_method_powerlimit = ACCESS_METHOD_WMI3,
 	.no_ylogo_light = true,
 	.no_ioport_light = true,
+	// Legacy fan maxspeed method answers but does not track WMAE
+	// fullspeed state; there is no separate maxspeed feature in WMAE
+	.no_fan_maxspeed = true,
 	.acpi_check_dev = false,
 	.ramio_physical_start = 0xFE500400,
 	.ramio_size = 0xC00
@@ -1827,6 +1846,8 @@ enum OtherMethodFeature {
 	OtherMethodFeature_FAN_FULLSPEED = 0x04020000,
 	OtherMethodFeature_FAN_SPEED_1 = 0x04030001,
 	OtherMethodFeature_FAN_SPEED_2 = 0x04030002,
+	// found in Q7CN DSDT; ID is a bitmask, so the third fan is bit 2
+	// (0x...04, not 0x...03); present in firmware but not used yet
 	OtherMethodFeature_FAN_SPEED_3 = 0x04030004,
 
 	OtherMethodFeature_C_U1 = 0x05010000,
@@ -4155,7 +4176,7 @@ static int show_other_method_attribute(struct device *dev,
 	err = wmi_other_method_get_value(feature_id, &value);
 	mutex_unlock(&priv->fancurve_mutex);
 	if (err)
-		return -EINVAL;
+		return err;
 	return sysfs_emit(buf, "%d\n", value);
 }
 
@@ -4175,7 +4196,7 @@ static int store_other_method_attribute(struct device *dev,
 	err = wmi_other_method_set_value(feature_id, value);
 	mutex_unlock(&priv->fancurve_mutex);
 	if (err)
-		return -EINVAL;
+		return err;
 	return count;
 }
 
@@ -4524,30 +4545,28 @@ static ssize_t cpu_shortterm_powerlimit_show(struct device *dev,
 					     struct device_attribute *attr,
 					     char *buf)
 {
-	ssize_t ret;
+	struct legion_private *priv = dev_get_drvdata(dev);
 
-	ret = show_simple_wmi_attribute_from_buffer(
+	if (priv->conf->access_method_powerlimit == ACCESS_METHOD_WMI3)
+		return show_other_method_attribute(dev, attr, buf,
+			OtherMethodFeature_CPU_SHORT_TERM_POWER_LIMIT);
+	return show_simple_wmi_attribute_from_buffer(
 		dev, attr, buf, WMI_GUID_LENOVO_CPU_METHOD, 0,
 		WMI_METHOD_ID_CPU_GET_SHORTTERM_POWERLIMIT, 16, 0, 1);
-	if (ret < 0)
-		ret = show_other_method_attribute(dev, attr, buf,
-			OtherMethodFeature_CPU_SHORT_TERM_POWER_LIMIT);
-	return ret;
 }
 
 static ssize_t cpu_shortterm_powerlimit_store(struct device *dev,
 					      struct device_attribute *attr,
 					      const char *buf, size_t count)
 {
-	ssize_t ret;
+	struct legion_private *priv = dev_get_drvdata(dev);
 
-	ret = store_simple_wmi_attribute(
+	if (priv->conf->access_method_powerlimit == ACCESS_METHOD_WMI3)
+		return store_other_method_attribute(dev, attr, buf, count,
+			OtherMethodFeature_CPU_SHORT_TERM_POWER_LIMIT);
+	return store_simple_wmi_attribute(
 		dev, attr, buf, count, WMI_GUID_LENOVO_CPU_METHOD, 0,
 		WMI_METHOD_ID_CPU_SET_SHORTTERM_POWERLIMIT, false, 1);
-	if (ret < 0)
-		ret = store_other_method_attribute(dev, attr, buf, count,
-			OtherMethodFeature_CPU_SHORT_TERM_POWER_LIMIT);
-	return ret;
 }
 
 static DEVICE_ATTR_RW(cpu_shortterm_powerlimit);
@@ -4556,30 +4575,28 @@ static ssize_t cpu_longterm_powerlimit_show(struct device *dev,
 					    struct device_attribute *attr,
 					    char *buf)
 {
-	ssize_t ret;
+	struct legion_private *priv = dev_get_drvdata(dev);
 
-	ret = show_simple_wmi_attribute_from_buffer(
+	if (priv->conf->access_method_powerlimit == ACCESS_METHOD_WMI3)
+		return show_other_method_attribute(dev, attr, buf,
+			OtherMethodFeature_CPU_LONG_TERM_POWER_LIMIT);
+	return show_simple_wmi_attribute_from_buffer(
 		dev, attr, buf, WMI_GUID_LENOVO_CPU_METHOD, 0,
 		WMI_METHOD_ID_CPU_GET_LONGTERM_POWERLIMIT, 16, 0, 1);
-	if (ret < 0)
-		ret = show_other_method_attribute(dev, attr, buf,
-			OtherMethodFeature_CPU_LONG_TERM_POWER_LIMIT);
-	return ret;
 }
 
 static ssize_t cpu_longterm_powerlimit_store(struct device *dev,
 					     struct device_attribute *attr,
 					     const char *buf, size_t count)
 {
-	ssize_t ret;
+	struct legion_private *priv = dev_get_drvdata(dev);
 
-	ret = store_simple_wmi_attribute(
+	if (priv->conf->access_method_powerlimit == ACCESS_METHOD_WMI3)
+		return store_other_method_attribute(dev, attr, buf, count,
+			OtherMethodFeature_CPU_LONG_TERM_POWER_LIMIT);
+	return store_simple_wmi_attribute(
 		dev, attr, buf, count, WMI_GUID_LENOVO_CPU_METHOD, 0,
 		WMI_METHOD_ID_CPU_SET_LONGTERM_POWERLIMIT, false, 1);
-	if (ret < 0)
-		ret = store_other_method_attribute(dev, attr, buf, count,
-			OtherMethodFeature_CPU_LONG_TERM_POWER_LIMIT);
-	return ret;
 }
 
 static DEVICE_ATTR_RW(cpu_longterm_powerlimit);
@@ -4641,30 +4658,28 @@ static ssize_t cpu_cross_loading_powerlimit_show(struct device *dev,
 						 struct device_attribute *attr,
 						 char *buf)
 {
-	ssize_t ret;
+	struct legion_private *priv = dev_get_drvdata(dev);
 
-	ret = show_simple_wmi_attribute(
+	if (priv->conf->access_method_powerlimit == ACCESS_METHOD_WMI3)
+		return show_other_method_attribute(dev, attr, buf,
+			OtherMethodFeature_CPU_CROSS_LOAD_POWER_LIMIT);
+	return show_simple_wmi_attribute(
 		dev, attr, buf, WMI_GUID_LENOVO_GPU_METHOD, 0,
 		WMI_METHOD_ID_CPU_GET_CROSS_LOADING_POWERLIMIT, false, 1);
-	if (ret < 0)
-		ret = show_other_method_attribute(dev, attr, buf,
-			OtherMethodFeature_CPU_CROSS_LOAD_POWER_LIMIT);
-	return ret;
 }
 
 static ssize_t cpu_cross_loading_powerlimit_store(struct device *dev,
 						  struct device_attribute *attr,
 						  const char *buf, size_t count)
 {
-	ssize_t ret;
+	struct legion_private *priv = dev_get_drvdata(dev);
 
-	ret = store_simple_wmi_attribute(
+	if (priv->conf->access_method_powerlimit == ACCESS_METHOD_WMI3)
+		return store_other_method_attribute(dev, attr, buf, count,
+			OtherMethodFeature_CPU_CROSS_LOAD_POWER_LIMIT);
+	return store_simple_wmi_attribute(
 		dev, attr, buf, count, WMI_GUID_LENOVO_GPU_METHOD, 0,
 		WMI_METHOD_ID_CPU_SET_CROSS_LOADING_POWERLIMIT, false, 1);
-	if (ret < 0)
-		ret = store_other_method_attribute(dev, attr, buf, count,
-			OtherMethodFeature_CPU_CROSS_LOAD_POWER_LIMIT);
-	return ret;
 }
 
 static DEVICE_ATTR_RW(cpu_cross_loading_powerlimit);
@@ -4693,31 +4708,29 @@ static ssize_t gpu_ppab_powerlimit_show(struct device *dev,
 					struct device_attribute *attr,
 					char *buf)
 {
-	ssize_t ret;
+	struct legion_private *priv = dev_get_drvdata(dev);
 
-	ret = show_simple_wmi_attribute_from_buffer(
+	if (priv->conf->access_method_powerlimit == ACCESS_METHOD_WMI3)
+		return show_other_method_attribute(dev, attr, buf,
+			OtherMethodFeature_GPU_POWER_BOOST);
+	return show_simple_wmi_attribute_from_buffer(
 		dev, attr, buf, WMI_GUID_LENOVO_GPU_METHOD, 0,
 		WMI_METHOD_ID_GPU_GET_PPAB_POWERLIMIT, 16, 0, 1);
-	if (ret < 0)
-		ret = show_other_method_attribute(dev, attr, buf,
-			OtherMethodFeature_GPU_POWER_BOOST);
-	return ret;
 }
 
 static ssize_t gpu_ppab_powerlimit_store(struct device *dev,
 					 struct device_attribute *attr,
 					 const char *buf, size_t count)
 {
-	ssize_t ret;
+	struct legion_private *priv = dev_get_drvdata(dev);
 
-	ret = store_simple_wmi_attribute(dev, attr, buf, count,
+	if (priv->conf->access_method_powerlimit == ACCESS_METHOD_WMI3)
+		return store_other_method_attribute(dev, attr, buf, count,
+			OtherMethodFeature_GPU_POWER_BOOST);
+	return store_simple_wmi_attribute(dev, attr, buf, count,
 					  WMI_GUID_LENOVO_GPU_METHOD, 0,
 					  WMI_METHOD_ID_GPU_SET_PPAB_POWERLIMIT,
 					  false, 1);
-	if (ret < 0)
-		ret = store_other_method_attribute(dev, attr, buf, count,
-			OtherMethodFeature_GPU_POWER_BOOST);
-	return ret;
 }
 
 static DEVICE_ATTR_RW(gpu_ppab_powerlimit);
@@ -4726,31 +4739,29 @@ static ssize_t gpu_ctgp_powerlimit_show(struct device *dev,
 					struct device_attribute *attr,
 					char *buf)
 {
-	ssize_t ret;
+	struct legion_private *priv = dev_get_drvdata(dev);
 
-	ret = show_simple_wmi_attribute_from_buffer(
+	if (priv->conf->access_method_powerlimit == ACCESS_METHOD_WMI3)
+		return show_other_method_attribute(dev, attr, buf,
+			OtherMethodFeature_GPU_cTGP);
+	return show_simple_wmi_attribute_from_buffer(
 		dev, attr, buf, WMI_GUID_LENOVO_GPU_METHOD, 0,
 		WMI_METHOD_ID_GPU_GET_CTGP_POWERLIMIT, 16, 0, 1);
-	if (ret < 0)
-		ret = show_other_method_attribute(dev, attr, buf,
-			OtherMethodFeature_GPU_cTGP);
-	return ret;
 }
 
 static ssize_t gpu_ctgp_powerlimit_store(struct device *dev,
 					 struct device_attribute *attr,
 					 const char *buf, size_t count)
 {
-	ssize_t ret;
+	struct legion_private *priv = dev_get_drvdata(dev);
 
-	ret = store_simple_wmi_attribute(dev, attr, buf, count,
+	if (priv->conf->access_method_powerlimit == ACCESS_METHOD_WMI3)
+		return store_other_method_attribute(dev, attr, buf, count,
+			OtherMethodFeature_GPU_cTGP);
+	return store_simple_wmi_attribute(dev, attr, buf, count,
 					  WMI_GUID_LENOVO_GPU_METHOD, 0,
 					  WMI_METHOD_ID_GPU_SET_CTGP_POWERLIMIT,
 					  false, 1);
-	if (ret < 0)
-		ret = store_other_method_attribute(dev, attr, buf, count,
-			OtherMethodFeature_GPU_cTGP);
-	return ret;
 }
 
 static DEVICE_ATTR_RW(gpu_ctgp_powerlimit);
@@ -4850,32 +4861,20 @@ static DEVICE_ATTR_RW(fan_fullspeed);
 static ssize_t fan_maxspeed_show(struct device *dev,
 				 struct device_attribute *attr, char *buf)
 {
-	ssize_t ret;
-
-	ret = show_simple_wmi_attribute(dev, attr, buf,
+	return show_simple_wmi_attribute(dev, attr, buf,
 					 WMI_GUID_LENOVO_FAN_METHOD, 0,
 					 WMI_METHOD_ID_FAN_GET_MAXSPEED, false,
 					 1);
-	if (ret < 0)
-		ret = show_other_method_attribute(dev, attr, buf,
-			OtherMethodFeature_FAN_FULLSPEED);
-	return ret;
 }
 
 static ssize_t fan_maxspeed_store(struct device *dev,
 				  struct device_attribute *attr,
 				  const char *buf, size_t count)
 {
-	ssize_t ret;
-
-	ret = store_simple_wmi_attribute(dev, attr, buf, count,
+	return store_simple_wmi_attribute(dev, attr, buf, count,
 					  WMI_GUID_LENOVO_FAN_METHOD, 0,
 					  WMI_METHOD_ID_FAN_SET_MAXSPEED, false,
 					  1);
-	if (ret < 0)
-		ret = store_other_method_attribute(dev, attr, buf, count,
-			OtherMethodFeature_FAN_FULLSPEED);
-	return ret;
 }
 
 static DEVICE_ATTR_RW(fan_maxspeed);
@@ -4967,7 +4966,19 @@ static struct attribute *legion_sysfs_attributes[] = {
 	NULL
 };
 
+static umode_t legion_sysfs_is_visible(struct kobject *kobj,
+				       struct attribute *attr, int idx)
+{
+	struct device *dev = kobj_to_dev(kobj);
+	struct legion_private *priv = dev_get_drvdata(dev);
+
+	if (attr == &dev_attr_fan_maxspeed.attr && priv->conf->no_fan_maxspeed)
+		return 0;
+	return attr->mode;
+}
+
 static const struct attribute_group legion_attribute_group = {
+	.is_visible = legion_sysfs_is_visible,
 	.attrs = legion_sysfs_attributes
 };
 
@@ -5018,9 +5029,10 @@ static void legion_wmi_notify(struct wmi_device *wdev, union acpi_object *data)
 
 	mutex_lock(&legion_shared_mutex);
 	priv = legion_shared;
-	if ((!priv) && (priv->loaded)) {
+	if (!priv || !priv->loaded) {
 		pr_info("Received WMI event while not initialized!\n");
-		goto unlock;
+		mutex_unlock(&legion_shared_mutex);
+		return;
 	}
 
 	wpriv = dev_get_drvdata(&wdev->dev);
@@ -5037,7 +5049,6 @@ static void legion_wmi_notify(struct wmi_device *wdev, union acpi_object *data)
 		break;
 	}
 
-unlock:
 	mutex_unlock(&legion_shared_mutex);
 	// todo; fix that!
 	// problem: we get an event just before the powermode change (from the key?),

--- a/kernel_module/legion-laptop.c
+++ b/kernel_module/legion-laptop.c
@@ -1030,6 +1030,31 @@ static const struct model_config model_nrcn = {
 };
 
 
+// Legion Pro 7 16IAX10H (83F5) - Arrow Lake 2025
+// Pure WMI access - EC RAM at 0xFE5004xx per DSDT
+// Fan fullspeed via WMAE 0x04020000, not WMAB
+// No Y-logo or IO-port LED control in WMAF on this firmware
+static const struct model_config model_q7cn = {
+	.registers = &ec_register_offsets_v0,
+	.check_embedded_controller_id = false,
+	.embedded_controller_id = 0x0000,
+	.memoryio_physical_ec_start = 0xC400,
+	.memoryio_size = 0x300,
+	.has_minifancurve = false,
+	.has_custom_powermode = true,
+	.access_method_powermode = ACCESS_METHOD_WMI,
+	.access_method_keyboard = ACCESS_METHOD_WMI,
+	.access_method_fanspeed = ACCESS_METHOD_WMI3,
+	.access_method_temperature = ACCESS_METHOD_WMI3,
+	.access_method_fancurve = ACCESS_METHOD_WMI3,
+	.access_method_fanfullspeed = ACCESS_METHOD_WMI3,
+	.no_ylogo_light = true,
+	.no_ioport_light = true,
+	.acpi_check_dev = false,
+	.ramio_physical_start = 0xFE500400,
+	.ramio_size = 0xC00
+};
+
 static const struct dmi_system_id denylist[] = { {} };
 
 static const struct dmi_system_id optimistic_allowlist[] = {
@@ -1423,6 +1448,15 @@ static const struct dmi_system_id optimistic_allowlist[] = {
 			DMI_MATCH(DMI_BIOS_VERSION, "NRCN"),
 		},
 		.driver_data = (void *)&model_nrcn
+	},
+	{
+		// Legion Pro 7 16IAX10H (83F5) - Arrow Lake 2025
+		.ident = "Q7CN",
+		.matches = {
+			DMI_MATCH(DMI_SYS_VENDOR, "LENOVO"),
+			DMI_MATCH(DMI_BIOS_VERSION, "Q7CN"),
+		},
+		.driver_data = (void *)&model_q7cn
 	},
 	{}
 };

--- a/kernel_module/legion-laptop.c
+++ b/kernel_module/legion-laptop.c
@@ -230,6 +230,9 @@ struct model_config {
 	// set to true if the legacy fan maxspeed WMI method is a stub that
 	// does not reflect fan state; hides the fan_maxspeed attribute
 	bool no_fan_maxspeed;
+	// hide hwmon values which bypass the configured access methods and
+	// read the legacy EXT_IC_TEMP_INPUT/EXT_FAN*_TARGET_RPM EC offsets
+	bool no_legacy_ec_hwmon;
 
 	bool acpi_check_dev;
 
@@ -1070,6 +1073,10 @@ static const struct model_config model_q7cn = {
 	// Legacy fan maxspeed method answers but does not track WMAE
 	// fullspeed state; there is no separate maxspeed feature in WMAE
 	.no_fan_maxspeed = true,
+	// The Q7CN DSDT only defines WMAE access for CPU/GPU temperatures and
+	// current fan speeds; legacy IC-temperature and fan-target offsets are
+	// not verified on this EC generation.
+	.no_legacy_ec_hwmon = true,
 	.acpi_check_dev = false,
 	.ramio_physical_start = 0xFE500400,
 	.ramio_size = 0xC00
@@ -5484,6 +5491,22 @@ static struct attribute *sensor_hwmon_attributes[] = {
 	NULL
 };
 
+static umode_t legion_hwmon_sensor_is_visible(struct kobject *kobj,
+					      struct attribute *attr, int idx)
+{
+	struct device *dev = kobj_to_dev(kobj);
+	struct legion_private *priv = dev_get_drvdata(dev);
+
+	if (priv->conf->no_legacy_ec_hwmon &&
+	    (attr == &sensor_dev_attr_temp3_input.dev_attr.attr ||
+	     attr == &sensor_dev_attr_temp3_label.dev_attr.attr ||
+	     attr == &sensor_dev_attr_fan1_target.dev_attr.attr ||
+	     attr == &sensor_dev_attr_fan2_target.dev_attr.attr))
+		return 0;
+
+	return attr->mode;
+}
+
 static ssize_t fan_max_show(struct device *dev,
 			    struct device_attribute *devattr, char *buf)
 {
@@ -6133,7 +6156,7 @@ static umode_t legion_hwmon_is_visible(struct kobject *kobj,
 
 static const struct attribute_group legion_hwmon_sensor_group = {
 	.attrs = sensor_hwmon_attributes,
-	.is_visible = NULL
+	.is_visible = legion_hwmon_sensor_is_visible
 };
 
 static const struct attribute_group legion_hwmon_fancurve_group = {

--- a/kernel_module/legion-laptop.c
+++ b/kernel_module/legion-laptop.c
@@ -5767,7 +5767,7 @@ static ssize_t pwm1_mode_show(struct device *dev,
 	struct legion_private *priv = dev_get_drvdata(dev);
 
 	mutex_lock(&priv->fancurve_mutex);
-	err = ec_read_fanfullspeed(&priv->ecram, priv->conf, &value);
+	err = read_fanfullspeed(priv, &value);
 	if (err) {
 		err = -1;
 		pr_info("Failed to pwm1_mode/maximumfanspeed\n");
@@ -5800,8 +5800,7 @@ static ssize_t pwm1_mode_store(struct device *dev,
 	is_maximumfanspeed = value == 0;
 
 	mutex_lock(&priv->fancurve_mutex);
-	err = ec_write_fanfullspeed(&priv->ecram, priv->conf,
-				    is_maximumfanspeed);
+	err = write_fanfullspeed(priv, is_maximumfanspeed);
 	if (err) {
 		err = -1;
 		pr_info("Failed to write pwm1_mode/maximumfanspeed\n");

--- a/kernel_module/legion-laptop.c
+++ b/kernel_module/legion-laptop.c
@@ -1786,8 +1786,10 @@ enum OtherMethodFeature {
 	OtherMethodFeature_GPU_POWER_TARGET_ON_AC_OFFSET_FROM_BASELINE =
 		0x02040000,
 
+	OtherMethodFeature_FAN_FULLSPEED = 0x04020000,
 	OtherMethodFeature_FAN_SPEED_1 = 0x04030001,
 	OtherMethodFeature_FAN_SPEED_2 = 0x04030002,
+	OtherMethodFeature_FAN_SPEED_3 = 0x04030004,
 
 	OtherMethodFeature_C_U1 = 0x05010000,
 	OtherMethodFeature_TEMP_CPU = 0x05040000,
@@ -1809,6 +1811,16 @@ static ssize_t wmi_other_method_get_value(enum OtherMethodFeature feature_id,
 	if (!error)
 		*value = res;
 	return error;
+}
+
+static ssize_t wmi_other_method_set_value(enum OtherMethodFeature feature_id,
+					  int value)
+{
+	u32 param[2] = { feature_id, value };
+
+	return wmi_exec_arg(LEGION_WMI_LENOVO_OTHER_METHOD_GUID, 0,
+			    WMI_METHOD_ID_SET_FEATURE_VALUE, param,
+			    sizeof(param));
 }
 
 /* =================================== */

--- a/kernel_module/legion-laptop.c
+++ b/kernel_module/legion-laptop.c
@@ -218,6 +218,9 @@ struct model_config {
 	enum access_method access_method_fancurve;
 	enum access_method access_method_fanfullspeed;
 	bool three_state_keyboard;
+	// set to true to skip registering non-functional LED controls
+	bool no_ylogo_light;
+	bool no_ioport_light;
 
 	bool acpi_check_dev;
 
@@ -6465,20 +6468,26 @@ static int legion_add(struct platform_device *pdev)
 			"Failed to init keyboard backlight LED driver. Skipping ...\n");
 	}
 
-	pr_info("Init Y-Logo LED driver\n");
-	err = legion_light_init(priv, &priv->ylogo_light, LIGHT_ID_YLOGO, 0, 1,
-				"platform::ylogo");
-	if (err) {
-		dev_info(&pdev->dev,
-			 "Failed to init Y-Logo LED driver. Skipping ...\n");
+	if (!priv->conf->no_ylogo_light) {
+		pr_info("Init Y-Logo LED driver\n");
+		err = legion_light_init(priv, &priv->ylogo_light,
+					LIGHT_ID_YLOGO, 0, 1,
+					"platform::ylogo");
+		if (err) {
+			dev_info(&pdev->dev,
+				 "Failed to init Y-Logo LED driver. Skipping ...\n");
+		}
 	}
 
-	pr_info("Init IO-Port LED driver\n");
-	err = legion_light_init(priv, &priv->iport_light, LIGHT_ID_IOPORT, 1, 2,
-				"platform::ioport");
-	if (err) {
-		dev_info(&pdev->dev,
-			 "Failed to init IO-Port LED driver. Skipping ...\n");
+	if (!priv->conf->no_ioport_light) {
+		pr_info("Init IO-Port LED driver\n");
+		err = legion_light_init(priv, &priv->iport_light,
+					LIGHT_ID_IOPORT, 1, 2,
+					"platform::ioport");
+		if (err) {
+			dev_info(&pdev->dev,
+				 "Failed to init IO-Port LED driver. Skipping ...\n");
+		}
 	}
 
 	dev_info(&pdev->dev, "legion_laptop loaded for this device\n");

--- a/kernel_module/legion-laptop.c
+++ b/kernel_module/legion-laptop.c
@@ -4792,6 +4792,11 @@ static ssize_t gpu_temperature_limit_show(struct device *dev,
 					  struct device_attribute *attr,
 					  char *buf)
 {
+	struct legion_private *priv = dev_get_drvdata(dev);
+
+	if (priv->conf->access_method_powerlimit == ACCESS_METHOD_WMI3)
+		return show_other_method_attribute(dev, attr, buf,
+			OtherMethodFeature_GPU_TEMPERATURE_LIMIT);
 	return show_simple_wmi_attribute(
 		dev, attr, buf, WMI_GUID_LENOVO_GPU_METHOD, 0,
 		WMI_METHOD_ID_GPU_GET_TEMPERATURE_LIMIT, false, 1);
@@ -4801,6 +4806,11 @@ static ssize_t gpu_temperature_limit_store(struct device *dev,
 					   struct device_attribute *attr,
 					   const char *buf, size_t count)
 {
+	struct legion_private *priv = dev_get_drvdata(dev);
+
+	if (priv->conf->access_method_powerlimit == ACCESS_METHOD_WMI3)
+		return store_other_method_attribute(dev, attr, buf, count,
+			OtherMethodFeature_GPU_TEMPERATURE_LIMIT);
 	return store_simple_wmi_attribute(
 		dev, attr, buf, count, WMI_GUID_LENOVO_GPU_METHOD, 0,
 		WMI_METHOD_ID_GPU_SET_TEMPERATURE_LIMIT, false, 1);
@@ -4971,9 +4981,29 @@ static umode_t legion_sysfs_is_visible(struct kobject *kobj,
 {
 	struct device *dev = kobj_to_dev(kobj);
 	struct legion_private *priv = dev_get_drvdata(dev);
+	bool wmi3_power = priv->conf->access_method_powerlimit ==
+			  ACCESS_METHOD_WMI3;
 
 	if (attr == &dev_attr_fan_maxspeed.attr && priv->conf->no_fan_maxspeed)
 		return 0;
+
+	/*
+	 * WMAE-only firmware may retain the legacy CPU/GPU GUIDs as stubs.
+	 * Do not advertise attributes which are not routed through WMAE: reads
+	 * either fail with an unexpected ACPI result or return placeholder data,
+	 * while setters can report success without changing hardware state.
+	 */
+	if (wmi3_power &&
+	    (attr == &dev_attr_cpu_oc.attr ||
+	     attr == &dev_attr_cpu_apu_sppt_powerlimit.attr ||
+	     attr == &dev_attr_cpu_default_powerlimit.attr ||
+	     attr == &dev_attr_cpu_peak_powerlimit.attr ||
+	     attr == &dev_attr_gpu_oc.attr ||
+	     attr == &dev_attr_gpu_ctgp2_powerlimit.attr ||
+	     attr == &dev_attr_gpu_default_ppab_ctrgp_powerlimit.attr ||
+	     attr == &dev_attr_gpu_boost_clock.attr))
+		return 0;
+
 	return attr->mode;
 }
 


### PR DESCRIPTION
I recently bought a Legion Pro 7 16IAX10H (83F5, Intel Arrow Lake, BIOS Q7CN) and was impressed to discover this project. After some struggle getting the driver to load on my laptop (the 2025 firmware is quite different from older
  models), I managed to get most core features working.

The main challenge is that Q7CN firmware routes nearly everything through the WMAE (OtherMethod/GetFeatureValue/SetFeatureValue) WMI interface, rather than the dedicated per-feature WMI GUIDs (CPU method, GPU method, fan method) or direct EC register access used by older models. Several generic improvements were needed to support this, which should also benefit other newer models that follow the same pattern.

  What this PR does:
  - Adds WMAE wmi_other_method_set_value() — the write counterpart that was missing
  - Adds ACCESS_METHOD_WMI3 dispatch for fan fullspeed (older models use WMAB, Q7CN uses WMAE 0x04020000)
  - Fixes pwm1_mode hwmon to use the access method dispatch instead of hardcoded EC reads (was broken for any non-EC model)
  - Adds WMAE fallback to CPU/GPU power limit sysfs attributes — tries the dedicated WMI GUID first, falls back to WMAE on failure (backward compatible)
  - Adds no_ylogo_light/no_ioport_light model config flags for models where these LEDs aren't WMI-controllable
  - Adds model_q7cn config and DMI match entry
  - Disables WMI keyboard backlight registration (keyboard is USB HID: ITE 048d:c193 "Lenovo Lighting", i will look into that later)

  What doesn't work / uncertain

  - Fan curves read as all zeros — the WMI3 fan curve read path may need a different approach for this firmware
  - Fan fullspeed — the FNST toggle works (reads back correctly), but I'm not entirely sure it forces unconditional max RPM vs just switching to a more aggressive curve. The fans don't audibly ramp to maximum at idle when enabled, though
  that could be normal EC behavior at low temperatures, i didnt test that well yet.
  - CPU/GPU power limit writes — reads work via WMAE fallback, but writes may need the laptop to be in custom power mode (ODV1=0x03) per the DSDT logic. Needs more testing under load
  - Keyboard backlight — controlled by USB HID (ITE 048d:c193), needs a separate driver?
  - Y-logo / IO-port LEDs — seems not controllable via WMAF on this firmware. The proper control mechanism hasn't been identified yet

Also, I only have this one laptop to test on, so I cannot verify that these changes don't break older Legion models. The generic improvements (WMAE fallback, pwm1_mode fix) are designed to be backward compatible — they try the existing path first and only fall back to WMAE on failure. But please take this with a grain of salt and test on other hardware if possible.

