### PR TITLE
Adapt to kernel 7.0

### DIFF
--- a/kernel_module/legion-laptop.c
+++ b/kernel_module/legion-laptop.c
@@ -6455,8 +6455,11 @@ static SIMPLE_DEV_PM_OPS(legion_pm, NULL, legion_pm_resume);
 // same as ideapad
 static const struct acpi_device_id legion_device_ids[] = {
 	// todo: change to "VPC2004", and also ACPI paths
-	//{ "PNP0C09", 0 },
-	{ "VPC2004", 0 },
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0)
+	    { "VPC2004", 0 },
+#else
+	    { "PNP0C09", 0 },
+#endif
 	{ "", 0 },
 };
 MODULE_DEVICE_TABLE(acpi, legion_device_ids);

--- a/kernel_module/legion-laptop.c
+++ b/kernel_module/legion-laptop.c
@@ -210,6 +210,7 @@ struct model_config {
 	// TODO: maybe use bitfield
 	bool has_minifancurve;
 	bool has_custom_powermode;
+	bool has_extreme_powermode;
 	enum access_method access_method_powermode;
 
 	enum access_method access_method_keyboard;
@@ -955,6 +956,7 @@ static const struct model_config model_lzcn = {
 	.memoryio_size = 0x300,
 	.has_minifancurve = true,
 	.has_custom_powermode = true,
+	.has_extreme_powermode = true,
 	.access_method_powermode = ACCESS_METHOD_WMI,
 	.access_method_keyboard = ACCESS_METHOD_WMI2,
 	.access_method_fanspeed = ACCESS_METHOD_WMI3,
@@ -3535,27 +3537,31 @@ enum legion_ec_powermode {
 	LEGION_EC_POWERMODE_QUIET = 2,
 	LEGION_EC_POWERMODE_BALANCED = 0,
 	LEGION_EC_POWERMODE_PERFORMANCE = 1,
-	LEGION_EC_POWERMODE_CUSTOM = 3
+	LEGION_EC_POWERMODE_CUSTOM = 3,
+	LEGION_EC_POWERMODE_EXTREME = 7 // based on GZ44
 };
 
 enum legion_wmi_powermode {
-	LEGION_WMI_POWERMODE_QUIET = 1,
+	LEGION_WMI_POWERMODE_LOW_POWER = 1,
 	LEGION_WMI_POWERMODE_BALANCED = 2,
 	LEGION_WMI_POWERMODE_PERFORMANCE = 3,
-	LEGION_WMI_POWERMODE_CUSTOM = 255
+	LEGION_WMI_POWERMODE_CUSTOM = 255,
+	LEGION_WMI_POWERMODE_MAX_POWER = 224
 };
 
 static enum legion_wmi_powermode ec_to_wmi_powermode(int ec_mode)
 {
 	switch (ec_mode) {
 	case LEGION_EC_POWERMODE_QUIET:
-		return LEGION_WMI_POWERMODE_QUIET;
+		return LEGION_WMI_POWERMODE_LOW_POWER;
 	case LEGION_EC_POWERMODE_BALANCED:
 		return LEGION_WMI_POWERMODE_BALANCED;
 	case LEGION_EC_POWERMODE_PERFORMANCE:
 		return LEGION_WMI_POWERMODE_PERFORMANCE;
 	case LEGION_EC_POWERMODE_CUSTOM:
 		return LEGION_WMI_POWERMODE_CUSTOM;
+	case LEGION_EC_POWERMODE_EXTREME:
+		return LEGION_WMI_POWERMODE_MAX_POWER;
 	default:
 		return LEGION_WMI_POWERMODE_BALANCED;
 	}
@@ -3565,7 +3571,7 @@ static enum legion_ec_powermode
 wmi_to_ec_powermode(enum legion_wmi_powermode wmi_mode)
 {
 	switch (wmi_mode) {
-	case LEGION_WMI_POWERMODE_QUIET:
+	case LEGION_WMI_POWERMODE_LOW_POWER:
 		return LEGION_EC_POWERMODE_QUIET;
 	case LEGION_WMI_POWERMODE_BALANCED:
 		return LEGION_EC_POWERMODE_BALANCED;
@@ -3573,6 +3579,8 @@ wmi_to_ec_powermode(enum legion_wmi_powermode wmi_mode)
 		return LEGION_EC_POWERMODE_PERFORMANCE;
 	case LEGION_WMI_POWERMODE_CUSTOM:
 		return LEGION_EC_POWERMODE_CUSTOM;
+	case LEGION_WMI_POWERMODE_MAX_POWER:
+		return LEGION_EC_POWERMODE_EXTREME;
 	default:
 		return LEGION_EC_POWERMODE_BALANCED;
 	}
@@ -3587,7 +3595,11 @@ static ssize_t ec_read_powermode(struct legion_private *priv, int *powermode)
 
 static ssize_t ec_write_powermode(struct legion_private *priv, u8 value)
 {
-	if (!((value >= 0 && value <= 2) || value == 255)) {
+	if (value != LEGION_EC_POWERMODE_BALANCED &&
+    value != LEGION_EC_POWERMODE_PERFORMANCE &&
+    value != LEGION_EC_POWERMODE_QUIET &&
+    value != LEGION_EC_POWERMODE_CUSTOM &&
+    value != LEGION_EC_POWERMODE_EXTREME) {
 		pr_info("Unexpected power mode value ignored: %d\n", value);
 		return -ENOMEM;
 	}
@@ -3622,9 +3634,11 @@ static ssize_t wmi_read_powermode(int *powermode)
 
 static ssize_t wmi_write_powermode(u8 value)
 {
-	if (!((value >= LEGION_WMI_POWERMODE_QUIET &&
-	       value <= LEGION_WMI_POWERMODE_PERFORMANCE) ||
-	      value == LEGION_WMI_POWERMODE_CUSTOM)) {
+	if (value != LEGION_WMI_POWERMODE_BALANCED &&
+    value != LEGION_WMI_POWERMODE_PERFORMANCE &&
+    value != LEGION_WMI_POWERMODE_LOW_POWER &&
+    value != LEGION_WMI_POWERMODE_CUSTOM &&
+    value != LEGION_WMI_POWERMODE_MAX_POWER) {
 		pr_info("Unexpected power mode value ignored: %d\n", value);
 		return -ENOMEM;
 	}
@@ -5008,12 +5022,16 @@ static int legion_platform_profile_get(struct platform_profile_handler *pprof,
 	case LEGION_WMI_POWERMODE_PERFORMANCE:
 		*profile = PLATFORM_PROFILE_PERFORMANCE;
 		break;
-	case LEGION_WMI_POWERMODE_QUIET:
-		*profile = PLATFORM_PROFILE_QUIET;
+	case LEGION_WMI_POWERMODE_LOW_POWER:
+		*profile = PLATFORM_PROFILE_LOW_POWER;
 		break;
 	case LEGION_WMI_POWERMODE_CUSTOM:
-		*profile = PLATFORM_PROFILE_BALANCED_PERFORMANCE;
+		*profile = PLATFORM_PROFILE_CUSTOM;
 		break;
+	case LEGION_WMI_POWERMODE_MAX_POWER:
+		*profile = PLATFORM_PROFILE_MAX_POWER;
+		break;
+
 	default:
 		return -EINVAL;
 	}
@@ -5037,7 +5055,6 @@ static int legion_platform_profile_set(struct platform_profile_handler *pprof,
 	priv = container_of(pprof, struct legion_private,
 			    platform_profile_handler);
 #endif
-
 	switch (profile) {
 	case PLATFORM_PROFILE_BALANCED:
 		powermode = LEGION_WMI_POWERMODE_BALANCED;
@@ -5045,11 +5062,14 @@ static int legion_platform_profile_set(struct platform_profile_handler *pprof,
 	case PLATFORM_PROFILE_PERFORMANCE:
 		powermode = LEGION_WMI_POWERMODE_PERFORMANCE;
 		break;
-	case PLATFORM_PROFILE_QUIET:
-		powermode = LEGION_WMI_POWERMODE_QUIET;
+	case PLATFORM_PROFILE_LOW_POWER:
+		powermode = LEGION_WMI_POWERMODE_LOW_POWER;
 		break;
-	case PLATFORM_PROFILE_BALANCED_PERFORMANCE:
+	case PLATFORM_PROFILE_CUSTOM:
 		powermode = LEGION_WMI_POWERMODE_CUSTOM;
+		break;
+	case PLATFORM_PROFILE_MAX_POWER:
+		powermode = LEGION_WMI_POWERMODE_MAX_POWER;
 		break;
 	default:
 		return -EOPNOTSUPP;
@@ -5060,15 +5080,19 @@ static int legion_platform_profile_set(struct platform_profile_handler *pprof,
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 14, 0)
 static bool conf_has_custom_powermode;
+static bool conf_has_extreme_powermode;
 static enum access_method conf_access_method_powermode;
 
 static int legion_platform_profile_probe(void *drvdata, unsigned long *choices)
 {
-	set_bit(PLATFORM_PROFILE_QUIET, choices);
+	set_bit(PLATFORM_PROFILE_LOW_POWER, choices);
 	set_bit(PLATFORM_PROFILE_BALANCED, choices);
 	set_bit(PLATFORM_PROFILE_PERFORMANCE, choices);
 	if (conf_has_custom_powermode && conf_access_method_powermode == ACCESS_METHOD_WMI) {
-		set_bit(PLATFORM_PROFILE_BALANCED_PERFORMANCE, choices);
+		set_bit(PLATFORM_PROFILE_CUSTOM, choices);
+	}
+	if (conf_has_extreme_powermode && conf_access_method_powermode == ACCESS_METHOD_WMI) {
+		set_bit(PLATFORM_PROFILE_MAX_POWER, choices);
 	}
 
 	return 0;
@@ -5095,6 +5119,7 @@ static int legion_platform_profile_init(struct legion_private *priv)
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 14, 0)
 	conf_has_custom_powermode = priv->conf->has_custom_powermode;
+	conf_has_extreme_powermode = priv->conf->has_extreme_powermode;
 	conf_access_method_powermode = priv->conf->access_method_powermode;
 #else
 	priv->platform_profile_handler.profile_get =
@@ -5102,14 +5127,19 @@ static int legion_platform_profile_init(struct legion_private *priv)
 	priv->platform_profile_handler.profile_set =
 		legion_platform_profile_set;
 
-	set_bit(PLATFORM_PROFILE_QUIET, priv->platform_profile_handler.choices);
+	set_bit(PLATFORM_PROFILE_LOW_POWER, priv->platform_profile_handler.choices);
 	set_bit(PLATFORM_PROFILE_BALANCED,
 		priv->platform_profile_handler.choices);
 	set_bit(PLATFORM_PROFILE_PERFORMANCE,
 		priv->platform_profile_handler.choices);
 	if (priv->conf->has_custom_powermode &&
 	    priv->conf->access_method_powermode == ACCESS_METHOD_WMI) {
-		set_bit(PLATFORM_PROFILE_BALANCED_PERFORMANCE,
+		set_bit(PLATFORM_PROFILE_CUSTOM,
+			priv->platform_profile_handler.choices);
+	}
+	if (priv->conf->has_extreme_powermode &&
+	    priv->conf->access_method_powermode == ACCESS_METHOD_WMI) {
+		set_bit(PLATFORM_PROFILE_MAX_POWER,
 			priv->platform_profile_handler.choices);
 	}
 #endif
@@ -6421,7 +6451,8 @@ static SIMPLE_DEV_PM_OPS(legion_pm, NULL, legion_pm_resume);
 // same as ideapad
 static const struct acpi_device_id legion_device_ids[] = {
 	// todo: change to "VPC2004", and also ACPI paths
-	{ "PNP0C09", 0 },
+	//{ "PNP0C09", 0 },
+	{ "VPC2004", 0 },
 	{ "", 0 },
 };
 MODULE_DEVICE_TABLE(acpi, legion_device_ids);

--- a/kernel_module/legion-laptop.c
+++ b/kernel_module/legion-laptop.c
@@ -213,15 +213,15 @@ enum acpi_paths_inventory_ids {
 };
 
 static const char *default_acpi_paths[ACPI_PATH_MAX] = {
-	[ACPI_PATH_STA]="_STA",
-	[ACPI_PATH_CFG]="_CFG",
-	[ACPI_PATH_READ_RAPIDCHARGE]="VPC0.GBMD",
-	[ACPI_PATH_WRITE_RAPIDCHARGE]="VPC0.SBMC",
-	[ACPI_PATH_READ_POWERMODE]="VPC0.BTSM",
-	[ACPI_PATH_READ_FANSPEED1]="FANS",
-	[ACPI_PATH_READ_FANSPEED2]="FA2S",
-	[ACPI_PATH_READ_CPU_TEMP]="CPUT",
-	[ACPI_PATH_READ_GPU_TEMP]="GPUT",
+	[ACPI_PATH_STA] = "_STA",
+	[ACPI_PATH_CFG] = "_CFG",
+	[ACPI_PATH_READ_RAPIDCHARGE] = "VPC0.GBMD",
+	[ACPI_PATH_WRITE_RAPIDCHARGE] = "VPC0.SBMC",
+	[ACPI_PATH_READ_POWERMODE] = "VPC0.BTSM",
+	[ACPI_PATH_READ_FANSPEED1] = "FANS",
+	[ACPI_PATH_READ_FANSPEED2] = "FA2S",
+	[ACPI_PATH_READ_CPU_TEMP] = "CPUT",
+	[ACPI_PATH_READ_GPU_TEMP] = "GPUT",
 };
 
 struct model_config {
@@ -1460,19 +1460,18 @@ static const struct dmi_system_id optimistic_allowlist[] = {
 /* ================================= */
 /* ACPI and WMI access               */
 /* ================================= */
-//global, 
-//wanted to use _priv->conf but involves 
+//global,
+//wanted to use _priv->conf but involves
 //move all structs/defn from all the way down up
 static const struct model_config *_model;
 
 static const char *get_model_acpi_path(const struct model_config *model, enum acpi_paths_inventory_ids id)
 {
-    if (id < 0 || id >= ACPI_PATH_MAX)
-        return NULL;
-    if (model->acpi_paths[id] != NULL) {
-        return model->acpi_paths[id];
-    }
-    return default_acpi_paths[id];
+	if (id < 0 || id >= ACPI_PATH_MAX)
+		return NULL;
+	if (model->acpi_paths[id] != NULL)
+		return model->acpi_paths[id];
+	return default_acpi_paths[id];
 }
 
 // function from ideapad-laptop.c
@@ -1483,13 +1482,11 @@ static int eval_int(struct acpi_device *adev, const char *name, unsigned long *r
 	acpi_handle handle;
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0)
 	status = acpi_get_handle(NULL, (char *) name, &handle);
-	if (ACPI_FAILURE(status)){
+	if (ACPI_FAILURE(status))
 		return -EIO;
-	}
 #else
-	if (!adev) {
+	if (!adev)
 		return -ENODEV;
-	}
 	handle = adev->handle;
 #endif
 	status = acpi_evaluate_integer(handle, (char *)name, NULL, &result);
@@ -1509,9 +1506,8 @@ static int exec_simple_method(struct acpi_device *adev, const char *name,
 	acpi_status status;
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0)
 	status = acpi_get_handle(NULL, (char *)name, &handle);
-	if (ACPI_FAILURE(status)){
+	if (ACPI_FAILURE(status))
 		return -EIO;
-	}
 #else
 	handle = adev->handle;
 #endif
@@ -1526,6 +1522,7 @@ static int exec_sbmc(struct acpi_device *adev, unsigned long arg)
 {
 	// \_SB.PCI0.LPC0.EC0.VPC0.SBMC
 	const char *acpi_path;
+
 	acpi_path = get_model_acpi_path(_model, ACPI_PATH_WRITE_RAPIDCHARGE);
 	return exec_simple_method(adev, acpi_path, arg);
 }
@@ -1539,6 +1536,7 @@ static int exec_sbmc(struct acpi_device *adev, unsigned long arg)
 static int eval_gbmd(struct acpi_device *adev, unsigned long *res)
 {
 	const char *acpi_path;
+
 	acpi_path = get_model_acpi_path(_model, ACPI_PATH_READ_RAPIDCHARGE);
 	return eval_int(adev, acpi_path, res);
 }
@@ -1547,6 +1545,7 @@ static int eval_spmo(struct acpi_device *adev, unsigned long *res)
 {
 	// \_SB.PCI0.LPC0.EC0.QCHO
 	const char *acpi_path;
+
 	acpi_path = get_model_acpi_path(_model, ACPI_PATH_READ_POWERMODE);
 	return eval_int(adev, acpi_path, res);
 }
@@ -3668,10 +3667,10 @@ static ssize_t ec_read_powermode(struct legion_private *priv, int *powermode)
 static ssize_t ec_write_powermode(struct legion_private *priv, u8 value)
 {
 	if (value != LEGION_EC_POWERMODE_BALANCED &&
-    value != LEGION_EC_POWERMODE_PERFORMANCE &&
-    value != LEGION_EC_POWERMODE_QUIET &&
-    value != LEGION_EC_POWERMODE_CUSTOM &&
-    value != LEGION_EC_POWERMODE_EXTREME) {
+			value != LEGION_EC_POWERMODE_PERFORMANCE &&
+			value != LEGION_EC_POWERMODE_QUIET &&
+			value != LEGION_EC_POWERMODE_CUSTOM &&
+			value != LEGION_EC_POWERMODE_EXTREME) {
 		pr_info("Unexpected power mode value ignored: %d\n", value);
 		return -ENOMEM;
 	}
@@ -3707,10 +3706,10 @@ static ssize_t wmi_read_powermode(int *powermode)
 static ssize_t wmi_write_powermode(u8 value)
 {
 	if (value != LEGION_WMI_POWERMODE_BALANCED &&
-    value != LEGION_WMI_POWERMODE_PERFORMANCE &&
-    value != LEGION_WMI_POWERMODE_LOW_POWER &&
-    value != LEGION_WMI_POWERMODE_CUSTOM &&
-    value != LEGION_WMI_POWERMODE_MAX_POWER) {
+		value != LEGION_WMI_POWERMODE_PERFORMANCE &&
+		value != LEGION_WMI_POWERMODE_LOW_POWER &&
+		value != LEGION_WMI_POWERMODE_CUSTOM &&
+		value != LEGION_WMI_POWERMODE_MAX_POWER) {
 		pr_info("Unexpected power mode value ignored: %d\n", value);
 		return -ENOMEM;
 	}
@@ -3995,6 +3994,7 @@ static int debugfs_fancurve_show(struct seq_file *s, void *unused)
 	seq_printf(s, "legion_laptop ec_readonly: %d\n", ec_readonly);
 
 	const char *acpi_path;
+
 	acpi_path = get_model_acpi_path(_model, ACPI_PATH_CFG);
 	err = eval_int(priv->adev, acpi_path, &cfg);
 	seq_printf(s, "ACPI CFG error: %d\n", err);
@@ -5165,13 +5165,11 @@ static int legion_platform_profile_probe(void *drvdata, unsigned long *choices)
 	set_bit(PLATFORM_PROFILE_LOW_POWER, choices);
 	set_bit(PLATFORM_PROFILE_BALANCED, choices);
 	set_bit(PLATFORM_PROFILE_PERFORMANCE, choices);
-	if (conf_has_custom_powermode && conf_access_method_powermode == ACCESS_METHOD_WMI) {
+	if (conf_has_custom_powermode && conf_access_method_powermode == ACCESS_METHOD_WMI)
 		set_bit(PLATFORM_PROFILE_CUSTOM, choices);
-	}
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 19, 0)
-	if (conf_has_extreme_powermode && conf_access_method_powermode == ACCESS_METHOD_WMI) {
+	if (conf_has_extreme_powermode && conf_access_method_powermode == ACCESS_METHOD_WMI)
 		set_bit(PLATFORM_PROFILE_MAX_POWER, choices);
-	}
 #endif
 	return 0;
 }
@@ -6072,8 +6070,8 @@ static int acpi_init(struct legion_private *priv, struct acpi_device *adev)
 	bool skip_acpi_sta_check;
 	struct device *dev = &priv->platform_device->dev;
 	const char *acpi_path;
-	acpi_path = get_model_acpi_path(_model, ACPI_PATH_WRITE_RAPIDCHARGE);
 
+	acpi_path = get_model_acpi_path(_model, ACPI_PATH_WRITE_RAPIDCHARGE);
 	priv->adev = adev;
 #if LINUX_VERSION_CODE <= KERNEL_VERSION(7, 0, 0)
 	if (!priv->adev) {
@@ -6081,7 +6079,7 @@ static int acpi_init(struct legion_private *priv, struct acpi_device *adev)
 		goto err_acpi_init;
 	}
 #else
-  dev_info(dev, "Ignoring ACPI handle\n");
+	dev_info(dev, "Ignoring ACPI handle\n");
 #endif
 	skip_acpi_sta_check = force || (!priv->conf->acpi_check_dev);
 	if (!skip_acpi_sta_check) {
@@ -6566,7 +6564,9 @@ static struct platform_driver legion_driver = {
 static int __init legion_init(void)
 {
 	int err;
-
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0)
+	static struct platform_device *legion_pdev;
+#endif
 	pr_info("Loading legion_laptop\n");
 	err = platform_driver_register(&legion_driver);
 	if (err) {
@@ -6574,8 +6574,7 @@ static int __init legion_init(void)
 		return err;
 	}
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0)
-	static struct platform_device *legion_pdev;
-  legion_pdev = platform_device_register_simple("legion", -1, NULL, 0);
+	legion_pdev = platform_device_register_simple("legion", -1, NULL, 0);
 	if (IS_ERR(legion_pdev)) {
 		pr_err("Failed to allocate virtual legion device\n");
 		platform_driver_unregister(&legion_driver);
@@ -6590,7 +6589,7 @@ module_init(legion_init);
 static void __exit legion_exit(void)
 {
 	platform_driver_unregister(&legion_driver);
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0 , 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0)
 	platform_device_unregister(_priv.platform_device);
 #endif
 	pr_info("legion_laptop exit\n");

--- a/kernel_module/legion-laptop.c
+++ b/kernel_module/legion-laptop.c
@@ -198,6 +198,32 @@ enum access_method {
 	ACCESS_METHOD_EC3 = 11, // loq
 };
 
+// acpi paths used by this driver
+enum acpi_paths_inventory_ids {
+	ACPI_PATH_STA = 0, // _STA
+	ACPI_PATH_CFG,     // _CFG
+	ACPI_PATH_READ_RAPIDCHARGE, // GBMD
+	ACPI_PATH_WRITE_RAPIDCHARGE,// SBMC
+	ACPI_PATH_READ_POWERMODE, // BTSM
+	ACPI_PATH_READ_FANSPEED1, // FANS
+	ACPI_PATH_READ_FANSPEED2, // FA2S
+	ACPI_PATH_READ_CPU_TEMP, // CPUT
+	ACPI_PATH_READ_GPU_TEMP, // GPUT
+	ACPI_PATH_MAX // not a PATH just the max nbr of this enum
+};
+
+static const char *default_acpi_paths[ACPI_PATH_MAX] = {
+	[ACPI_PATH_STA]="_STA",
+	[ACPI_PATH_CFG]="_CFG",
+	[ACPI_PATH_READ_RAPIDCHARGE]="VPC0.GBMD",
+	[ACPI_PATH_WRITE_RAPIDCHARGE]="VPC0.SBMC",
+	[ACPI_PATH_READ_POWERMODE]="VPC0.BTSM",
+	[ACPI_PATH_READ_FANSPEED1]="FANS",
+	[ACPI_PATH_READ_FANSPEED2]="FA2S",
+	[ACPI_PATH_READ_CPU_TEMP]="CPUT",
+	[ACPI_PATH_READ_GPU_TEMP]="GPUT",
+};
+
 struct model_config {
 	const struct ec_register_offsets *registers;
 	bool check_embedded_controller_id;
@@ -224,6 +250,7 @@ struct model_config {
 
 	phys_addr_t ramio_physical_start;
 	size_t ramio_size;
+	const char *acpi_paths[ACPI_PATH_MAX];
 };
 
 /* =================================== */
@@ -965,7 +992,11 @@ static const struct model_config model_lzcn = {
 	.access_method_fanfullspeed = ACCESS_METHOD_WMI3,
 	.acpi_check_dev = false,
 	.ramio_physical_start = 0xFE0B0400,
-	.ramio_size = 0x600
+	.ramio_size = 0x600,
+	.acpi_paths = {
+		[ACPI_PATH_STA] = "\\_SB.PC00.LPCB.EC0.VPC0._STA",
+		[ACPI_PATH_CFG] = "\\_SB.PC00.LPCB.EC0.VPC0._CFG"
+	}
 };
 
 // LOQ Model 2024
@@ -1429,13 +1460,38 @@ static const struct dmi_system_id optimistic_allowlist[] = {
 /* ================================= */
 /* ACPI and WMI access               */
 /* ================================= */
+//global, 
+//wanted to use _priv->conf but involves 
+//move all structs/defn from all the way down up
+static const struct model_config *_model;
+
+static const char *get_model_acpi_path(const struct model_config *model, enum acpi_paths_inventory_ids id)
+{
+    if (id < 0 || id >= ACPI_PATH_MAX)
+        return NULL;
+    if (model->acpi_paths[id] != NULL) {
+        return model->acpi_paths[id];
+    }
+    return default_acpi_paths[id];
+}
 
 // function from ideapad-laptop.c
-static int eval_int(acpi_handle handle, const char *name, unsigned long *res)
+static int eval_int(struct acpi_device *adev, const char *name, unsigned long *res)
 {
 	unsigned long long result;
 	acpi_status status;
-
+	acpi_handle handle;
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0)
+	status = acpi_get_handle(NULL, (char *) name, &handle);
+	if (ACPI_FAILURE(status)){
+		return -EIO;
+	}
+#else
+	if (!adev) {
+		return -ENODEV;
+	}
+	handle = adev->handle;
+#endif
 	status = acpi_evaluate_integer(handle, (char *)name, NULL, &result);
 	if (ACPI_FAILURE(status))
 		return -EIO;
@@ -1446,20 +1502,32 @@ static int eval_int(acpi_handle handle, const char *name, unsigned long *res)
 }
 
 // function from ideapad-laptop.c
-static int exec_simple_method(acpi_handle handle, const char *name,
+static int exec_simple_method(struct acpi_device *adev, const char *name,
 			      unsigned long arg)
 {
-	acpi_status status =
+	acpi_handle handle;
+	acpi_status status;
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0)
+	status = acpi_get_handle(NULL, (char *)name, &handle);
+	if (ACPI_FAILURE(status)){
+		return -EIO;
+	}
+#else
+	handle = adev->handle;
+#endif
+	status =
 		acpi_execute_simple_method(handle, (char *)name, arg);
 
 	return ACPI_FAILURE(status) ? -EIO : 0;
 }
 
 // function from ideapad-laptop.c
-static int exec_sbmc(acpi_handle handle, unsigned long arg)
+static int exec_sbmc(struct acpi_device *adev, unsigned long arg)
 {
 	// \_SB.PCI0.LPC0.EC0.VPC0.SBMC
-	return exec_simple_method(handle, "VPC0.SBMC", arg);
+	const char *acpi_path;
+	acpi_path = get_model_acpi_path(_model, ACPI_PATH_WRITE_RAPIDCHARGE);
+	return exec_simple_method(adev, acpi_path, arg);
 }
 
 //static int eval_qcho(acpi_handle handle, unsigned long *res)
@@ -1468,15 +1536,19 @@ static int exec_sbmc(acpi_handle handle, unsigned long arg)
 //	return eval_int(handle, "QCHO", res);
 //}
 
-static int eval_gbmd(acpi_handle handle, unsigned long *res)
+static int eval_gbmd(struct acpi_device *adev, unsigned long *res)
 {
-	return eval_int(handle, "VPC0.GBMD", res);
+	const char *acpi_path;
+	acpi_path = get_model_acpi_path(_model, ACPI_PATH_READ_RAPIDCHARGE);
+	return eval_int(adev, acpi_path, res);
 }
 
-static int eval_spmo(acpi_handle handle, unsigned long *res)
+static int eval_spmo(struct acpi_device *adev, unsigned long *res)
 {
 	// \_SB.PCI0.LPC0.EC0.QCHO
-	return eval_int(handle, "VPC0.BTSM", res);
+	const char *acpi_path;
+	acpi_path = get_model_acpi_path(_model, ACPI_PATH_READ_POWERMODE);
+	return eval_int(adev, acpi_path, res);
 }
 
 static int acpi_process_buffer_to_ints(const char *id_name, int id_nr,
@@ -2679,9 +2751,9 @@ static ssize_t ec_read_fanspeed(struct ecram *ecram,
 }
 
 // '\_SB.PCI0.LPC0.EC0.FANS
-#define ACPI_PATH_FAN_SPEED1 "FANS"
+// #define ACPI_PATH_FAN_SPEED1 "FANS"
 // '\_SB.PCI0.LPC0.EC0.FA2S
-#define ACPI_PATH_FAN_SPEED2 "FA2S"
+// #define ACPI_PATH_FAN_SPEED2 "FA2S"
 
 static ssize_t acpi_read_fanspeed(struct legion_private *priv, int fan_id,
 				  int *value)
@@ -2691,23 +2763,23 @@ static ssize_t acpi_read_fanspeed(struct legion_private *priv, int fan_id,
 	const char *acpi_path;
 
 	if (fan_id == 0) {
-		acpi_path = ACPI_PATH_FAN_SPEED1;
+		acpi_path = get_model_acpi_path(_model, ACPI_PATH_READ_FANSPEED1);
 	} else if (fan_id == 1) {
-		acpi_path = ACPI_PATH_FAN_SPEED2;
+		acpi_path = get_model_acpi_path(_model, ACPI_PATH_READ_FANSPEED2);
 	} else {
 		// TODO: use all correct error codes
 		return -EEXIST;
 	}
-	err = eval_int(priv->adev->handle, acpi_path, &acpi_value);
+	err = eval_int(priv->adev, acpi_path, &acpi_value);
 	if (!err)
 		*value = (int)acpi_value * 100;
 	return err;
 }
 
 // '\_SB.PCI0.LPC0.EC0.CPUT
-#define ACPI_PATH_CPU_TEMP "CPUT"
+// #define ACPI_PATH_CPU_TEMP "CPUT"
 // '\_SB.PCI0.LPC0.EC0.GPUT
-#define ACPI_PATH_GPU_TEMP "GPUT"
+// #define ACPI_PATH_GPU_TEMP "GPUT"
 
 static ssize_t acpi_read_temperature(struct legion_private *priv, int fan_id,
 				     int *value)
@@ -2717,14 +2789,14 @@ static ssize_t acpi_read_temperature(struct legion_private *priv, int fan_id,
 	const char *acpi_path;
 
 	if (fan_id == 0) {
-		acpi_path = ACPI_PATH_CPU_TEMP;
+		acpi_path = get_model_acpi_path(_model, ACPI_PATH_READ_CPU_TEMP);
 	} else if (fan_id == 1) {
-		acpi_path = ACPI_PATH_GPU_TEMP;
+		acpi_path = get_model_acpi_path(_model, ACPI_PATH_READ_GPU_TEMP);
 	} else {
 		// TODO: use all correct error codes
 		return -EEXIST;
 	}
-	err = eval_int(priv->adev->handle, acpi_path, &acpi_value);
+	err = eval_int(priv->adev, acpi_path, &acpi_value);
 	if (!err)
 		*value = (int)acpi_value;
 	return err;
@@ -3614,7 +3686,7 @@ static ssize_t acpi_read_powermode(struct legion_private *priv, int *powermode)
 
 	// spmo method not always available
 	// \_SB.PCI0.LPC0.EC0.SPMO
-	err = eval_spmo(priv->adev->handle, &acpi_powermode);
+	err = eval_spmo(priv->adev, &acpi_powermode);
 	*powermode = (int)acpi_powermode;
 	return err;
 }
@@ -3728,7 +3800,7 @@ static int acpi_read_rapidcharge(struct acpi_device *adev, bool *state)
 	 * return 0;
 	 */
 
-	err = eval_gbmd(adev->handle, &result);
+	err = eval_gbmd(adev, &result);
 	if (err)
 		return err;
 
@@ -3742,7 +3814,7 @@ static int acpi_write_rapidcharge(struct acpi_device *adev, bool state)
 	unsigned long fct_nr = state > 0 ? FCT_RAPID_CHARGE_ON :
 					   FCT_RAPID_CHARGE_OFF;
 
-	err = exec_sbmc(adev->handle, fct_nr);
+	err = exec_sbmc(adev, fct_nr);
 	pr_info("Set rapidcharge to %d by calling %lu: result: %d\n", state,
 		fct_nr, err);
 	return err;
@@ -3922,7 +3994,9 @@ static int debugfs_fancurve_show(struct seq_file *s, void *unused)
 	seq_printf(s, "legion_laptop features: %s\n", LEGIONFEATURES);
 	seq_printf(s, "legion_laptop ec_readonly: %d\n", ec_readonly);
 
-	err = eval_int(priv->adev->handle, "VPC0._CFG", &cfg);
+	const char *acpi_path;
+	acpi_path = get_model_acpi_path(_model, ACPI_PATH_CFG);
+	err = eval_int(priv->adev, acpi_path, &cfg);
 	seq_printf(s, "ACPI CFG error: %d\n", err);
 	seq_printf(s, "ACPI CFG: %lu\n", cfg);
 
@@ -5997,22 +6071,29 @@ static int acpi_init(struct legion_private *priv, struct acpi_device *adev)
 	unsigned long cfg;
 	bool skip_acpi_sta_check;
 	struct device *dev = &priv->platform_device->dev;
+	const char *acpi_path;
+	acpi_path = get_model_acpi_path(_model, ACPI_PATH_WRITE_RAPIDCHARGE);
 
 	priv->adev = adev;
+#if LINUX_VERSION_CODE <= KERNEL_VERSION(7, 0, 0)
 	if (!priv->adev) {
 		dev_info(dev, "Could not get ACPI handle\n");
 		goto err_acpi_init;
 	}
-
+#else
+  dev_info(dev, "Ignoring ACPI handle\n");
+#endif
 	skip_acpi_sta_check = force || (!priv->conf->acpi_check_dev);
 	if (!skip_acpi_sta_check) {
-		err = eval_int(priv->adev->handle, "_STA", &cfg);
+		acpi_path = get_model_acpi_path(_model, ACPI_PATH_STA);
+		err = eval_int(priv->adev, acpi_path, &cfg);
 		if (err) {
 			dev_info(dev, "Could not evaluate ACPI _STA\n");
 			goto err_acpi_init;
 		}
 
-		err = eval_int(priv->adev->handle, "VPC0._CFG", &cfg);
+		acpi_path = get_model_acpi_path(_model, ACPI_PATH_CFG);
+		err = eval_int(priv->adev, acpi_path, &cfg);
 		if (err) {
 			dev_info(dev, "Could not evaluate ACPI _CFG\n");
 			goto err_acpi_init;
@@ -6271,13 +6352,16 @@ static int legion_add(struct platform_device *pdev)
 		 dmi_sys->ident);
 
 	priv->conf = dmi_sys->driver_data;
-
+	_model = priv->conf;
+#if LINUX_VERSION_CODE < KERNEL_VERSION(7, 0, 0)
 	err = acpi_init(priv, ACPI_COMPANION(&pdev->dev));
 	if (err) {
 		dev_info(&pdev->dev, "Could not init ACPI access: %d\n", err);
 		goto err_acpi_init;
 	}
-
+#else
+	err = acpi_init(priv, NULL);
+#endif
 	// TODO: remove; only used for reverse engineering
 	pr_info("Creating RAM access to embedded controller\n");
 	err = ecram_memoryio_init(&priv->ec_memoryio,
@@ -6455,9 +6539,7 @@ static SIMPLE_DEV_PM_OPS(legion_pm, NULL, legion_pm_resume);
 // same as ideapad
 static const struct acpi_device_id legion_device_ids[] = {
 	// todo: change to "VPC2004", and also ACPI paths
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0)
-	    { "VPC2004", 0 },
-#else
+#if LINUX_VERSION_CODE < KERNEL_VERSION(7, 0, 0)
 	    { "PNP0C09", 0 },
 #endif
 	{ "", 0 },
@@ -6474,8 +6556,10 @@ static struct platform_driver legion_driver = {
 	.resume = legion_resume,
 	.driver = {
 		.name   = "legion",
+#if LINUX_VERSION_CODE < KERNEL_VERSION(7, 0, 0) //leave as virtual driver
 		.pm     = &legion_pm,
 		.acpi_match_table = ACPI_PTR(legion_device_ids),
+#endif
 	},
 };
 
@@ -6489,7 +6573,15 @@ static int __init legion_init(void)
 		pr_info("legion_laptop: platform_driver_register failed\n");
 		return err;
 	}
-
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0)
+	static struct platform_device *legion_pdev;
+  legion_pdev = platform_device_register_simple("legion", -1, NULL, 0);
+	if (IS_ERR(legion_pdev)) {
+		pr_err("Failed to allocate virtual legion device\n");
+		platform_driver_unregister(&legion_driver);
+		return PTR_ERR(legion_pdev);
+	}
+#endif
 	return 0;
 }
 
@@ -6498,6 +6590,9 @@ module_init(legion_init);
 static void __exit legion_exit(void)
 {
 	platform_driver_unregister(&legion_driver);
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0 , 0)
+	platform_device_unregister(_priv.platform_device);
+#endif
 	pr_info("legion_laptop exit\n");
 }
 

--- a/kernel_module/legion-laptop.c
+++ b/kernel_module/legion-laptop.c
@@ -5028,10 +5028,11 @@ static int legion_platform_profile_get(struct platform_profile_handler *pprof,
 	case LEGION_WMI_POWERMODE_CUSTOM:
 		*profile = PLATFORM_PROFILE_CUSTOM;
 		break;
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 19, 0)
 	case LEGION_WMI_POWERMODE_MAX_POWER:
 		*profile = PLATFORM_PROFILE_MAX_POWER;
 		break;
-
+#endif
 	default:
 		return -EINVAL;
 	}
@@ -5068,9 +5069,11 @@ static int legion_platform_profile_set(struct platform_profile_handler *pprof,
 	case PLATFORM_PROFILE_CUSTOM:
 		powermode = LEGION_WMI_POWERMODE_CUSTOM;
 		break;
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 19, 0)
 	case PLATFORM_PROFILE_MAX_POWER:
 		powermode = LEGION_WMI_POWERMODE_MAX_POWER;
 		break;
+#endif
 	default:
 		return -EOPNOTSUPP;
 	}
@@ -5091,10 +5094,11 @@ static int legion_platform_profile_probe(void *drvdata, unsigned long *choices)
 	if (conf_has_custom_powermode && conf_access_method_powermode == ACCESS_METHOD_WMI) {
 		set_bit(PLATFORM_PROFILE_CUSTOM, choices);
 	}
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 19, 0)
 	if (conf_has_extreme_powermode && conf_access_method_powermode == ACCESS_METHOD_WMI) {
 		set_bit(PLATFORM_PROFILE_MAX_POWER, choices);
 	}
-
+#endif
 	return 0;
 }
 

--- a/python/legion_linux/legion_linux/legion.py
+++ b/python/legion_linux/legion_linux/legion.py
@@ -19,11 +19,14 @@ from PIL import Image
 
 
 log = logging.getLogger(__name__)
-
+kernel_version = tuple(map(int,os.uname().release.split('-')[0].split('.')))
 
 DEFAULT_ENCODING = "utf8"
 DEFAULT_CONFIG_DIR = "/etc/legion_linux"
-LEGION_SYS_BASEPATH = '/sys/module/legion_laptop/drivers/platform:legion/VPC2004:00'
+if kernel_version >= (7, 0, 0):
+    LEGION_SYS_BASEPATH = '/sys/module/legion_laptop/drivers/platform:legion/VPC2004:00'
+else:
+    LEGION_SYS_BASEPATH = '/sys/module/legion_laptop/drivers/platform:legion/PNP0C09:00'
 IDEAPAD_SYS_BASEPATH = '/sys/bus/platform/drivers/ideapad_acpi/VPC2004:00'
 LBLDVC_FILE = "/sys/firmware/efi/efivars/LBLDVC-871455d1-5576-4fb8-9865-af0824463c9f"
 LBLDESP_FILE = "/sys/firmware/efi/efivars/LBLDESP-871455d0-5576-4fb8-9865-af0824463b9e"

--- a/python/legion_linux/legion_linux/legion.py
+++ b/python/legion_linux/legion_linux/legion.py
@@ -23,7 +23,7 @@ log = logging.getLogger(__name__)
 
 DEFAULT_ENCODING = "utf8"
 DEFAULT_CONFIG_DIR = "/etc/legion_linux"
-LEGION_SYS_BASEPATH = '/sys/module/legion_laptop/drivers/platform:legion/PNP0C09:00'
+LEGION_SYS_BASEPATH = '/sys/module/legion_laptop/drivers/platform:legion/VPC2004:00'
 IDEAPAD_SYS_BASEPATH = '/sys/bus/platform/drivers/ideapad_acpi/VPC2004:00'
 LBLDVC_FILE = "/sys/firmware/efi/efivars/LBLDVC-871455d1-5576-4fb8-9865-af0824463c9f"
 LBLDESP_FILE = "/sys/firmware/efi/efivars/LBLDESP-871455d0-5576-4fb8-9865-af0824463b9e"
@@ -501,14 +501,16 @@ class MaximumFanSpeedFeature(BoolFileFeature):
 
 class PlatformProfileFeature(FileFeature):
     def __init__(self):
-        super().__init__("/sys/firmware/acpi/platform_profile")
+        super().__init__(
+            LEGION_SYS_BASEPATH + "/platform-profile/platform-profile-[0-9]/profile")
         self.choices = StrFileFeature(
-            "/sys/firmware/acpi/platform_profile_choices")
+            LEGION_SYS_BASEPATH + "/platform-profile/platform-profile-[0-9]/choices")
         self.all_values = [
-            NamedValue("quiet", "Quiet Mode"),
+            NamedValue("low-power", "Low Power"),
             NamedValue("balanced", "Balanced Mode"),
             NamedValue("performance", "Performance Mode"),
-            NamedValue("balanced-performance", "Custom Mode")
+            NamedValue("custom", "Custom Mode"),
+            NamedValue("max-power", "Max Power")
         ]
 
     def get_values(self) -> List[NamedValue]:

--- a/python/legion_linux/legion_linux/legion.py
+++ b/python/legion_linux/legion_linux/legion.py
@@ -24,7 +24,7 @@ kernel_version = tuple(map(int,os.uname().release.split('-')[0].split('.')))
 DEFAULT_ENCODING = "utf8"
 DEFAULT_CONFIG_DIR = "/etc/legion_linux"
 if kernel_version >= (7, 0, 0):
-    LEGION_SYS_BASEPATH = '/sys/module/legion_laptop/drivers/platform:legion/VPC2004:00'
+    LEGION_SYS_BASEPATH = '/sys/module/legion_laptop/drivers/platform:legion/legion'
 else:
     LEGION_SYS_BASEPATH = '/sys/module/legion_laptop/drivers/platform:legion/PNP0C09:00'
 IDEAPAD_SYS_BASEPATH = '/sys/bus/platform/drivers/ideapad_acpi/VPC2004:00'


### PR DESCRIPTION
- Adds powermode Extreme, WMI value 0xE0, EC Value 0x07, exposes it in platform profile.
- Adds flag to model config for handling of extreme powermode.
- Change old powermodes to its equivalence in lenovo-wmi-gamezone (legion.c / legion.py).

```
  lenovo-wmi-gamezone     legion-laptop
  -------------------     -------------
  low-power               quiet
  balanced                balanced
  performance             performance
  custom                  balanced-performance
  max-power               extreme (new)
```
- Change ACPI device id from PNP0C09 to VPC2004, kernel driver in 7.0 acpi-ec binds PNP0C09 and blocks it.
- Change path to look for platform profiles in client legion.py, the old `/sys/firmware/acpi/platform_profile` doesnt accept custom powermode for some reason see `linux/drivers/acpi/platform_profile.c:422`.

Issue related #422 