### PR TITLE
legion-laptop: guard PLATFORM_PROFILE_{CUSTOM,MAX_POWER} by kernel version (fix build on <6.10)

### DIFF
--- a/kernel_module/legion-laptop.c
+++ b/kernel_module/legion-laptop.c
@@ -2076,7 +2076,7 @@ static ssize_t ecram_memoryio_read(const struct ecram_memoryio *ec_memoryio,
  * Return status because of commong signature for alle
  * methods to access EC RAM.
  */
-static ssize_t ecram_memoryio_write(const struct ecram_memoryio *ec_memoryio,
+static __maybe_unused ssize_t ecram_memoryio_write(const struct ecram_memoryio *ec_memoryio,
 				    u16 ec_offset, u8 value)
 {
 	if (ec_offset < ec_memoryio->physical_ec_start) {
@@ -5249,9 +5249,11 @@ static int legion_platform_profile_get(struct platform_profile_handler *pprof,
 	case LEGION_WMI_POWERMODE_LOW_POWER:
 		*profile = PLATFORM_PROFILE_LOW_POWER;
 		break;
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 10, 0)
 	case LEGION_WMI_POWERMODE_CUSTOM:
 		*profile = PLATFORM_PROFILE_CUSTOM;
 		break;
+#endif
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 19, 0)
 	case LEGION_WMI_POWERMODE_MAX_POWER:
 		*profile = PLATFORM_PROFILE_MAX_POWER;
@@ -5290,9 +5292,11 @@ static int legion_platform_profile_set(struct platform_profile_handler *pprof,
 	case PLATFORM_PROFILE_LOW_POWER:
 		powermode = LEGION_WMI_POWERMODE_LOW_POWER;
 		break;
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 10, 0)
 	case PLATFORM_PROFILE_CUSTOM:
 		powermode = LEGION_WMI_POWERMODE_CUSTOM;
 		break;
+#endif
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 19, 0)
 	case PLATFORM_PROFILE_MAX_POWER:
 		powermode = LEGION_WMI_POWERMODE_MAX_POWER;
@@ -5315,8 +5319,10 @@ static int legion_platform_profile_probe(void *drvdata, unsigned long *choices)
 	set_bit(PLATFORM_PROFILE_LOW_POWER, choices);
 	set_bit(PLATFORM_PROFILE_BALANCED, choices);
 	set_bit(PLATFORM_PROFILE_PERFORMANCE, choices);
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 10, 0)
 	if (conf_has_custom_powermode && conf_access_method_powermode == ACCESS_METHOD_WMI)
 		set_bit(PLATFORM_PROFILE_CUSTOM, choices);
+#endif
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 19, 0)
 	if (conf_has_extreme_powermode && conf_access_method_powermode == ACCESS_METHOD_WMI)
 		set_bit(PLATFORM_PROFILE_MAX_POWER, choices);
@@ -5358,16 +5364,20 @@ static int legion_platform_profile_init(struct legion_private *priv)
 		priv->platform_profile_handler.choices);
 	set_bit(PLATFORM_PROFILE_PERFORMANCE,
 		priv->platform_profile_handler.choices);
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 10, 0)
 	if (priv->conf->has_custom_powermode &&
 	    priv->conf->access_method_powermode == ACCESS_METHOD_WMI) {
 		set_bit(PLATFORM_PROFILE_CUSTOM,
 			priv->platform_profile_handler.choices);
 	}
+#endif
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 19, 0)
 	if (priv->conf->has_extreme_powermode &&
 	    priv->conf->access_method_powermode == ACCESS_METHOD_WMI) {
 		set_bit(PLATFORM_PROFILE_MAX_POWER,
 			priv->platform_profile_handler.choices);
 	}
+#endif
 #endif
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 14, 0)


### PR DESCRIPTION
## Summary

Currently `main` does not compile on Linux kernels older than 6.10 because several uses of `PLATFORM_PROFILE_CUSTOM` and `PLATFORM_PROFILE_MAX_POWER` lack the `#if LINUX_VERSION_CODE >= KERNEL_VERSION(...)` guard that other call sites already have.

These two enum values were introduced upstream:

| Symbol | Introduced in |
|---|---|
| `PLATFORM_PROFILE_CUSTOM` | v6.10 |
| `PLATFORM_PROFILE_MAX_POWER` | v6.19 |

On Ubuntu 22.04 LTS / kernel **6.8.0-110-generic** (the most common Long-Term Support combination right now), `make` from a pristine `main` fails with:

```
error: 'PLATFORM_PROFILE_CUSTOM' undeclared (first use in this function); did you mean 'PLATFORM_PROFILE_LAST'?
error: 'PLATFORM_PROFILE_MAX_POWER' undeclared (first use in this function); did you mean 'PLATFORM_PROFILE_LAST'?
```

This breaks DKMS install for everyone on that kernel range and blocks dependent PRs (e.g. #443) from running clean CI.

## Fix

Wraps every reference to the two symbols in the guard pattern already used at lines 5255 (`*profile = PLATFORM_PROFILE_MAX_POWER`) and 5298 (`case PLATFORM_PROFILE_MAX_POWER`):

```c
#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 10, 0)
    /* PLATFORM_PROFILE_CUSTOM use */
#endif
#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 19, 0)
    /* PLATFORM_PROFILE_MAX_POWER use */
#endif
```

Three sites for `_CUSTOM` (the WMI→profile mapper, the profile→WMI mapper, and two `set_bit()` calls in the choices initializer) and one site for `_MAX_POWER` (a `set_bit()` in the pre-6.14 `legion_platform_profile_init` branch that was previously sitting outside any guard at all).

Also marks `ecram_memoryio_write` as `__maybe_unused` — the function currently has no in-tree caller and triggers `-Werror=unused-function` under the kernel build's default flags, which then masks any other compile error in the surrounding hunks.

**No logic change on kernels >= 6.19**, where every new `#if` evaluates true and every guard is a no-op.

## Verification

```bash
$ uname -r
6.8.0-110-generic
$ cd kernel_module && make
...
  CC [M]  /tmp/lll-fix/kernel_module/legion-laptop.o
  MODPOST /tmp/lll-fix/kernel_module/Module.symvers
  CC [M]  /tmp/lll-fix/kernel_module/legion-laptop.mod.o
  LD [M]  /tmp/lll-fix/kernel_module/legion-laptop.ko
  BTF [M] /tmp/lll-fix/kernel_module/legion-laptop.ko
$ echo $?
0
```

Diff: **+11 / -1 lines**, kernel module only, no Python or doc changes.

## Why send this separately

PR #443 (fan_unlock for KWCN54WW) is the meaningful feature work. This is just a build-fix prerequisite that any other contributor on Ubuntu 22.04 / Debian stable / RHEL 9-derived distros would need to land first. Splitting them keeps both reviewable as small focused changes — the feature PR can rebase on top of this once merged, or this one can land standalone since it's strictly correctness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)