### PR TITLE
Fix kernel NULL pointer dereference when enable_platformprofile is false

### DIFF
--- a/kernel_module/legion-laptop.c
+++ b/kernel_module/legion-laptop.c
@@ -4971,8 +4971,10 @@ static void legion_platform_profile_notify(struct device *dev)
 static void legion_platform_profile_notify(void)
 #endif
 {
-	if (!enable_platformprofile)
+	if (!enable_platformprofile) {
 		pr_info("Skipping platform_profile_notify because enable_platformprofile is false\n");
+		return;
+	}
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 14, 0)
 	platform_profile_notify(dev);


### PR DESCRIPTION
When driver is loaded with `option enable_platformprofile=0` and user changes power profile / Fn+Q, function `legion_platform_profile_notify` generates a kernel BUG error.

Happens with acpi_device_ids PNP0C09 or VC2004, tested on Kernel LTS 6.18 and 7.0.x.

```
kernel: BUG: kernel NULL pointer dereference, address: 0000000000000030
kernel: #PF: supervisor read access in kernel mode
kernel: #PF: error_code(0x0000) - not-present page
```