### PR TITLE
Fix maximunfanspeed

### DIFF
--- a/kernel_module/legion-laptop.c
+++ b/kernel_module/legion-laptop.c
@@ -1788,6 +1788,7 @@ enum OtherMethodFeature {
 
 	OtherMethodFeature_FAN_SPEED_1 = 0x04030001,
 	OtherMethodFeature_FAN_SPEED_2 = 0x04030002,
+	OtherMethodFeature_FAN_FULLSPEED = 0x04020000,
 
 	OtherMethodFeature_C_U1 = 0x05010000,
 	OtherMethodFeature_TEMP_CPU = 0x05040000,
@@ -1808,6 +1809,37 @@ static ssize_t wmi_other_method_get_value(enum OtherMethodFeature feature_id,
 			     WMI_METHOD_ID_GET_FEATURE_VALUE, &params, &res);
 	if (!error)
 		*value = res;
+	return error;
+}
+
+static ssize_t wmi_other_method_set_value(enum OtherMethodFeature feature_id, int value, int *output)
+{
+	struct acpi_buffer params;
+	int error;
+	unsigned long val;
+	unsigned long res;
+  // WMI Call 0x12 (18) struct:
+	//
+	// CreateWordField (Arg2, Zero, TYP1)
+	// CreateByteField (Arg2, 0x02, FEA1)
+	// CreateByteField (Arg2, 0x03, DEV1)
+	// CreateDWordField (Arg2, 0x04, DAT1)
+	//
+	//OtherMethodFeature_FAN_FULLSPEED = 0x04020000,
+	// TYP0 = 0x0000
+	// FEA0 = 0x02
+	// DEV0 = 0x04
+	// DAT1 = 0xXXXXXXXX = parameter to add
+	// val = OtherMethodXX + Param = 0x4020000 | (DAT1 << 32)
+	val = (unsigned long)feature_id | ((unsigned long)(u32)value << 32);
+	params.length = sizeof(val);
+	params.pointer = &val;
+	error = wmi_exec_int(LEGION_WMI_LENOVO_OTHER_METHOD_GUID, 0,
+					WMI_METHOD_ID_SET_FEATURE_VALUE, &params, &res);
+	if (error)
+		pr_info("Error calling WMI Other Method Set Value: %d\n", error);
+	else
+		*output = res;
 	return error;
 }
 
@@ -3495,6 +3527,25 @@ static ssize_t wmi_write_fanfullspeed(struct legion_private *priv, bool state)
 					1, state);
 }
 
