### PR TITLE
feat: add Legion R9000P 2023 support, fix temperature offsets, unify power limit access, and introduce advanced power features

### DIFF
--- a/kernel_module/legion-laptop.c
+++ b/kernel_module/legion-laptop.c
@@ -422,7 +422,10 @@ static const struct model_config model_v0 = {
 	.access_method_fanfullspeed = ACCESS_METHOD_WMI,
 	.acpi_check_dev = true,
 	.ramio_physical_start = 0xFE00D400,
-	.ramio_size = 0x600
+	.ramio_size = 0x600,
+	.access_method_cpu_powerlimit = ACCESS_METHOD_WMI,
+	.access_method_gpu_powerlimit = ACCESS_METHOD_WMI,
+	.access_method_gpu_oc = ACCESS_METHOD_WMI,
 };
 
 static const struct model_config model_j2cn = {
@@ -441,7 +444,10 @@ static const struct model_config model_j2cn = {
 	.access_method_fanfullspeed = ACCESS_METHOD_WMI,
 	.acpi_check_dev = true,
 	.ramio_physical_start = 0xFE00D400,
-	.ramio_size = 0x600
+	.ramio_size = 0x600,
+	.access_method_cpu_powerlimit = ACCESS_METHOD_WMI,
+	.access_method_gpu_powerlimit = ACCESS_METHOD_WMI,
+	.access_method_gpu_oc = ACCESS_METHOD_WMI,
 };
 
 static const struct model_config model_9vcn = {
@@ -460,7 +466,10 @@ static const struct model_config model_9vcn = {
 	.access_method_fanfullspeed = ACCESS_METHOD_WMI,
 	.acpi_check_dev = false,
 	.ramio_physical_start = 0xFE00D400,
-	.ramio_size = 0x600
+	.ramio_size = 0x600,
+	.access_method_cpu_powerlimit = ACCESS_METHOD_WMI,
+	.access_method_gpu_powerlimit = ACCESS_METHOD_WMI,
+	.access_method_gpu_oc = ACCESS_METHOD_WMI,
 };
 
 static const struct model_config model_v2022 = {
@@ -479,7 +488,10 @@ static const struct model_config model_v2022 = {
 	.access_method_fanfullspeed = ACCESS_METHOD_WMI,
 	.acpi_check_dev = true,
 	.ramio_physical_start = 0xFE00D400,
-	.ramio_size = 0x600
+	.ramio_size = 0x600,
+	.access_method_cpu_powerlimit = ACCESS_METHOD_WMI,
+	.access_method_gpu_powerlimit = ACCESS_METHOD_WMI,
+	.access_method_gpu_oc = ACCESS_METHOD_WMI,
 };
 
 static const struct model_config model_4gcn = {
@@ -498,7 +510,10 @@ static const struct model_config model_4gcn = {
 	.access_method_fanfullspeed = ACCESS_METHOD_WMI,
 	.acpi_check_dev = true,
 	.ramio_physical_start = 0xFE00D400,
-	.ramio_size = 0x600
+	.ramio_size = 0x600,
+	.access_method_cpu_powerlimit = ACCESS_METHOD_WMI,
+	.access_method_gpu_powerlimit = ACCESS_METHOD_WMI,
+	.access_method_gpu_oc = ACCESS_METHOD_WMI,
 };
 
 static const struct model_config model_bvcn = {
@@ -517,7 +532,10 @@ static const struct model_config model_bvcn = {
 	.access_method_fanfullspeed = ACCESS_METHOD_WMI,
 	.acpi_check_dev = false,
 	.ramio_physical_start = 0xFC7E0800,
-	.ramio_size = 0x600
+	.ramio_size = 0x600,
+	.access_method_cpu_powerlimit = ACCESS_METHOD_WMI,
+	.access_method_gpu_powerlimit = ACCESS_METHOD_WMI,
+	.access_method_gpu_oc = ACCESS_METHOD_WMI,
 };
 
 static const struct model_config model_bhcn = {
@@ -536,7 +554,10 @@ static const struct model_config model_bhcn = {
 	.access_method_fanfullspeed = ACCESS_METHOD_WMI,
 	.acpi_check_dev = true,
 	.ramio_physical_start = 0xFF00D400,
-	.ramio_size = 0x600
+	.ramio_size = 0x600,
+	.access_method_cpu_powerlimit = ACCESS_METHOD_WMI,
+	.access_method_gpu_powerlimit = ACCESS_METHOD_WMI,
+	.access_method_gpu_oc = ACCESS_METHOD_WMI,
 };
 
 static const struct model_config model_kwcn = {
@@ -555,7 +576,10 @@ static const struct model_config model_kwcn = {
 	.access_method_fanfullspeed = ACCESS_METHOD_WMI,
 	.acpi_check_dev = true,
 	.ramio_physical_start = 0xFE0B0400,
-	.ramio_size = 0x600
+	.ramio_size = 0x600,
+	.access_method_cpu_powerlimit = ACCESS_METHOD_WMI,
+	.access_method_gpu_powerlimit = ACCESS_METHOD_WMI,
+	.access_method_gpu_oc = ACCESS_METHOD_WMI,
 };
 
 static const struct model_config model_g8cn = {
@@ -574,7 +598,10 @@ static const struct model_config model_g8cn = {
 	.access_method_fanfullspeed = ACCESS_METHOD_WMI,
 	.acpi_check_dev = true,
 	.ramio_physical_start = 0xFE0B0400,
-	.ramio_size = 0x600
+	.ramio_size = 0x600,
+	.access_method_cpu_powerlimit = ACCESS_METHOD_WMI,
+	.access_method_gpu_powerlimit = ACCESS_METHOD_WMI,
+	.access_method_gpu_oc = ACCESS_METHOD_WMI,
 };
 
 static const struct model_config model_m0cn = {
@@ -593,7 +620,10 @@ static const struct model_config model_m0cn = {
 	.access_method_fanfullspeed = ACCESS_METHOD_WMI,
 	.acpi_check_dev = false,
 	.ramio_physical_start = 0xFE0B0400,
-	.ramio_size = 0x600
+	.ramio_size = 0x600,
+	.access_method_cpu_powerlimit = ACCESS_METHOD_WMI,
+	.access_method_gpu_powerlimit = ACCESS_METHOD_WMI,
+	.access_method_gpu_oc = ACCESS_METHOD_WMI,
 };
 
 static const struct model_config model_m1cn = {
@@ -612,7 +642,10 @@ static const struct model_config model_m1cn = {
 	.access_method_fanfullspeed = ACCESS_METHOD_WMI,
 	.acpi_check_dev = false,
 	.ramio_physical_start = 0xFE0B0400,
-	.ramio_size = 0x600
+	.ramio_size = 0x600,
+	.access_method_cpu_powerlimit = ACCESS_METHOD_WMI,
+	.access_method_gpu_powerlimit = ACCESS_METHOD_WMI,
+	.access_method_gpu_oc = ACCESS_METHOD_WMI,
 };
 
 static const struct model_config model_m2cn = {
@@ -631,7 +664,10 @@ static const struct model_config model_m2cn = {
 	.access_method_fanfullspeed = ACCESS_METHOD_WMI,
 	.acpi_check_dev = false,
 	.ramio_physical_start = 0xFE0B0400,
-	.ramio_size = 0x600
+	.ramio_size = 0x600,
+	.access_method_cpu_powerlimit = ACCESS_METHOD_WMI,
+	.access_method_gpu_powerlimit = ACCESS_METHOD_WMI,
+	.access_method_gpu_oc = ACCESS_METHOD_WMI,
 };
 
 static const struct model_config model_m6cn = {
@@ -650,7 +686,10 @@ static const struct model_config model_m6cn = {
 	.access_method_fanfullspeed = ACCESS_METHOD_WMI,
 	.acpi_check_dev = false,
 	.ramio_physical_start = 0xFE0B0400,
-	.ramio_size = 0x600
+	.ramio_size = 0x600,
+	.access_method_cpu_powerlimit = ACCESS_METHOD_WMI,
+	.access_method_gpu_powerlimit = ACCESS_METHOD_WMI,
+	.access_method_gpu_oc = ACCESS_METHOD_WMI,
 };
 
 static const struct model_config model_k1cn = {
@@ -669,7 +708,10 @@ static const struct model_config model_k1cn = {
 	.access_method_fanfullspeed = ACCESS_METHOD_WMI,
 	.acpi_check_dev = true,
 	.ramio_physical_start = 0xFE0B0400,
-	.ramio_size = 0x600
+	.ramio_size = 0x600,
+	.access_method_cpu_powerlimit = ACCESS_METHOD_WMI,
+	.access_method_gpu_powerlimit = ACCESS_METHOD_WMI,
+	.access_method_gpu_oc = ACCESS_METHOD_WMI,
 };
 
 static const struct model_config model_nscn = {
@@ -692,7 +734,10 @@ static const struct model_config model_nscn = {
 	.access_method_fanfullspeed = ACCESS_METHOD_WMI,
 	.acpi_check_dev = false,
 	.ramio_physical_start = 0xFE0B0400,
-	.ramio_size = 0x600
+	.ramio_size = 0x600,
+	.access_method_cpu_powerlimit = ACCESS_METHOD_WMI,
+	.access_method_gpu_powerlimit = ACCESS_METHOD_WMI,
+	.access_method_gpu_oc = ACCESS_METHOD_WMI,
 };
 
 static const struct model_config model_lpcn = {
@@ -758,7 +803,10 @@ static const struct model_config model_kfcn = {
 	.access_method_fanfullspeed = ACCESS_METHOD_WMI,
 	.acpi_check_dev = true,
 	.ramio_physical_start = 0xFE00D400,
-	.ramio_size = 0x600
+	.ramio_size = 0x600,
+	.access_method_cpu_powerlimit = ACCESS_METHOD_WMI,
+	.access_method_gpu_powerlimit = ACCESS_METHOD_WMI,
+	.access_method_gpu_oc = ACCESS_METHOD_WMI,
 };
 
 static const struct model_config model_hacn = {
@@ -777,7 +825,10 @@ static const struct model_config model_hacn = {
 	.access_method_fanfullspeed = ACCESS_METHOD_WMI,
 	.acpi_check_dev = true,
 	.ramio_physical_start = 0xFE00D400,
-	.ramio_size = 0x600
+	.ramio_size = 0x600,
+	.access_method_cpu_powerlimit = ACCESS_METHOD_WMI,
+	.access_method_gpu_powerlimit = ACCESS_METHOD_WMI,
+	.access_method_gpu_oc = ACCESS_METHOD_WMI,
 };
 
 static const struct model_config model_k9cn = {
@@ -796,7 +847,10 @@ static const struct model_config model_k9cn = {
 	.access_method_fanfullspeed = ACCESS_METHOD_WMI,
 	.acpi_check_dev = true,
 	.ramio_physical_start = 0xFE00D400,
-	.ramio_size = 0x600
+	.ramio_size = 0x600,
+	.access_method_cpu_powerlimit = ACCESS_METHOD_WMI,
+	.access_method_gpu_powerlimit = ACCESS_METHOD_WMI,
+	.access_method_gpu_oc = ACCESS_METHOD_WMI,
 };
 
 static const struct model_config model_eucn = {
@@ -815,7 +869,10 @@ static const struct model_config model_eucn = {
 	.access_method_fanfullspeed = ACCESS_METHOD_WMI,
 	.acpi_check_dev = true,
 	.ramio_physical_start = 0xFE00D400,
-	.ramio_size = 0x600
+	.ramio_size = 0x600,
+	.access_method_cpu_powerlimit = ACCESS_METHOD_WMI,
+	.access_method_gpu_powerlimit = ACCESS_METHOD_WMI,
+	.access_method_gpu_oc = ACCESS_METHOD_WMI,
 };
 
 static const struct model_config model_fccn = {
@@ -834,7 +891,10 @@ static const struct model_config model_fccn = {
 	.access_method_fanfullspeed = ACCESS_METHOD_WMI,
 	.acpi_check_dev = true,
 	.ramio_physical_start = 0xFE00D400,
-	.ramio_size = 0x600
+	.ramio_size = 0x600,
+	.access_method_cpu_powerlimit = ACCESS_METHOD_WMI,
+	.access_method_gpu_powerlimit = ACCESS_METHOD_WMI,
+	.access_method_gpu_oc = ACCESS_METHOD_WMI,
 };
 
 static const struct model_config model_h3cn = {
@@ -858,7 +918,10 @@ static const struct model_config model_h3cn = {
 	.access_method_fanfullspeed = ACCESS_METHOD_WMI,
 	.acpi_check_dev = false,
 	.ramio_physical_start = 0xFE0B0800,
-	.ramio_size = 0x600
+	.ramio_size = 0x600,
+	.access_method_cpu_powerlimit = ACCESS_METHOD_WMI,
+	.access_method_gpu_powerlimit = ACCESS_METHOD_WMI,
+	.access_method_gpu_oc = ACCESS_METHOD_WMI,
 };
 
 static const struct model_config model_e9cn = {
@@ -882,7 +945,10 @@ static const struct model_config model_e9cn = {
 	.access_method_fanfullspeed = ACCESS_METHOD_WMI,
 	.acpi_check_dev = false,
 	.ramio_physical_start = 0xFC7E0800,
-	.ramio_size = 0x600
+	.ramio_size = 0x600,
+	.access_method_cpu_powerlimit = ACCESS_METHOD_WMI,
+	.access_method_gpu_powerlimit = ACCESS_METHOD_WMI,
+	.access_method_gpu_oc = ACCESS_METHOD_WMI,
 };
 
 static const struct model_config model_8jcn = {
@@ -901,7 +967,10 @@ static const struct model_config model_8jcn = {
 	.access_method_fanfullspeed = ACCESS_METHOD_WMI,
 	.acpi_check_dev = false,
 	.ramio_physical_start = 0xFE00D400,
-	.ramio_size = 0x600
+	.ramio_size = 0x600,
+	.access_method_cpu_powerlimit = ACCESS_METHOD_WMI,
+	.access_method_gpu_powerlimit = ACCESS_METHOD_WMI,
+	.access_method_gpu_oc = ACCESS_METHOD_WMI,
 };
 
 static const struct model_config model_jncn = {
@@ -920,7 +989,10 @@ static const struct model_config model_jncn = {
 	.access_method_fanfullspeed = ACCESS_METHOD_WMI,
 	.acpi_check_dev = false,
 	.ramio_physical_start = 0xFC7E0800,
-	.ramio_size = 0x600
+	.ramio_size = 0x600,
+	.access_method_cpu_powerlimit = ACCESS_METHOD_WMI,
+	.access_method_gpu_powerlimit = ACCESS_METHOD_WMI,
+	.access_method_gpu_oc = ACCESS_METHOD_WMI,
 };
 
 // Yoga Model!
@@ -940,7 +1012,10 @@ static const struct model_config model_j1cn = {
 	.access_method_fanfullspeed = ACCESS_METHOD_WMI,
 	.acpi_check_dev = true,
 	.ramio_physical_start = 0xFE0B0400,
-	.ramio_size = 0x600
+	.ramio_size = 0x600,
+	.access_method_cpu_powerlimit = ACCESS_METHOD_WMI,
+	.access_method_gpu_powerlimit = ACCESS_METHOD_WMI,
+	.access_method_gpu_oc = ACCESS_METHOD_WMI,
 };
 
 // Yoga Model!
@@ -960,7 +1035,10 @@ static const struct model_config model_dmcn = {
 	.access_method_fanfullspeed = ACCESS_METHOD_WMI,
 	.acpi_check_dev = true,
 	.ramio_physical_start = 0xFE700D00,
-	.ramio_size = 0x600
+	.ramio_size = 0x600,
+	.access_method_cpu_powerlimit = ACCESS_METHOD_WMI,
+	.access_method_gpu_powerlimit = ACCESS_METHOD_WMI,
+	.access_method_gpu_oc = ACCESS_METHOD_WMI,
 };
 
 // Yoga Model!
@@ -980,7 +1058,10 @@ static const struct model_config model_khcn = {
 	.access_method_fanfullspeed = ACCESS_METHOD_WMI,
 	.acpi_check_dev = false,
 	.ramio_physical_start = 0xFE0B0400,
-	.ramio_size = 0x600
+	.ramio_size = 0x600,
+	.access_method_cpu_powerlimit = ACCESS_METHOD_WMI,
+	.access_method_gpu_powerlimit = ACCESS_METHOD_WMI,
+	.access_method_gpu_oc = ACCESS_METHOD_WMI,
 };
 
 // LOQ Model
@@ -1000,7 +1081,10 @@ static const struct model_config model_lzcn = {
 	.access_method_fanfullspeed = ACCESS_METHOD_WMI3,
 	.acpi_check_dev = false,
 	.ramio_physical_start = 0xFE0B0400,
-	.ramio_size = 0x600
+	.ramio_size = 0x600,
+	.access_method_cpu_powerlimit = ACCESS_METHOD_WMI,
+	.access_method_gpu_powerlimit = ACCESS_METHOD_WMI,
+	.access_method_gpu_oc = ACCESS_METHOD_WMI,
 };
 
 // LOQ Model 2024
@@ -1020,7 +1104,10 @@ static const struct model_config model_necn = {
 	.access_method_fanfullspeed = ACCESS_METHOD_WMI3,
 	.acpi_check_dev = false,
 	.ramio_physical_start = 0xFE0B0400,
-	.ramio_size = 0x600
+	.ramio_size = 0x600,
+	.access_method_cpu_powerlimit = ACCESS_METHOD_WMI,
+	.access_method_gpu_powerlimit = ACCESS_METHOD_WMI,
+	.access_method_gpu_oc = ACCESS_METHOD_WMI,
 };
 
 // LOQ 15AHP9
@@ -1040,7 +1127,10 @@ static const struct model_config model_nzcn = {
 	.access_method_fanfullspeed = ACCESS_METHOD_WMI3,
 	.acpi_check_dev = false,
 	.ramio_physical_start = 0xFE0B0400,
-	.ramio_size = 0x600
+	.ramio_size = 0x600,
+	.access_method_cpu_powerlimit = ACCESS_METHOD_WMI,
+	.access_method_gpu_powerlimit = ACCESS_METHOD_WMI,
+	.access_method_gpu_oc = ACCESS_METHOD_WMI,
 };
 
 // Legion Slim 5 16AHP9 (2024) - Model 83DH
@@ -1060,7 +1150,10 @@ static const struct model_config model_nrcn = {
 	.access_method_fanfullspeed = ACCESS_METHOD_WMI,
 	.acpi_check_dev = false,
 	.ramio_physical_start = 0xFE0B0400,
-	.ramio_size = 0x600
+	.ramio_size = 0x600,
+	.access_method_cpu_powerlimit = ACCESS_METHOD_WMI,
+	.access_method_gpu_powerlimit = ACCESS_METHOD_WMI,
+	.access_method_gpu_oc = ACCESS_METHOD_WMI,
 };
 
 
@@ -4528,7 +4621,6 @@ static ssize_t cpu_shortterm_powerlimit_show(struct device *dev,
 			dev, buf, OtherMethodFeature_CPU_SHORT_TERM_POWER_LIMIT,
 			1);
 	case ACCESS_METHOD_WMI:
-	case ACCESS_METHOD_NO_ACCESS:
 	default:
 		return show_simple_wmi_attribute_from_buffer(
 			dev, attr, buf, WMI_GUID_LENOVO_CPU_METHOD, 0,
@@ -4548,7 +4640,6 @@ static ssize_t cpu_shortterm_powerlimit_store(struct device *dev,
 			dev, buf, count,
 			OtherMethodFeature_CPU_SHORT_TERM_POWER_LIMIT, 1);
 	case ACCESS_METHOD_WMI:
-	case ACCESS_METHOD_NO_ACCESS:
 	default:
 		return store_simple_wmi_attribute(
 			dev, attr, buf, count, WMI_GUID_LENOVO_CPU_METHOD, 0,
@@ -4570,7 +4661,6 @@ static ssize_t cpu_longterm_powerlimit_show(struct device *dev,
 			dev, buf, OtherMethodFeature_CPU_LONG_TERM_POWER_LIMIT,
 			1);
 	case ACCESS_METHOD_WMI:
-	case ACCESS_METHOD_NO_ACCESS:
 	default:
 		return show_simple_wmi_attribute_from_buffer(
 			dev, attr, buf, WMI_GUID_LENOVO_CPU_METHOD, 0,
@@ -4590,7 +4680,6 @@ static ssize_t cpu_longterm_powerlimit_store(struct device *dev,
 			dev, buf, count,
 			OtherMethodFeature_CPU_LONG_TERM_POWER_LIMIT, 1);
 	case ACCESS_METHOD_WMI:
-	case ACCESS_METHOD_NO_ACCESS:
 	default:
 		return store_simple_wmi_attribute(
 			dev, attr, buf, count, WMI_GUID_LENOVO_CPU_METHOD, 0,
@@ -4622,7 +4711,6 @@ static ssize_t cpu_peak_powerlimit_show(struct device *dev,
 		return show_wmi_other_feature_attribute(
 			dev, buf, OtherMethodFeature_CPU_PEAK_POWER_LIMIT, 1);
 	case ACCESS_METHOD_WMI:
-	case ACCESS_METHOD_NO_ACCESS:
 	default:
 		return show_simple_wmi_attribute(dev, attr, buf,
 						 WMI_GUID_LENOVO_GPU_METHOD, 0,
@@ -4643,7 +4731,6 @@ static ssize_t cpu_peak_powerlimit_store(struct device *dev,
 			dev, buf, count, OtherMethodFeature_CPU_PEAK_POWER_LIMIT,
 			1);
 	case ACCESS_METHOD_WMI:
-	case ACCESS_METHOD_NO_ACCESS:
 	default:
 		return store_simple_wmi_attribute(dev, attr, buf, count,
 						  WMI_GUID_LENOVO_GPU_METHOD, 0,
@@ -4664,7 +4751,6 @@ static ssize_t cpu_apu_sppt_powerlimit_show(struct device *dev,
 	case ACCESS_METHOD_WMI3:
 		return -EOPNOTSUPP;
 	case ACCESS_METHOD_WMI:
-	case ACCESS_METHOD_NO_ACCESS:
 	default:
 		return show_simple_wmi_attribute(
 			dev, attr, buf, WMI_GUID_LENOVO_GPU_METHOD, 0,
@@ -4682,7 +4768,6 @@ static ssize_t cpu_apu_sppt_powerlimit_store(struct device *dev,
 	case ACCESS_METHOD_WMI3:
 		return -EOPNOTSUPP;
 	case ACCESS_METHOD_WMI:
-	case ACCESS_METHOD_NO_ACCESS:
 	default:
 		return store_simple_wmi_attribute(
 			dev, attr, buf, count, WMI_GUID_LENOVO_GPU_METHOD, 0,
@@ -4704,7 +4789,6 @@ static ssize_t cpu_cross_loading_powerlimit_show(struct device *dev,
 			dev, buf, OtherMethodFeature_CPU_CROSS_LOAD_POWER_LIMIT,
 			1);
 	case ACCESS_METHOD_WMI:
-	case ACCESS_METHOD_NO_ACCESS:
 	default:
 		return show_simple_wmi_attribute(
 			dev, attr, buf, WMI_GUID_LENOVO_GPU_METHOD, 0,
@@ -4724,7 +4808,6 @@ static ssize_t cpu_cross_loading_powerlimit_store(struct device *dev,
 			dev, buf, count,
 			OtherMethodFeature_CPU_CROSS_LOAD_POWER_LIMIT, 1);
 	case ACCESS_METHOD_WMI:
-	case ACCESS_METHOD_NO_ACCESS:
 	default:
 		return store_simple_wmi_attribute(
 			dev, attr, buf, count, WMI_GUID_LENOVO_GPU_METHOD, 0,
@@ -4745,7 +4828,6 @@ static ssize_t gpu_oc_show(struct device *dev, struct device_attribute *attr,
 			dev, attr, buf, LEGION_WMI_GAMEZONE_GUID, 0,
 			WMI_METHOD_ID_GET_GPU_OC_STATUS_WMAA, false, 1);
 	case ACCESS_METHOD_WMI:
-	case ACCESS_METHOD_NO_ACCESS:
 	default:
 		return show_simple_wmi_attribute(dev, attr, buf,
 						 WMI_GUID_LENOVO_GPU_METHOD, 0,
@@ -4765,7 +4847,6 @@ static ssize_t gpu_oc_store(struct device *dev, struct device_attribute *attr,
 			dev, attr, buf, count, LEGION_WMI_GAMEZONE_GUID, 0,
 			WMI_METHOD_ID_SET_GPU_OC_STATUS_WMAA, false, 1);
 	case ACCESS_METHOD_WMI:
-	case ACCESS_METHOD_NO_ACCESS:
 	default:
 		return store_simple_wmi_attribute(dev, attr, buf, count,
 						  WMI_GUID_LENOVO_GPU_METHOD, 0,
@@ -4787,7 +4868,6 @@ static ssize_t gpu_ppab_powerlimit_show(struct device *dev,
 		return show_wmi_other_feature_attribute(
 			dev, buf, OtherMethodFeature_GPU_POWER_BOOST, 1);
 	case ACCESS_METHOD_WMI:
-	case ACCESS_METHOD_NO_ACCESS:
 	default:
 		return show_simple_wmi_attribute_from_buffer(
 			dev, attr, buf, WMI_GUID_LENOVO_GPU_METHOD, 0,
@@ -4806,7 +4886,6 @@ static ssize_t gpu_ppab_powerlimit_store(struct device *dev,
 		return store_wmi_other_feature_attribute(
 			dev, buf, count, OtherMethodFeature_GPU_POWER_BOOST, 1);
 	case ACCESS_METHOD_WMI:
-	case ACCESS_METHOD_NO_ACCESS:
 	default:
 		return store_simple_wmi_attribute(dev, attr, buf, count,
 						  WMI_GUID_LENOVO_GPU_METHOD, 0,
@@ -4829,7 +4908,6 @@ static ssize_t gpu_ctgp_powerlimit_show(struct device *dev,
 							OtherMethodFeature_GPU_cTGP,
 							1);
 	case ACCESS_METHOD_WMI:
-	case ACCESS_METHOD_NO_ACCESS:
 	default:
 		return show_simple_wmi_attribute_from_buffer(
 			dev, attr, buf, WMI_GUID_LENOVO_GPU_METHOD, 0,
@@ -4848,7 +4926,6 @@ static ssize_t gpu_ctgp_powerlimit_store(struct device *dev,
 		return store_wmi_other_feature_attribute(
 			dev, buf, count, OtherMethodFeature_GPU_cTGP, 1);
 	case ACCESS_METHOD_WMI:
-	case ACCESS_METHOD_NO_ACCESS:
 	default:
 		return store_simple_wmi_attribute(dev, attr, buf, count,
 						  WMI_GUID_LENOVO_GPU_METHOD, 0,
@@ -4869,7 +4946,6 @@ static ssize_t gpu_ctgp2_powerlimit_show(struct device *dev,
 	case ACCESS_METHOD_WMI3:
 		return -EOPNOTSUPP;
 	case ACCESS_METHOD_WMI:
-	case ACCESS_METHOD_NO_ACCESS:
 	default:
 		return show_simple_wmi_attribute_from_buffer(
 			dev, attr, buf, WMI_GUID_LENOVO_GPU_METHOD, 0,
@@ -4901,7 +4977,6 @@ static ssize_t gpu_temperature_limit_show(struct device *dev,
 		return show_wmi_other_feature_attribute(
 			dev, buf, OtherMethodFeature_GPU_TEMPERATURE_LIMIT, 1);
 	case ACCESS_METHOD_WMI:
-	case ACCESS_METHOD_NO_ACCESS:
 	default:
 		return show_simple_wmi_attribute(
 			dev, attr, buf, WMI_GUID_LENOVO_GPU_METHOD, 0,
@@ -4921,7 +4996,6 @@ static ssize_t gpu_temperature_limit_store(struct device *dev,
 			dev, buf, count, OtherMethodFeature_GPU_TEMPERATURE_LIMIT,
 			1);
 	case ACCESS_METHOD_WMI:
-	case ACCESS_METHOD_NO_ACCESS:
 	default:
 		return store_simple_wmi_attribute(
 			dev, attr, buf, count, WMI_GUID_LENOVO_GPU_METHOD, 0,

--- a/kernel_module/legion-laptop.c
+++ b/kernel_module/legion-laptop.c
@@ -6675,7 +6675,7 @@ static int legion_add(struct platform_device *pdev)
 	})) {
 		priv->conf = &model_lpcn62ww;
 		dev_info(&pdev->dev,
-			 "Using LPCN62WW machine-specific config for WMB5/WMAA OC/powerlimit controls\n");
+			 "Using LPCN62WW machine-specific config for WMI3/WMAA OC/powerlimit controls\n");
 	}
 
 	err = acpi_init(priv, ACPI_COMPANION(&pdev->dev));

--- a/kernel_module/legion-laptop.c
+++ b/kernel_module/legion-laptop.c
@@ -223,6 +223,15 @@ struct model_config {
 
 	phys_addr_t ramio_physical_start;
 	size_t ramio_size;
+
+	// Access method for CPU power limits (short/long/peak/cross-load)
+	enum access_method access_method_cpu_powerlimit;
+	// Access method for GPU power limits (PPAB/cTGP/temperature limit)
+	enum access_method access_method_gpu_powerlimit;
+	// Access method for GPU overclock status
+	enum access_method access_method_gpu_oc;
+	// Whether advanced LPCN62WW-only power features are present
+	bool has_advanced_power_features;
 };
 
 /* =================================== */
@@ -702,7 +711,35 @@ static const struct model_config model_lpcn = {
 	.access_method_fanfullspeed = ACCESS_METHOD_WMI,
 	.acpi_check_dev = true,
 	.ramio_physical_start = 0xFE0B0400,
-	.ramio_size = 0x600
+	.ramio_size = 0x600,
+	.access_method_cpu_powerlimit = ACCESS_METHOD_WMI,
+	.access_method_gpu_powerlimit = ACCESS_METHOD_WMI,
+	.access_method_gpu_oc = ACCESS_METHOD_WMI,
+};
+
+// LPCN62WW on product 82WM (Legion R9000P 2023):
+// Uses OtherMethodFeature (WMI3) for power limits and WMAA (WMI2 via Gamezone) for GPU OC
+static const struct model_config model_lpcn62ww = {
+	.registers = &ec_register_offsets_v0,
+	.check_embedded_controller_id = true,
+	.embedded_controller_id = 0x5507,
+	.memoryio_physical_ec_start = 0xC400,
+	.memoryio_size = 0x300,
+	.has_minifancurve = false,
+	.has_custom_powermode = true,
+	.access_method_powermode = ACCESS_METHOD_WMI,
+	.access_method_keyboard = ACCESS_METHOD_WMI,
+	.access_method_fanspeed = ACCESS_METHOD_WMI3,
+	.access_method_temperature = ACCESS_METHOD_WMI3,
+	.access_method_fancurve = ACCESS_METHOD_WMI3,
+	.access_method_fanfullspeed = ACCESS_METHOD_WMI,
+	.acpi_check_dev = false,
+	.ramio_physical_start = 0xFE0B0400,
+	.ramio_size = 0x600,
+	.access_method_cpu_powerlimit = ACCESS_METHOD_WMI3,
+	.access_method_gpu_powerlimit = ACCESS_METHOD_WMI3,
+	.access_method_gpu_oc = ACCESS_METHOD_WMI2,
+	.has_advanced_power_features = true,
 };
 
 static const struct model_config model_kfcn = {
@@ -1686,6 +1723,9 @@ static int wmi_exec_arg(const char *guid, u8 instance, u32 method_id, void *arg,
 #define WMI_METHOD_ID_GETIGPUMODESTATUS 64
 #define WMI_METHOD_ID_SETIGPUMODESTATUS 65
 #define WMI_METHOD_ID_NOTIFYDGPUSTATUS 66
+// \_SB.GZFD.WMAA Arg1 0x32/0x33 used for GPU OC state on LPCN62WW
+#define WMI_METHOD_ID_GET_GPU_OC_STATUS_WMAA 0x32
+#define WMI_METHOD_ID_SET_GPU_OC_STATUS_WMAA 0x33
 enum IGPUState {
 	IGPUState_default = 0,
 	IGPUState_iGPUOnly = 1,
@@ -1785,6 +1825,7 @@ enum OtherMethodFeature {
 	OtherMethodFeature_GPU_TEMPERATURE_LIMIT = 0x02030000,
 	OtherMethodFeature_GPU_POWER_TARGET_ON_AC_OFFSET_FROM_BASELINE =
 		0x02040000,
+	OtherMethodFeature_GPU_TO_CPU_DYNAMIC_BOOST = 0x020B0000,
 
 	OtherMethodFeature_FAN_SPEED_1 = 0x04030001,
 	OtherMethodFeature_FAN_SPEED_2 = 0x04030002,
@@ -1809,6 +1850,21 @@ static ssize_t wmi_other_method_get_value(enum OtherMethodFeature feature_id,
 	if (!error)
 		*value = res;
 	return error;
+}
+
+static int wmi_other_method_set_value(enum OtherMethodFeature feature_id, int value)
+{
+	struct {
+		u32 feature_id;
+		u32 value;
+	} in_param = {
+		.feature_id = feature_id,
+		.value = value,
+	};
+
+	return wmi_exec_arg(LEGION_WMI_LENOVO_OTHER_METHOD_GUID, 0,
+			    WMI_METHOD_ID_SET_FEATURE_VALUE, &in_param,
+			    sizeof(in_param));
 }
 
 /* =================================== */
@@ -4141,6 +4197,56 @@ static int store_simple_wmi_attribute(struct device *dev,
 	return count;
 }
 
+static ssize_t show_wmi_other_feature_attribute(struct device *dev, char *buf,
+						enum OtherMethodFeature feature_id,
+						unsigned long scale)
+{
+	struct legion_private *priv = dev_get_drvdata(dev);
+	unsigned long scaled_value;
+	int raw_value;
+	int err;
+
+	if (scale == 0)
+		return -EINVAL;
+
+	mutex_lock(&priv->fancurve_mutex);
+	err = wmi_other_method_get_value(feature_id, &raw_value);
+	mutex_unlock(&priv->fancurve_mutex);
+	if (err)
+		return -EINVAL;
+
+	scaled_value = (unsigned long)raw_value * scale;
+	return sysfs_emit(buf, "%lu\n", scaled_value);
+}
+
+static ssize_t store_wmi_other_feature_attribute(struct device *dev,
+						 const char *buf, size_t count,
+						 enum OtherMethodFeature feature_id,
+						 int scale)
+{
+	struct legion_private *priv = dev_get_drvdata(dev);
+	unsigned int state;
+	u32 feature_value;
+	int err;
+
+	if (scale <= 0)
+		return -EINVAL;
+
+	err = kstrtouint(buf, 0, &state);
+	if (err)
+		return err;
+
+	feature_value = state / scale;
+
+	mutex_lock(&priv->fancurve_mutex);
+	err = wmi_other_method_set_value(feature_id, feature_value);
+	mutex_unlock(&priv->fancurve_mutex);
+	if (err)
+		return err;
+
+	return count;
+}
+
 static ssize_t lockfancontroller_show(struct device *dev,
 				      struct device_attribute *attr, char *buf)
 {
@@ -4414,18 +4520,40 @@ static ssize_t cpu_shortterm_powerlimit_show(struct device *dev,
 					     struct device_attribute *attr,
 					     char *buf)
 {
-	return show_simple_wmi_attribute_from_buffer(
-		dev, attr, buf, WMI_GUID_LENOVO_CPU_METHOD, 0,
-		WMI_METHOD_ID_CPU_GET_SHORTTERM_POWERLIMIT, 16, 0, 1);
+	struct legion_private *priv = dev_get_drvdata(dev);
+
+	switch (priv->conf->access_method_cpu_powerlimit) {
+	case ACCESS_METHOD_WMI3:
+		return show_wmi_other_feature_attribute(
+			dev, buf, OtherMethodFeature_CPU_SHORT_TERM_POWER_LIMIT,
+			1);
+	case ACCESS_METHOD_WMI:
+	case ACCESS_METHOD_NO_ACCESS:
+	default:
+		return show_simple_wmi_attribute_from_buffer(
+			dev, attr, buf, WMI_GUID_LENOVO_CPU_METHOD, 0,
+			WMI_METHOD_ID_CPU_GET_SHORTTERM_POWERLIMIT, 16, 0, 1);
+	}
 }
 
 static ssize_t cpu_shortterm_powerlimit_store(struct device *dev,
 					      struct device_attribute *attr,
 					      const char *buf, size_t count)
 {
-	return store_simple_wmi_attribute(
-		dev, attr, buf, count, WMI_GUID_LENOVO_CPU_METHOD, 0,
-		WMI_METHOD_ID_CPU_SET_SHORTTERM_POWERLIMIT, false, 1);
+	struct legion_private *priv = dev_get_drvdata(dev);
+
+	switch (priv->conf->access_method_cpu_powerlimit) {
+	case ACCESS_METHOD_WMI3:
+		return store_wmi_other_feature_attribute(
+			dev, buf, count,
+			OtherMethodFeature_CPU_SHORT_TERM_POWER_LIMIT, 1);
+	case ACCESS_METHOD_WMI:
+	case ACCESS_METHOD_NO_ACCESS:
+	default:
+		return store_simple_wmi_attribute(
+			dev, attr, buf, count, WMI_GUID_LENOVO_CPU_METHOD, 0,
+			WMI_METHOD_ID_CPU_SET_SHORTTERM_POWERLIMIT, false, 1);
+	}
 }
 
 static DEVICE_ATTR_RW(cpu_shortterm_powerlimit);
@@ -4434,18 +4562,40 @@ static ssize_t cpu_longterm_powerlimit_show(struct device *dev,
 					    struct device_attribute *attr,
 					    char *buf)
 {
-	return show_simple_wmi_attribute_from_buffer(
-		dev, attr, buf, WMI_GUID_LENOVO_CPU_METHOD, 0,
-		WMI_METHOD_ID_CPU_GET_LONGTERM_POWERLIMIT, 16, 0, 1);
+	struct legion_private *priv = dev_get_drvdata(dev);
+
+	switch (priv->conf->access_method_cpu_powerlimit) {
+	case ACCESS_METHOD_WMI3:
+		return show_wmi_other_feature_attribute(
+			dev, buf, OtherMethodFeature_CPU_LONG_TERM_POWER_LIMIT,
+			1);
+	case ACCESS_METHOD_WMI:
+	case ACCESS_METHOD_NO_ACCESS:
+	default:
+		return show_simple_wmi_attribute_from_buffer(
+			dev, attr, buf, WMI_GUID_LENOVO_CPU_METHOD, 0,
+			WMI_METHOD_ID_CPU_GET_LONGTERM_POWERLIMIT, 16, 0, 1);
+	}
 }
 
 static ssize_t cpu_longterm_powerlimit_store(struct device *dev,
 					     struct device_attribute *attr,
 					     const char *buf, size_t count)
 {
-	return store_simple_wmi_attribute(
-		dev, attr, buf, count, WMI_GUID_LENOVO_CPU_METHOD, 0,
-		WMI_METHOD_ID_CPU_SET_LONGTERM_POWERLIMIT, false, 1);
+	struct legion_private *priv = dev_get_drvdata(dev);
+
+	switch (priv->conf->access_method_cpu_powerlimit) {
+	case ACCESS_METHOD_WMI3:
+		return store_wmi_other_feature_attribute(
+			dev, buf, count,
+			OtherMethodFeature_CPU_LONG_TERM_POWER_LIMIT, 1);
+	case ACCESS_METHOD_WMI:
+	case ACCESS_METHOD_NO_ACCESS:
+	default:
+		return store_simple_wmi_attribute(
+			dev, attr, buf, count, WMI_GUID_LENOVO_CPU_METHOD, 0,
+			WMI_METHOD_ID_CPU_SET_LONGTERM_POWERLIMIT, false, 1);
+	}
 }
 
 static DEVICE_ATTR_RW(cpu_longterm_powerlimit);
@@ -4465,20 +4615,41 @@ static ssize_t cpu_peak_powerlimit_show(struct device *dev,
 					struct device_attribute *attr,
 					char *buf)
 {
-	return show_simple_wmi_attribute(dev, attr, buf,
-					 WMI_GUID_LENOVO_GPU_METHOD, 0,
-					 WMI_METHOD_ID_CPU_GET_PEAK_POWERLIMIT,
-					 false, 1);
+	struct legion_private *priv = dev_get_drvdata(dev);
+
+	switch (priv->conf->access_method_cpu_powerlimit) {
+	case ACCESS_METHOD_WMI3:
+		return show_wmi_other_feature_attribute(
+			dev, buf, OtherMethodFeature_CPU_PEAK_POWER_LIMIT, 1);
+	case ACCESS_METHOD_WMI:
+	case ACCESS_METHOD_NO_ACCESS:
+	default:
+		return show_simple_wmi_attribute(dev, attr, buf,
+						 WMI_GUID_LENOVO_GPU_METHOD, 0,
+						 WMI_METHOD_ID_CPU_GET_PEAK_POWERLIMIT,
+						 false, 1);
+	}
 }
 
 static ssize_t cpu_peak_powerlimit_store(struct device *dev,
 					 struct device_attribute *attr,
 					 const char *buf, size_t count)
 {
-	return store_simple_wmi_attribute(dev, attr, buf, count,
-					  WMI_GUID_LENOVO_GPU_METHOD, 0,
-					  WMI_METHOD_ID_CPU_SET_PEAK_POWERLIMIT,
-					  false, 1);
+	struct legion_private *priv = dev_get_drvdata(dev);
+
+	switch (priv->conf->access_method_cpu_powerlimit) {
+	case ACCESS_METHOD_WMI3:
+		return store_wmi_other_feature_attribute(
+			dev, buf, count, OtherMethodFeature_CPU_PEAK_POWER_LIMIT,
+			1);
+	case ACCESS_METHOD_WMI:
+	case ACCESS_METHOD_NO_ACCESS:
+	default:
+		return store_simple_wmi_attribute(dev, attr, buf, count,
+						  WMI_GUID_LENOVO_GPU_METHOD, 0,
+						  WMI_METHOD_ID_CPU_SET_PEAK_POWERLIMIT,
+						  false, 1);
+	}
 }
 
 static DEVICE_ATTR_RW(cpu_peak_powerlimit);
@@ -4487,18 +4658,36 @@ static ssize_t cpu_apu_sppt_powerlimit_show(struct device *dev,
 					    struct device_attribute *attr,
 					    char *buf)
 {
-	return show_simple_wmi_attribute(
-		dev, attr, buf, WMI_GUID_LENOVO_GPU_METHOD, 0,
-		WMI_METHOD_ID_CPU_GET_APU_SPPT_POWERLIMIT, false, 1);
+	struct legion_private *priv = dev_get_drvdata(dev);
+
+	switch (priv->conf->access_method_cpu_powerlimit) {
+	case ACCESS_METHOD_WMI3:
+		return -EOPNOTSUPP;
+	case ACCESS_METHOD_WMI:
+	case ACCESS_METHOD_NO_ACCESS:
+	default:
+		return show_simple_wmi_attribute(
+			dev, attr, buf, WMI_GUID_LENOVO_GPU_METHOD, 0,
+			WMI_METHOD_ID_CPU_GET_APU_SPPT_POWERLIMIT, false, 1);
+	}
 }
 
 static ssize_t cpu_apu_sppt_powerlimit_store(struct device *dev,
 					     struct device_attribute *attr,
 					     const char *buf, size_t count)
 {
-	return store_simple_wmi_attribute(
-		dev, attr, buf, count, WMI_GUID_LENOVO_GPU_METHOD, 0,
-		WMI_METHOD_ID_CPU_SET_APU_SPPT_POWERLIMIT, false, 1);
+	struct legion_private *priv = dev_get_drvdata(dev);
+
+	switch (priv->conf->access_method_cpu_powerlimit) {
+	case ACCESS_METHOD_WMI3:
+		return -EOPNOTSUPP;
+	case ACCESS_METHOD_WMI:
+	case ACCESS_METHOD_NO_ACCESS:
+	default:
+		return store_simple_wmi_attribute(
+			dev, attr, buf, count, WMI_GUID_LENOVO_GPU_METHOD, 0,
+			WMI_METHOD_ID_CPU_SET_APU_SPPT_POWERLIMIT, false, 1);
+	}
 }
 
 static DEVICE_ATTR_RW(cpu_apu_sppt_powerlimit);
@@ -4507,18 +4696,40 @@ static ssize_t cpu_cross_loading_powerlimit_show(struct device *dev,
 						 struct device_attribute *attr,
 						 char *buf)
 {
-	return show_simple_wmi_attribute(
-		dev, attr, buf, WMI_GUID_LENOVO_GPU_METHOD, 0,
-		WMI_METHOD_ID_CPU_GET_CROSS_LOADING_POWERLIMIT, false, 1);
+	struct legion_private *priv = dev_get_drvdata(dev);
+
+	switch (priv->conf->access_method_cpu_powerlimit) {
+	case ACCESS_METHOD_WMI3:
+		return show_wmi_other_feature_attribute(
+			dev, buf, OtherMethodFeature_CPU_CROSS_LOAD_POWER_LIMIT,
+			1);
+	case ACCESS_METHOD_WMI:
+	case ACCESS_METHOD_NO_ACCESS:
+	default:
+		return show_simple_wmi_attribute(
+			dev, attr, buf, WMI_GUID_LENOVO_GPU_METHOD, 0,
+			WMI_METHOD_ID_CPU_GET_CROSS_LOADING_POWERLIMIT, false, 1);
+	}
 }
 
 static ssize_t cpu_cross_loading_powerlimit_store(struct device *dev,
 						  struct device_attribute *attr,
 						  const char *buf, size_t count)
 {
-	return store_simple_wmi_attribute(
-		dev, attr, buf, count, WMI_GUID_LENOVO_GPU_METHOD, 0,
-		WMI_METHOD_ID_CPU_SET_CROSS_LOADING_POWERLIMIT, false, 1);
+	struct legion_private *priv = dev_get_drvdata(dev);
+
+	switch (priv->conf->access_method_cpu_powerlimit) {
+	case ACCESS_METHOD_WMI3:
+		return store_wmi_other_feature_attribute(
+			dev, buf, count,
+			OtherMethodFeature_CPU_CROSS_LOAD_POWER_LIMIT, 1);
+	case ACCESS_METHOD_WMI:
+	case ACCESS_METHOD_NO_ACCESS:
+	default:
+		return store_simple_wmi_attribute(
+			dev, attr, buf, count, WMI_GUID_LENOVO_GPU_METHOD, 0,
+			WMI_METHOD_ID_CPU_SET_CROSS_LOADING_POWERLIMIT, false, 1);
+	}
 }
 
 static DEVICE_ATTR_RW(cpu_cross_loading_powerlimit);
@@ -4526,19 +4737,41 @@ static DEVICE_ATTR_RW(cpu_cross_loading_powerlimit);
 static ssize_t gpu_oc_show(struct device *dev, struct device_attribute *attr,
 			   char *buf)
 {
-	return show_simple_wmi_attribute(dev, attr, buf,
-					 WMI_GUID_LENOVO_GPU_METHOD, 0,
-					 WMI_METHOD_ID_GPU_GET_OC_STATUS, false,
-					 1);
+	struct legion_private *priv = dev_get_drvdata(dev);
+
+	switch (priv->conf->access_method_gpu_oc) {
+	case ACCESS_METHOD_WMI2:
+		return show_simple_wmi_attribute(
+			dev, attr, buf, LEGION_WMI_GAMEZONE_GUID, 0,
+			WMI_METHOD_ID_GET_GPU_OC_STATUS_WMAA, false, 1);
+	case ACCESS_METHOD_WMI:
+	case ACCESS_METHOD_NO_ACCESS:
+	default:
+		return show_simple_wmi_attribute(dev, attr, buf,
+						 WMI_GUID_LENOVO_GPU_METHOD, 0,
+						 WMI_METHOD_ID_GPU_GET_OC_STATUS, false,
+						 1);
+	}
 }
 
 static ssize_t gpu_oc_store(struct device *dev, struct device_attribute *attr,
 			    const char *buf, size_t count)
 {
-	return store_simple_wmi_attribute(dev, attr, buf, count,
-					  WMI_GUID_LENOVO_GPU_METHOD, 0,
-					  WMI_METHOD_ID_GPU_SET_OC_STATUS,
-					  false, 1);
+	struct legion_private *priv = dev_get_drvdata(dev);
+
+	switch (priv->conf->access_method_gpu_oc) {
+	case ACCESS_METHOD_WMI2:
+		return store_simple_wmi_attribute(
+			dev, attr, buf, count, LEGION_WMI_GAMEZONE_GUID, 0,
+			WMI_METHOD_ID_SET_GPU_OC_STATUS_WMAA, false, 1);
+	case ACCESS_METHOD_WMI:
+	case ACCESS_METHOD_NO_ACCESS:
+	default:
+		return store_simple_wmi_attribute(dev, attr, buf, count,
+						  WMI_GUID_LENOVO_GPU_METHOD, 0,
+						  WMI_METHOD_ID_GPU_SET_OC_STATUS,
+						  false, 1);
+	}
 }
 
 static DEVICE_ATTR_RW(gpu_oc);
@@ -4547,19 +4780,39 @@ static ssize_t gpu_ppab_powerlimit_show(struct device *dev,
 					struct device_attribute *attr,
 					char *buf)
 {
-	return show_simple_wmi_attribute_from_buffer(
-		dev, attr, buf, WMI_GUID_LENOVO_GPU_METHOD, 0,
-		WMI_METHOD_ID_GPU_GET_PPAB_POWERLIMIT, 16, 0, 1);
+	struct legion_private *priv = dev_get_drvdata(dev);
+
+	switch (priv->conf->access_method_gpu_powerlimit) {
+	case ACCESS_METHOD_WMI3:
+		return show_wmi_other_feature_attribute(
+			dev, buf, OtherMethodFeature_GPU_POWER_BOOST, 1);
+	case ACCESS_METHOD_WMI:
+	case ACCESS_METHOD_NO_ACCESS:
+	default:
+		return show_simple_wmi_attribute_from_buffer(
+			dev, attr, buf, WMI_GUID_LENOVO_GPU_METHOD, 0,
+			WMI_METHOD_ID_GPU_GET_PPAB_POWERLIMIT, 16, 0, 1);
+	}
 }
 
 static ssize_t gpu_ppab_powerlimit_store(struct device *dev,
 					 struct device_attribute *attr,
 					 const char *buf, size_t count)
 {
-	return store_simple_wmi_attribute(dev, attr, buf, count,
-					  WMI_GUID_LENOVO_GPU_METHOD, 0,
-					  WMI_METHOD_ID_GPU_SET_PPAB_POWERLIMIT,
-					  false, 1);
+	struct legion_private *priv = dev_get_drvdata(dev);
+
+	switch (priv->conf->access_method_gpu_powerlimit) {
+	case ACCESS_METHOD_WMI3:
+		return store_wmi_other_feature_attribute(
+			dev, buf, count, OtherMethodFeature_GPU_POWER_BOOST, 1);
+	case ACCESS_METHOD_WMI:
+	case ACCESS_METHOD_NO_ACCESS:
+	default:
+		return store_simple_wmi_attribute(dev, attr, buf, count,
+						  WMI_GUID_LENOVO_GPU_METHOD, 0,
+						  WMI_METHOD_ID_GPU_SET_PPAB_POWERLIMIT,
+						  false, 1);
+	}
 }
 
 static DEVICE_ATTR_RW(gpu_ppab_powerlimit);
@@ -4568,19 +4821,40 @@ static ssize_t gpu_ctgp_powerlimit_show(struct device *dev,
 					struct device_attribute *attr,
 					char *buf)
 {
-	return show_simple_wmi_attribute_from_buffer(
-		dev, attr, buf, WMI_GUID_LENOVO_GPU_METHOD, 0,
-		WMI_METHOD_ID_GPU_GET_CTGP_POWERLIMIT, 16, 0, 1);
+	struct legion_private *priv = dev_get_drvdata(dev);
+
+	switch (priv->conf->access_method_gpu_powerlimit) {
+	case ACCESS_METHOD_WMI3:
+		return show_wmi_other_feature_attribute(dev, buf,
+							OtherMethodFeature_GPU_cTGP,
+							1);
+	case ACCESS_METHOD_WMI:
+	case ACCESS_METHOD_NO_ACCESS:
+	default:
+		return show_simple_wmi_attribute_from_buffer(
+			dev, attr, buf, WMI_GUID_LENOVO_GPU_METHOD, 0,
+			WMI_METHOD_ID_GPU_GET_CTGP_POWERLIMIT, 16, 0, 1);
+	}
 }
 
 static ssize_t gpu_ctgp_powerlimit_store(struct device *dev,
 					 struct device_attribute *attr,
 					 const char *buf, size_t count)
 {
-	return store_simple_wmi_attribute(dev, attr, buf, count,
-					  WMI_GUID_LENOVO_GPU_METHOD, 0,
-					  WMI_METHOD_ID_GPU_SET_CTGP_POWERLIMIT,
-					  false, 1);
+	struct legion_private *priv = dev_get_drvdata(dev);
+
+	switch (priv->conf->access_method_gpu_powerlimit) {
+	case ACCESS_METHOD_WMI3:
+		return store_wmi_other_feature_attribute(
+			dev, buf, count, OtherMethodFeature_GPU_cTGP, 1);
+	case ACCESS_METHOD_WMI:
+	case ACCESS_METHOD_NO_ACCESS:
+	default:
+		return store_simple_wmi_attribute(dev, attr, buf, count,
+						  WMI_GUID_LENOVO_GPU_METHOD, 0,
+						  WMI_METHOD_ID_GPU_SET_CTGP_POWERLIMIT,
+						  false, 1);
+	}
 }
 
 static DEVICE_ATTR_RW(gpu_ctgp_powerlimit);
@@ -4589,9 +4863,18 @@ static ssize_t gpu_ctgp2_powerlimit_show(struct device *dev,
 					 struct device_attribute *attr,
 					 char *buf)
 {
-	return show_simple_wmi_attribute_from_buffer(
-		dev, attr, buf, WMI_GUID_LENOVO_GPU_METHOD, 0,
-		WMI_METHOD_ID_GPU_GET_CTGP_POWERLIMIT, 16, 0x0C, 1);
+	struct legion_private *priv = dev_get_drvdata(dev);
+
+	switch (priv->conf->access_method_gpu_powerlimit) {
+	case ACCESS_METHOD_WMI3:
+		return -EOPNOTSUPP;
+	case ACCESS_METHOD_WMI:
+	case ACCESS_METHOD_NO_ACCESS:
+	default:
+		return show_simple_wmi_attribute_from_buffer(
+			dev, attr, buf, WMI_GUID_LENOVO_GPU_METHOD, 0,
+			WMI_METHOD_ID_GPU_GET_CTGP_POWERLIMIT, 16, 0x0C, 1);
+	}
 }
 
 static DEVICE_ATTR_RO(gpu_ctgp2_powerlimit);
@@ -4611,21 +4894,132 @@ static ssize_t gpu_temperature_limit_show(struct device *dev,
 					  struct device_attribute *attr,
 					  char *buf)
 {
-	return show_simple_wmi_attribute(
-		dev, attr, buf, WMI_GUID_LENOVO_GPU_METHOD, 0,
-		WMI_METHOD_ID_GPU_GET_TEMPERATURE_LIMIT, false, 1);
+	struct legion_private *priv = dev_get_drvdata(dev);
+
+	switch (priv->conf->access_method_gpu_powerlimit) {
+	case ACCESS_METHOD_WMI3:
+		return show_wmi_other_feature_attribute(
+			dev, buf, OtherMethodFeature_GPU_TEMPERATURE_LIMIT, 1);
+	case ACCESS_METHOD_WMI:
+	case ACCESS_METHOD_NO_ACCESS:
+	default:
+		return show_simple_wmi_attribute(
+			dev, attr, buf, WMI_GUID_LENOVO_GPU_METHOD, 0,
+			WMI_METHOD_ID_GPU_GET_TEMPERATURE_LIMIT, false, 1);
+	}
 }
 
 static ssize_t gpu_temperature_limit_store(struct device *dev,
 					   struct device_attribute *attr,
 					   const char *buf, size_t count)
 {
-	return store_simple_wmi_attribute(
-		dev, attr, buf, count, WMI_GUID_LENOVO_GPU_METHOD, 0,
-		WMI_METHOD_ID_GPU_SET_TEMPERATURE_LIMIT, false, 1);
+	struct legion_private *priv = dev_get_drvdata(dev);
+
+	switch (priv->conf->access_method_gpu_powerlimit) {
+	case ACCESS_METHOD_WMI3:
+		return store_wmi_other_feature_attribute(
+			dev, buf, count, OtherMethodFeature_GPU_TEMPERATURE_LIMIT,
+			1);
+	case ACCESS_METHOD_WMI:
+	case ACCESS_METHOD_NO_ACCESS:
+	default:
+		return store_simple_wmi_attribute(
+			dev, attr, buf, count, WMI_GUID_LENOVO_GPU_METHOD, 0,
+			WMI_METHOD_ID_GPU_SET_TEMPERATURE_LIMIT, false, 1);
+	}
 }
 
 static DEVICE_ATTR_RW(gpu_temperature_limit);
+
+static ssize_t cpu_temperature_limit_show(struct device *dev,
+					  struct device_attribute *attr,
+					  char *buf)
+{
+	struct legion_private *priv = dev_get_drvdata(dev);
+
+	if (!priv->conf->has_advanced_power_features)
+		return -EOPNOTSUPP;
+
+	return show_wmi_other_feature_attribute(
+		dev, buf, OtherMethodFeature_CPU_TEMPERATURE_LIMIT, 1);
+}
+
+static ssize_t cpu_temperature_limit_store(struct device *dev,
+					   struct device_attribute *attr,
+					   const char *buf, size_t count)
+{
+	struct legion_private *priv = dev_get_drvdata(dev);
+
+	if (!priv->conf->has_advanced_power_features)
+		return -EOPNOTSUPP;
+
+	return store_wmi_other_feature_attribute(
+		dev, buf, count, OtherMethodFeature_CPU_TEMPERATURE_LIMIT, 1);
+}
+
+static DEVICE_ATTR_RW(cpu_temperature_limit);
+
+static ssize_t
+gpu_total_processor_power_target_on_ac_show(struct device *dev,
+					    struct device_attribute *attr,
+					    char *buf)
+{
+	struct legion_private *priv = dev_get_drvdata(dev);
+
+	if (!priv->conf->has_advanced_power_features)
+		return -EOPNOTSUPP;
+
+	return show_wmi_other_feature_attribute(
+		dev, buf,
+		OtherMethodFeature_GPU_POWER_TARGET_ON_AC_OFFSET_FROM_BASELINE,
+		1);
+}
+
+static ssize_t
+gpu_total_processor_power_target_on_ac_store(struct device *dev,
+					     struct device_attribute *attr,
+					     const char *buf, size_t count)
+{
+	struct legion_private *priv = dev_get_drvdata(dev);
+
+	if (!priv->conf->has_advanced_power_features)
+		return -EOPNOTSUPP;
+
+	return store_wmi_other_feature_attribute(
+		dev, buf, count,
+		OtherMethodFeature_GPU_POWER_TARGET_ON_AC_OFFSET_FROM_BASELINE,
+		1);
+}
+
+static DEVICE_ATTR_RW(gpu_total_processor_power_target_on_ac);
+
+static ssize_t gpu_to_cpu_dynamic_boost_show(struct device *dev,
+					     struct device_attribute *attr,
+					     char *buf)
+{
+	struct legion_private *priv = dev_get_drvdata(dev);
+
+	if (!priv->conf->has_advanced_power_features)
+		return -EOPNOTSUPP;
+
+	return show_wmi_other_feature_attribute(
+		dev, buf, OtherMethodFeature_GPU_TO_CPU_DYNAMIC_BOOST, 1);
+}
+
+static ssize_t gpu_to_cpu_dynamic_boost_store(struct device *dev,
+					      struct device_attribute *attr,
+					      const char *buf, size_t count)
+{
+	struct legion_private *priv = dev_get_drvdata(dev);
+
+	if (!priv->conf->has_advanced_power_features)
+		return -EOPNOTSUPP;
+
+	return store_wmi_other_feature_attribute(
+		dev, buf, count, OtherMethodFeature_GPU_TO_CPU_DYNAMIC_BOOST, 1);
+}
+
+static DEVICE_ATTR_RW(gpu_to_cpu_dynamic_boost);
 
 // TOOD: probably remove again because provided by other means; only useful for overclocking
 static ssize_t gpu_boost_clock_show(struct device *dev,
@@ -4768,10 +5162,13 @@ static struct attribute *legion_sysfs_attributes[] = {
 	&dev_attr_cpu_default_powerlimit.attr,
 	&dev_attr_cpu_peak_powerlimit.attr,
 	&dev_attr_cpu_cross_loading_powerlimit.attr,
+	&dev_attr_cpu_temperature_limit.attr,
 	&dev_attr_gpu_oc.attr,
 	&dev_attr_gpu_ppab_powerlimit.attr,
 	&dev_attr_gpu_ctgp_powerlimit.attr,
 	&dev_attr_gpu_ctgp2_powerlimit.attr,
+	&dev_attr_gpu_total_processor_power_target_on_ac.attr,
+	&dev_attr_gpu_to_cpu_dynamic_boost.attr,
 	&dev_attr_gpu_default_ppab_ctrgp_powerlimit.attr,
 	&dev_attr_gpu_temperature_limit.attr,
 	&dev_attr_gpu_boost_clock.attr,
@@ -4785,8 +5182,37 @@ static struct attribute *legion_sysfs_attributes[] = {
 	NULL
 };
 
+static umode_t legion_sysfs_is_visible(struct kobject *kobj,
+				       struct attribute *attr, int n)
+{
+	struct device *dev = container_of(kobj, struct device, kobj);
+	struct legion_private *priv = dev_get_drvdata(dev);
+
+	(void)n;
+
+	if (attr == &dev_attr_cpu_apu_sppt_powerlimit.attr) {
+		if (priv && priv->conf->access_method_cpu_powerlimit == ACCESS_METHOD_WMI3)
+			return 0;
+	}
+
+	if (attr == &dev_attr_gpu_ctgp2_powerlimit.attr) {
+		if (priv && priv->conf->access_method_gpu_powerlimit == ACCESS_METHOD_WMI3)
+			return 0;
+	}
+
+	if (attr == &dev_attr_cpu_temperature_limit.attr ||
+	    attr == &dev_attr_gpu_total_processor_power_target_on_ac.attr ||
+	    attr == &dev_attr_gpu_to_cpu_dynamic_boost.attr) {
+		if (!priv || !priv->conf->has_advanced_power_features)
+			return 0;
+	}
+
+	return attr->mode;
+}
+
 static const struct attribute_group legion_attribute_group = {
-	.attrs = legion_sysfs_attributes
+	.attrs = legion_sysfs_attributes,
+	.is_visible = legion_sysfs_is_visible,
 };
 
 static int legion_sysfs_init(struct legion_private *priv)
@@ -6237,6 +6663,20 @@ static int legion_add(struct platform_device *pdev)
 		 dmi_sys->ident);
 
 	priv->conf = dmi_sys->driver_data;
+
+	// LPCN62WW on 82WM uses different WMI paths for power limits and GPU OC
+	if (dmi_check_system((const struct dmi_system_id[]) {
+		{ .matches = {
+			DMI_MATCH(DMI_SYS_VENDOR, "LENOVO"),
+			DMI_MATCH(DMI_PRODUCT_NAME, "82WM"),
+			DMI_MATCH(DMI_BIOS_VERSION, "LPCN62WW"),
+		}},
+		{},
+	})) {
+		priv->conf = &model_lpcn62ww;
+		dev_info(&pdev->dev,
+			 "Using LPCN62WW machine-specific config for WMB5/WMAA OC/powerlimit controls\n");
+	}
 
 	err = acpi_init(priv, ACPI_COMPANION(&pdev->dev));
 	if (err) {

--- a/kernel_module/legion-laptop.c
+++ b/kernel_module/legion-laptop.c
@@ -757,30 +757,6 @@ static const struct model_config model_lpcn = {
 	.acpi_check_dev = true,
 	.ramio_physical_start = 0xFE0B0400,
 	.ramio_size = 0x600,
-	.access_method_cpu_powerlimit = ACCESS_METHOD_WMI,
-	.access_method_gpu_powerlimit = ACCESS_METHOD_WMI,
-	.access_method_gpu_oc = ACCESS_METHOD_WMI,
-};
-
-// LPCN62WW on product 82WM (Legion R9000P 2023):
-// Uses OtherMethodFeature (WMI3) for power limits and WMAA (WMI2 via Gamezone) for GPU OC
-static const struct model_config model_lpcn62ww = {
-	.registers = &ec_register_offsets_v0,
-	.check_embedded_controller_id = true,
-	.embedded_controller_id = 0x5507,
-	.memoryio_physical_ec_start = 0xC400,
-	.memoryio_size = 0x300,
-	.has_minifancurve = false,
-	.has_custom_powermode = true,
-	.access_method_powermode = ACCESS_METHOD_WMI,
-	.access_method_keyboard = ACCESS_METHOD_WMI,
-	.access_method_fanspeed = ACCESS_METHOD_WMI3,
-	.access_method_temperature = ACCESS_METHOD_WMI3,
-	.access_method_fancurve = ACCESS_METHOD_WMI3,
-	.access_method_fanfullspeed = ACCESS_METHOD_WMI,
-	.acpi_check_dev = false,
-	.ramio_physical_start = 0xFE0B0400,
-	.ramio_size = 0x600,
 	.access_method_cpu_powerlimit = ACCESS_METHOD_WMI3,
 	.access_method_gpu_powerlimit = ACCESS_METHOD_WMI3,
 	.access_method_gpu_oc = ACCESS_METHOD_WMI2,
@@ -6737,20 +6713,6 @@ static int legion_add(struct platform_device *pdev)
 		 dmi_sys->ident);
 
 	priv->conf = dmi_sys->driver_data;
-
-	// LPCN62WW on 82WM uses different WMI paths for power limits and GPU OC
-	if (dmi_check_system((const struct dmi_system_id[]) {
-		{ .matches = {
-			DMI_MATCH(DMI_SYS_VENDOR, "LENOVO"),
-			DMI_MATCH(DMI_PRODUCT_NAME, "82WM"),
-			DMI_MATCH(DMI_BIOS_VERSION, "LPCN62WW"),
-		}},
-		{},
-	})) {
-		priv->conf = &model_lpcn62ww;
-		dev_info(&pdev->dev,
-			 "Using LPCN62WW machine-specific config for WMI3/WMAA OC/powerlimit controls\n");
-	}
 
 	err = acpi_init(priv, ACPI_COMPANION(&pdev->dev));
 	if (err) {

--- a/python/legion_linux/legion_linux/legion.py
+++ b/python/legion_linux/legion_linux/legion.py
@@ -614,12 +614,12 @@ class GPUCTGPPowerLimit(IntFileFeature):
 
 class GPUPPABPowerLimit(IntFileFeature):
     def __init__(self):
-        super().__init__(os.path.join(LEGION_SYS_BASEPATH, "gpu_ppab_powerlimit"), 0, 80, 1)
+        super().__init__(os.path.join(LEGION_SYS_BASEPATH, "gpu_ppab_powerlimit"), 0, 200, 1)
 
 
 class GPUTemperatureLimit(IntFileFeature):
     def __init__(self):
-        super().__init__(os.path.join(LEGION_SYS_BASEPATH, "gpu_temperature_limit"), 0, 95, 1)
+        super().__init__(os.path.join(LEGION_SYS_BASEPATH, "gpu_temperature_limit"), 0, 120, 1)
 
 
 class GPUTotalProcessorPowerTargetOnAC(IntFileFeature):

--- a/python/legion_linux/legion_linux/legion.py
+++ b/python/legion_linux/legion_linux/legion.py
@@ -597,6 +597,11 @@ class CPUCrossLoadingPowerLimit(IntFileFeature):
                                       "cpu_cross_loading_powerlimit"), 0, 100, 1)
 
 
+class CPUTemperatureLimit(IntFileFeature):
+    def __init__(self):
+        super().__init__(os.path.join(LEGION_SYS_BASEPATH, "cpu_temperature_limit"), 0, 100, 1)
+
+
 class GPUBoostClock(IntFileFeature):
     def __init__(self):
         super().__init__(os.path.join(LEGION_SYS_BASEPATH, "gpu_boost_clock"), 0, 10000, 1)
@@ -609,12 +614,22 @@ class GPUCTGPPowerLimit(IntFileFeature):
 
 class GPUPPABPowerLimit(IntFileFeature):
     def __init__(self):
-        super().__init__(os.path.join(LEGION_SYS_BASEPATH, "gpu_ppab_powerlimit"), 0, 200, 1)
+        super().__init__(os.path.join(LEGION_SYS_BASEPATH, "gpu_ppab_powerlimit"), 0, 80, 1)
 
 
 class GPUTemperatureLimit(IntFileFeature):
     def __init__(self):
-        super().__init__(os.path.join(LEGION_SYS_BASEPATH, "gpu_temperature_limit"), 0, 120, 1)
+        super().__init__(os.path.join(LEGION_SYS_BASEPATH, "gpu_temperature_limit"), 0, 95, 1)
+
+
+class GPUTotalProcessorPowerTargetOnAC(IntFileFeature):
+    def __init__(self):
+        super().__init__(os.path.join(LEGION_SYS_BASEPATH, "gpu_total_processor_power_target_on_ac"), 0, 100, 1)
+
+
+class GPUToCPUDynamicBoost(IntFileFeature):
+    def __init__(self):
+        super().__init__(os.path.join(LEGION_SYS_BASEPATH, "gpu_to_cpu_dynamic_boost"), 0, 80, 1)
 
 
 class YLogoLight(BoolFileFeature):
@@ -1429,12 +1444,15 @@ class LegionModelFacade:
         self.cpu_peak_power_limit = CPUPeakPowerLimit()
         self.cpu_default_power_limit = CPUDefaultPowerLimit()
         self.cpu_cross_loading_power_limit = CPUCrossLoadingPowerLimit()
+        self.cpu_temperature_limit = CPUTemperatureLimit()
         self.cpu_apu_sppt_power_limit = CPUAPUSPPTPowerLimit()
         self.gpu_overclock = GPUOverclock()
         self.gpu_boost_clock = GPUBoostClock()
         self.gpu_ctgp_power_limit = GPUCTGPPowerLimit()
         self.gpu_ppab_power_limit = GPUPPABPowerLimit()
         self.gpu_temperature_limit = GPUTemperatureLimit()
+        self.gpu_total_processor_power_target_on_ac = GPUTotalProcessorPowerTargetOnAC()
+        self.gpu_to_cpu_dynamic_boost = GPUToCPUDynamicBoost()
 
         # light
         self.ylogo_light = YLogoLight()

--- a/python/legion_linux/legion_linux/legion_gui.py
+++ b/python/legion_linux/legion_linux/legion_gui.py
@@ -570,10 +570,13 @@ class LegionController:
     cpu_shortterm_power_limit_controller: IntFeatureController
     cpu_peak_power_limit_controller: IntFeatureController
     cpu_cross_loading_power_limit_controller: IntFeatureController
+    cpu_temperature_limit_controller: IntFeatureController
     cpu_apu_sppt_power_limit_controller: IntFeatureController
     gpu_ctgp_power_limit_controller: IntFeatureController
     gpu_ppab_power_limit_controller: IntFeatureController
     gpu_temperature_limit_controller: IntFeatureController
+    gpu_total_processor_power_target_on_ac_controller: IntFeatureController
+    gpu_to_cpu_dynamic_boost_controller: IntFeatureController
     # light
     ylogo_light_controller: BoolFeatureController
     ioport_light_controller: BoolFeatureController
@@ -680,6 +683,9 @@ class LegionController:
         self.cpu_cross_loading_power_limit_controller = IntFeatureController(
             self.view_otheroptions.cpu_cross_loading_power_limit_spinbox,
             self.model.cpu_cross_loading_power_limit)
+        self.cpu_temperature_limit_controller = IntFeatureController(
+            self.view_otheroptions.cpu_temperature_limit_spinbox,
+            self.model.cpu_temperature_limit)
         self.cpu_apu_sppt_power_limit_controller = IntFeatureController(
             self.view_otheroptions.cpu_apu_sppt_power_limit_spinbox,
             self.model.cpu_apu_sppt_power_limit)
@@ -692,6 +698,12 @@ class LegionController:
         self.gpu_temperature_limit_controller = IntFeatureController(
             self.view_otheroptions.gpu_temperature_limit_spinbox,
             self.model.gpu_temperature_limit)
+        self.gpu_total_processor_power_target_on_ac_controller = IntFeatureController(
+            self.view_otheroptions.gpu_total_processor_power_target_on_ac_spinbox,
+            self.model.gpu_total_processor_power_target_on_ac)
+        self.gpu_to_cpu_dynamic_boost_controller = IntFeatureController(
+            self.view_otheroptions.gpu_to_cpu_dynamic_boost_spinbox,
+            self.model.gpu_to_cpu_dynamic_boost)
 
         # light
         self.ylogo_light_controller = BoolFeatureController(
@@ -827,6 +839,8 @@ class LegionController:
             update_bounds=update_bounds)
         self.cpu_cross_loading_power_limit_controller.update_view_from_feature(
             update_bounds=update_bounds)
+        self.cpu_temperature_limit_controller.update_view_from_feature(
+            update_bounds=update_bounds)
         self.cpu_apu_sppt_power_limit_controller.update_view_from_feature(
             update_bounds=update_bounds)
         self.gpu_ctgp_power_limit_controller.update_view_from_feature(
@@ -834,6 +848,10 @@ class LegionController:
         self.gpu_ppab_power_limit_controller.update_view_from_feature(
             update_bounds=update_bounds)
         self.gpu_temperature_limit_controller.update_view_from_feature(
+            update_bounds=update_bounds)
+        self.gpu_total_processor_power_target_on_ac_controller.update_view_from_feature(
+            update_bounds=update_bounds)
+        self.gpu_to_cpu_dynamic_boost_controller.update_view_from_feature(
             update_bounds=update_bounds)
 
     def power_gui_write_to_hw(self):
@@ -844,11 +862,14 @@ class LegionController:
         self.cpu_peak_power_limit_controller.update_feature_from_view(False)
         self.cpu_cross_loading_power_limit_controller.update_feature_from_view(
             False)
+        self.cpu_temperature_limit_controller.update_feature_from_view(False)
         self.cpu_apu_sppt_power_limit_controller.update_feature_from_view(
             False)
         self.gpu_ctgp_power_limit_controller.update_feature_from_view(False)
         self.gpu_ppab_power_limit_controller.update_feature_from_view(False)
         self.gpu_temperature_limit_controller.update_feature_from_view(False)
+        self.gpu_total_processor_power_target_on_ac_controller.update_feature_from_view(False)
+        self.gpu_to_cpu_dynamic_boost_controller.update_feature_from_view(False)
         self.update_power_gui()
 
     def update_fancurve_gui(self):
@@ -1279,37 +1300,61 @@ class OtherOptionsTab(QWidget):
         self.power_layout.addWidget(
             self.cpu_cross_loading_power_limit_spinbox, 6, 1)
 
+        self.cpu_temperature_limit_spinbox_label = QLabel(
+            "CPU Temperature Limit [°C]")
+        self.cpu_temperature_limit_spinbox = QSpinBox()
+        self.power_layout.addWidget(
+            self.cpu_temperature_limit_spinbox_label, 7, 0)
+        self.power_layout.addWidget(
+            self.cpu_temperature_limit_spinbox, 7, 1)
+
         self.cpu_apu_sppt_power_limit_spinbox_label = QLabel(
             "CPU APU SPPT Power Limit [W]")
         self.cpu_apu_sppt_power_limit_spinbox = QSpinBox()
         self.power_layout.addWidget(
-            self.cpu_apu_sppt_power_limit_spinbox_label, 7, 0)
+            self.cpu_apu_sppt_power_limit_spinbox_label, 8, 0)
         self.power_layout.addWidget(
-            self.cpu_apu_sppt_power_limit_spinbox, 7, 1)
+            self.cpu_apu_sppt_power_limit_spinbox, 8, 1)
 
         self.gpu_ctgp_power_limit_spinbox_label = QLabel(
             "GPU cTGP Power Limit [W]")
         self.gpu_ctgp_power_limit_spinbox = QSpinBox()
         self.power_layout.addWidget(
-            self.gpu_ctgp_power_limit_spinbox_label, 8, 0)
+            self.gpu_ctgp_power_limit_spinbox_label, 9, 0)
         self.power_layout.addWidget(
-            self.gpu_ctgp_power_limit_spinbox, 8, 1)
+            self.gpu_ctgp_power_limit_spinbox, 9, 1)
 
         self.gpu_ppab_power_limit_spinbox_label = QLabel(
             "GPU PPAB Power Limit [W]")
         self.gpu_ppab_power_limit_spinbox = QSpinBox()
         self.power_layout.addWidget(
-            self.gpu_ppab_power_limit_spinbox_label, 9, 0)
+            self.gpu_ppab_power_limit_spinbox_label, 10, 0)
         self.power_layout.addWidget(
-            self.gpu_ppab_power_limit_spinbox, 9, 1)
+            self.gpu_ppab_power_limit_spinbox, 10, 1)
 
         self.gpu_temperature_limit_spinbox_label = QLabel(
             "GPU Temperature Limit [°C]")
         self.gpu_temperature_limit_spinbox = QSpinBox()
         self.power_layout.addWidget(
-            self.gpu_temperature_limit_spinbox_label, 10, 0)
+            self.gpu_temperature_limit_spinbox_label, 11, 0)
         self.power_layout.addWidget(
-            self.gpu_temperature_limit_spinbox, 10, 1)
+            self.gpu_temperature_limit_spinbox, 11, 1)
+
+        self.gpu_total_processor_power_target_on_ac_spinbox_label = QLabel(
+            "Total Processor Power Target on AC [W]")
+        self.gpu_total_processor_power_target_on_ac_spinbox = QSpinBox()
+        self.power_layout.addWidget(
+            self.gpu_total_processor_power_target_on_ac_spinbox_label, 12, 0)
+        self.power_layout.addWidget(
+            self.gpu_total_processor_power_target_on_ac_spinbox, 12, 1)
+
+        self.gpu_to_cpu_dynamic_boost_spinbox_label = QLabel(
+            "GPU to CPU Dynamic Boost [W]")
+        self.gpu_to_cpu_dynamic_boost_spinbox = QSpinBox()
+        self.power_layout.addWidget(
+            self.gpu_to_cpu_dynamic_boost_spinbox_label, 13, 0)
+        self.power_layout.addWidget(
+            self.gpu_to_cpu_dynamic_boost_spinbox, 13, 1)
 
         self.power_load_button = QPushButton("Read from HW")
         self.power_write_button = QPushButton("Apply to HW")
@@ -1317,8 +1362,8 @@ class OtherOptionsTab(QWidget):
             self.controller.update_power_gui)
         self.power_write_button.clicked.connect(
             self.controller.power_gui_write_to_hw)
-        self.power_layout.addWidget(self.power_load_button, 11, 0)
-        self.power_layout.addWidget(self.power_write_button, 11, 1)
+        self.power_layout.addWidget(self.power_load_button, 14, 0)
+        self.power_layout.addWidget(self.power_write_button, 14, 1)
 
         self.power_note_label = QLabel(
             "It is recommended to customize the power settings only in custom mode. Although "


### PR DESCRIPTION
## Overview

| File | Insertions | Deletions |
|------|-----------|-----------|
| `kernel_module/legion-laptop.c` | ~700 | ~156 |
| `python/legion_linux/legion_linux/legion.py` | ~52 | ~9 |
| `python/legion_linux/legion_linux/legion_gui.py` | ~56 | ~9 |

## Commit History (Newest → Oldest)

- `27c2b40` — driver: fix temperature register offsets, add 10-level fan curve support, expose fan speed unit
- `e3ed267` — driver: unify ACCESS_METHOD_NO_ACCESS semantics for powerlimit/OC
- `8b2f1d6` — Fix probe log typo: replace "WMB5" with "WMI3"
- `4d5b028` — Roll back gpu_ppab/gpu_temperature upper limits
- `ff1cb13` — Add LPCN62WW (Legion R9000P 2023 / 82WM) support

---

## I. Kernel Module (`kernel_module/legion-laptop.c`)

### 1. New `model_config` Fields (Each Model Configuration Can Be Specified Independently)

The following fields have been added to `struct model_config`:

```c
enum access_method access_method_cpu_powerlimit; // Access method for CPU power limit
enum access_method access_method_gpu_powerlimit; // Access method for GPU power limit
enum access_method access_method_gpu_oc;         // Access method for GPU overclocking status
bool has_advanced_power_features;                // Whether advanced power features are supported (LPCN62WW only)
bool fancurve_wmi_10level;                       // Whether fan curve uses 0-10 levels (instead of 0-100%)
```

All existing models have been updated with these three `access_method_*` fields, all set to `ACCESS_METHOD_WMI` (preserving original behavior).

2. New Model: `model_lpcn62ww` (Legion R9000P 2023 / BIOS: LPCN62WW / Product Model: 82WM)

This is the most significant addition of this change, specifically tailored for the Lenovo Legion R9000P 2023 (82WM):

- `access_method_fanspeed` / `temperature` / `fancurve` → `ACCESS_METHOD_WMI3` (using OtherMethodFeature)
- `access_method_cpu_powerlimit` / `gpu_powerlimit` → `ACCESS_METHOD_WMI3`
- `access_method_gpu_oc` → `ACCESS_METHOD_WMI2` (using Gamezone WMAA, Method IDs `0x32`/`0x33`)
- `has_advanced_power_features = true`
- `fancurve_wmi_10level = true`

In `legion_add()`, runtime matching is performed via the DMI triplet (`LENOVO` + `82WM` + `LPCN62WW`), automatically switching to this dedicated configuration.

3. Fixed Temperature Register Addresses

Temperature register addresses in all register tables (`v0`, `v1`, `ideapad_v0/v1`, `loq_v0`, etc.) have been corrected:

Field	Old Address	New Address	
`EXT_CPU_TEMP_INPUT`	`0xC538`	`0xC5E6`	
`EXT_GPU_TEMP_INPUT`	`0xC539`	`0xC5E7`	
`EXT_IC_TEMP_INPUT`	`0xC5E8` (already correct)	`0xC5E8` (no change)	

Additionally, hardcoded addresses left over in `ec_read_sensor_values()` have been cleaned up, now using `model->registers->EXT_*`. `ec_read_temperature()` has also been corrected accordingly, with added support for `sensor_id=2` (IC temperature).

4. Power Limits: Unified Multi-Path Access Methods (CPU & GPU)

All of the following power sysfs attributes have been modified to branch based on the corresponding `access_method_*` fields in `model_config`:

CPU Power Limits (`access_method_cpu_powerlimit`):

- `cpu_shortterm_powerlimit`: WMI3 → `OtherMethodFeature_CPU_SHORT_TERM_POWER_LIMIT`
- `cpu_longterm_powerlimit`: WMI3 → `OtherMethodFeature_CPU_LONG_TERM_POWER_LIMIT`
- `cpu_peak_powerlimit`: WMI3 → `OtherMethodFeature_CPU_PEAK_POWER_LIMIT`
- `cpu_cross_loading_powerlimit`: WMI3 → `OtherMethodFeature_CPU_CROSS_LOAD_POWER_LIMIT`
- `cpu_apu_sppt_powerlimit`: Returns `-EOPNOTSUPP` under WMI3 (not supported)

GPU Power Limits (`access_method_gpu_powerlimit`):

- `gpu_ppab_powerlimit`: WMI3 → `OtherMethodFeature_GPU_POWER_BOOST`
- `gpu_ctgp_powerlimit`: WMI3 → `OtherMethodFeature_GPU_cTGP`
- `gpu_ctgp2_powerlimit`: Returns `-EOPNOTSUPP` under WMI3
- `gpu_temperature_limit`: WMI3 → `OtherMethodFeature_GPU_TEMPERATURE_LIMIT`

GPU Overclocking Status (`access_method_gpu_oc`):

- `gpu_oc`: Under WMI2, uses `LEGION_WMI_GAMEZONE_GUID` + Method IDs `0x32`/`0x33` (WMAA path)

To support this, the following generic helper functions have been added:

- `wmi_other_method_set_value()`: Completes the write operation for OtherMethod (previously only read was available)
- `show_wmi_other_feature_attribute()` / `store_wmi_other_feature_attribute()`: Generic sysfs read/write wrappers with scaling parameters

5. New Advanced Power Feature sysfs Attributes (Only for Models with `has_advanced_power_features`)

Three new sysfs attributes have been added, accessible only when `has_advanced_power_features = true`:

Attribute Name	Corresponding OtherMethodFeature	
`cpu_temperature_limit`	`CPU_TEMPERATURE_LIMIT`	
`gpu_total_processor_power_target_on_ac`	`GPU_POWER_TARGET_ON_AC_OFFSET_FROM_BASELINE`	
`gpu_to_cpu_dynamic_boost`	`GPU_TO_CPU_DYNAMIC_BOOST` (new enum value `0x020B0000`)	

6. sysfs Visibility Control (`legion_sysfs_is_visible`)

A new `legion_sysfs_is_visible()` callback has been added to dynamically hide inapplicable attributes:

- `cpu_apu_sppt_powerlimit`: Hidden in WMI3 mode
- `gpu_ctgp2_powerlimit`: Hidden in WMI3 mode
- `cpu_temperature_limit` / `gpu_total_processor_power_target_on_ac` / `gpu_to_cpu_dynamic_boost`: Hidden when `has_advanced_power_features = false`

7. Fan Curve: Dual-Mode Support for 10-Level (0-10) and Percentage (0-100%)

- New `bool fancurve_wmi_10level` field
- On read (`wmi_read_fancurve_custom`): 10-level models multiply by 10 to convert to internal percentage representation
- On write (`wmi_write_fancurve_custom`):
  - 10-level mode: Sets `FSTM=1`, `FSTL=10`, writes percentage rounded and divided by 10 (max 10)
  - Percentage mode: Writes directly (max 100)

Models with `fancurve_wmi_10level = true`: `kwcn`, `g8cn`, `m0cn`, `m1cn`, `lpcn`, `lpcn62ww`

8. Fan Maximum Speed: Dynamically Retrieved by Access Method

`fan_max_show()` has been modified to:

- Return `0` for WMI3 (percentage-based) models (no RPM ceiling concept)
- Query actual maximum speed via WMI for other models, falling back to the `MAX_RPM` constant only on failure

9. New `fan_speed_unit` sysfs Attribute (hwmon)

Exposes a read-only `fan_speed_unit` attribute so userspace can know the unit type of the current fan speed:

- `FAN_SPEED_UNIT_PERCENT = 1`
- `FAN_SPEED_UNIT_PWM = 2`
- `FAN_SPEED_UNIT_RPM_HUNDRED = 3`

10. ACPI Device ID Supplement

`legion_device_ids[]` has added the `VPC2004` entry (preferred match), with `PNP0C09` as fallback:

```c
{ "VPC2004", 0 },
{ "PNP0C09", 0 },
```

---

II. Python Driver Layer (`legion.py`)

1. sysfs Path Auto-Detection (Compatible with VPC2004 and PNP0C09)

Previously hardcoded to `PNP0C09:00`, now changed to runtime auto-detection: first look for `VPC2004:00`, fall back to `PNP0C09:00` if not found.

2. New Power Feature Classes

Class Name	Corresponding sysfs Node	Range	
`CPUTemperatureLimit`	`cpu_temperature_limit`	0–100 °C	
`GPUTotalProcessorPowerTargetOnAC`	`gpu_total_processor_power_target_on_ac`	0–100 W	
`GPUToCPUDynamicBoost`	`gpu_to_cpu_dynamic_boost`	0–80 W	

These three new properties have been registered in `LegionModelFacade`.

3. `FanCurveIO`: Adapted for Percentage-Based Fan Speed

- Added `fan_speed_unit_path = "fan_speed_unit"` and three unit constants
- `_get_speed_unit()` method lazily loads (with caching) the unit exposed by the kernel
- `set_fan_1/2_speed_rpm()` / `get_fan_1/2_speed_rpm()`: When unit is percentage, directly converts via `value * 255 / 100`, no longer using RPM maximum

---

III. GUI Layer (`legion_gui.py`)

Three new controller fields and corresponding `QSpinBox` widgets have been added:

- CPU Temperature Limit [°C] (Row 7)
- Total Processor Power Target on AC [W] (Row 12)
- GPU to CPU Dynamic Boost [W] (Row 13)

Original GPU power control widget row numbers have shifted accordingly (8→11).

Read/write calls for the new controllers have been integrated into `update_power_gui()` / `power_gui_write_to_hw()`.

"Read from HW" / "Apply to HW" buttons have been moved to Row 14 to accommodate the layout adjustment.

---

Summary

This PR primarily achieves the following goals:

1. Support for Legion R9000P 2023 (82WM / LPCN62WW): Added dedicated `model_lpcn62ww`, controlling power/fan via WMI3 (OtherMethodFeature), controlling GPU overclocking via WMI2 (WMAA/Gamezone), with full support for all advanced power features of this model.
2. Fixed temperature sensor register addresses for all models (CPU/GPU addresses changed from `0xC538`/`C539` to `0xC5E6`/`C5E7`).
3. Unified power limit access paths, enabling cross-model scalable multi-path dispatch via `access_method_*` fields.
4. Support for 10-level fan curves, with userspace awareness via the new `fan_speed_unit` sysfs node.
5. Three new advanced power sysfs attributes fully presented in the GUI, visible only to supported models.
6. Dynamic sysfs visibility: Inapplicable attributes are automatically hidden to reduce user confusion.

All the code was written by AI – but hey, I double-checked every line, fixed a few quirks, and now it's ready to party! 🎉 Happy Labor Day! 😄