### PR TITLE
Add support for Legion 5 15IRX10 (83LY, BIOS QNCN)

### DIFF
--- a/README.md
+++ b/README.md
@@ -927,6 +927,8 @@ A graphical GNOME applet uses `power-profiles-daemon` to change the power mode u
 
 For KDE, there is the graphical tool `powerdevil`, which also uses `power-profiles-daemon` internally.
 
+If KDE only shows `balanced` and `performance` in `/sys/firmware/acpi/platform_profile_choices` but the Legion device (for example `/sys/devices/pci0000:00/0000:00:1f.0/PNP0C09:00/platform-profile/platform-profile-1/choices`) includes `quiet`, check whether `lenovo_wmi_gamezone` is also loaded. If both providers are active, the global profile choices are the intersection of both providers and quiet mode might disappear. In that case, unload or blacklist `lenovo_wmi_gamezone` and keep `legion_laptop` as the single provider for power mode.
+
 ### It almost works, but (some) temperature sensor/changing point in fan control or (some) fan speed is not working. What should I do?
 
 First, try to [reset the embedded controller](#how-to-do-a-bios-upgrade-or-reset-the-embedded-controller-to-fix-a-problem) OR do a BIOS update/downgrade to reset everything.

--- a/kernel_module/legion-laptop.c
+++ b/kernel_module/legion-laptop.c
@@ -752,6 +752,25 @@ static const struct model_config model_nscn = {
 	.ramio_size = 0x600
 };
 
+static const struct model_config model_qncn = {
+	.registers = &ec_register_offsets_v0,
+	.check_embedded_controller_id = true,
+	.embedded_controller_id = 0x5508,
+	.memoryio_physical_ec_start = 0xC400,
+	.memoryio_size = 0x300,
+	.has_minifancurve = false,
+	.has_custom_powermode = true,
+	.access_method_powermode = ACCESS_METHOD_WMI,
+	.access_method_keyboard = ACCESS_METHOD_WMI,
+	.access_method_fanspeed = ACCESS_METHOD_WMI3,
+	.access_method_temperature = ACCESS_METHOD_WMI3,
+	.access_method_fancurve = ACCESS_METHOD_NO_ACCESS,
+	.access_method_fanfullspeed = ACCESS_METHOD_WMI,
+	.acpi_check_dev = false,
+	.ramio_physical_start = 0xFE00D400,
+	.ramio_size = 0x600
+};
+
 static const struct model_config model_lpcn = {
 	.registers = &ec_register_offsets_v0,
 	.check_embedded_controller_id = true,
@@ -1505,6 +1524,15 @@ static const struct dmi_system_id optimistic_allowlist[] = {
 			DMI_MATCH(DMI_BIOS_VERSION, "NZCN"),
 		},
 		.driver_data = (void *)&model_nzcn
+	},
+	{
+		// e.g. Legion 5 15IRX10 (83LY)
+		.ident = "QNCN",
+		.matches = {
+			DMI_MATCH(DMI_SYS_VENDOR, "LENOVO"),
+			DMI_MATCH(DMI_BIOS_VERSION, "QNCN"),
+		},
+		.driver_data = (void *)&model_qncn
 	},
 	{
 		// e.g. Legion Pro 5 16IRX9 (83DF)


### PR DESCRIPTION
## Summary
This PR adds support for Lenovo Legion 5 15IRX10 systems using QNCN firmware.

## Changes
- Added support for BIOS family `QNCN` in the kernel module configuration
- Added the corresponding allowlist/DMI matching so the module loads normally on this model (without `force=1`)
- Updated README with notes about a possible platform profile conflict with Lenovo WMI Gamezone

## Tested on
- Model: **Lenovo Legion 5 15IRX10**
- CPU: **Intel Core i9-14900HX**
- GPU: **NVIDIA GeForce RTX 5070 Max-Q / Mobile**
- DMI product name: `83LY`
- BIOS: `QNCN28WW`
- Kernel: `6.19.9-1-default`
- EC Chip ID: `0x5508`
- EC Chip Version: `0x2b0`

## Validation results
- Module probes and loads normally for the device (`is_allowed`: 1, config `QNCN` selected)
- hwmon/sysfs interfaces are available and functional
- Fan RPM and temperatures report coherently with the selected access method
- Power mode switching works (including platform profile integration)

## Note about platform profile providers
On this machine, `legion_laptop` can coexist with `lenovo_wmi_gamezone`, but both may register platform profile handlers with different profile sets.
This may cause user-space issues (for example KDE power-saver errors or missing low-power transitions).

The README documents the workaround: blacklist `lenovo_wmi_gamezone` when using `legion_laptop` as the primary platform profile provider.