+static int wmi_read_fanfullspeed_other(struct legion_private *priv, bool *state)
+{
+	int err;
+	int res;
+
+	err = wmi_other_method_get_value(OtherMethodFeature_FAN_FULLSPEED, &res);
+	if (!err)
+		*state = (res != 0); // ON
+	return err;
+}
+
+static int wmi_write_fanfullspeed_other(struct legion_private *priv, bool state)
+{
+	int res;
+	int value = (state)?1:0;
+
+	return wmi_other_method_set_value(OtherMethodFeature_FAN_FULLSPEED, value, &res);
+}
+
 static ssize_t read_fanfullspeed(struct legion_private *priv, bool *state)
 {
 	// TODO: use enums or function pointers?
@@ -3503,6 +3554,8 @@ static ssize_t read_fanfullspeed(struct legion_private *priv, bool *state)
 		return ec_read_fanfullspeed(&priv->ecram, priv->conf, state);
 	case ACCESS_METHOD_WMI:
 		return wmi_read_fanfullspeed(priv, state);
+	case ACCESS_METHOD_WMI3:
+		return wmi_read_fanfullspeed_other(priv, state);
 	default:
 		pr_info("No access method for fan full speed: %d\n",
 			priv->conf->access_method_fanfullspeed);
@@ -3520,6 +3573,8 @@ static ssize_t write_fanfullspeed(struct legion_private *priv, bool state)
 		return res;
 	case ACCESS_METHOD_WMI:
 		return wmi_write_fanfullspeed(priv, state);
+	case ACCESS_METHOD_WMI3:
+		return wmi_write_fanfullspeed_other(priv, state);
 	default:
 		pr_info("No access method for fan full speed: %d\n",
 			priv->conf->access_method_fanfullspeed);

--- a/kernel_module/legion-laptop.c
+++ b/kernel_module/legion-laptop.c
@@ -5727,65 +5727,6 @@ error:
 
 static SENSOR_DEVICE_ATTR_RW(minifancurve, minifancurve, 0);
 
-static ssize_t pwm1_mode_show(struct device *dev,
-			      struct device_attribute *devattr, char *buf)
-{
-	bool value;
-	int err;
-	struct legion_private *priv = dev_get_drvdata(dev);
-
-	mutex_lock(&priv->fancurve_mutex);
-	err = ec_read_fanfullspeed(&priv->ecram, priv->conf, &value);
-	if (err) {
-		err = -1;
-		pr_info("Failed to pwm1_mode/maximumfanspeed\n");
-		goto error_unlock;
-	}
-	mutex_unlock(&priv->fancurve_mutex);
-	return sprintf(buf, "%d\n", value ? 0 : 2);
-
-error_unlock:
-	mutex_unlock(&priv->fancurve_mutex);
-	return -1;
-}
-
-// TODO: remove? or use WMI method?
-static ssize_t pwm1_mode_store(struct device *dev,
-			       struct device_attribute *devattr,
-			       const char *buf, size_t count)
-{
-	int value;
-	int is_maximumfanspeed;
-	int err;
-	struct legion_private *priv = dev_get_drvdata(dev);
-
-	err = kstrtoint(buf, 0, &value);
-	if (err) {
-		err = -1;
-		pr_info("Parsing hwmon store failed: error:%d\n", err);
-		goto error;
-	}
-	is_maximumfanspeed = value == 0;
-
-	mutex_lock(&priv->fancurve_mutex);
-	err = ec_write_fanfullspeed(&priv->ecram, priv->conf,
-				    is_maximumfanspeed);
-	if (err) {
-		err = -1;
-		pr_info("Failed to write pwm1_mode/maximumfanspeed\n");
-		goto error_unlock;
-	}
-	mutex_unlock(&priv->fancurve_mutex);
-	return count;
-
-error_unlock:
-	mutex_unlock(&priv->fancurve_mutex);
-error:
-	return err;
-}
-
-static SENSOR_DEVICE_ATTR_RW(pwm1_mode, pwm1_mode, 0);
-
 static struct attribute *fancurve_hwmon_attributes[] = {
 	&sensor_dev_attr_fan1_max.dev_attr.attr,
 	&sensor_dev_attr_fan2_max.dev_attr.attr,
@@ -5892,7 +5833,7 @@ static struct attribute *fancurve_hwmon_attributes[] = {
 	//
 	&sensor_dev_attr_auto_points_size.dev_attr.attr,
 	&sensor_dev_attr_minifancurve.dev_attr.attr,
-	&sensor_dev_attr_pwm1_mode.dev_attr.attr, NULL
+	NULL
 };
 
 static umode_t legion_hwmon_is_visible(struct kobject *kobj,


### PR DESCRIPTION
- Removes pwm1_mode from sysfs, was already managed by fan_fullspeed
```
Before : /sys/module/legion_laptop/drivers/platform:legion/PNP0C09:00/hwmon/hwmon?/pwm1_mode
         /sys/module/legion_laptop/drivers/platform:legion/PNP0C09:00/fan_fullspeed
After  : /sys/module/legion_laptop/drivers/platform:legion/PNP0C09:00/fan_fullspeed
```

```bash 
$ sensors legion_hwmon-isa-0000
legion_hwmon-isa-0000
Adapter: ISA adapter
Fan 1:           1900 RPM  (max = 10000 RPM)
Fan 2:           1900 RPM  (max = 10000 RPM)
CPU Temperature:  +49.0°C
GPU Temperature:  +45.0°C
IC Temperature:    +0.0°C
```

- Adds WMI Other Method calls for FanFullSpeed for ACCESS_METHOD_WMI3.

```
- from dsdt :
-- Get
If ((DEV0 == 0x04))
{
 ...

    If ((FEA0 == 0x02))
    {
        Return (\_SB.PC00.LPCB.EC0.FFON)
    }
...

-- Set
If ((DEV1 == 0x04))
{
...
    If ((FEA1 == 0x02))
    {
        If ((ToInteger (DAT1) == One))
        {
            \_SB.PC00.LPCB.EC0.FFON = One
        }
        Else
        {
            \_SB.PC00.LPCB.EC0.FFON = Zero
        }
    }
...
```
