### PR TITLE
platform_profile: expose balanced-performance as alias for custom

### DIFF
--- a/kernel_module/legion-laptop.c
+++ b/kernel_module/legion-laptop.c
@@ -5338,6 +5338,11 @@ static int legion_platform_profile_set(struct platform_profile_handler *pprof,
 		powermode = LEGION_WMI_POWERMODE_LOW_POWER;
 		break;
 	case PLATFORM_PROFILE_CUSTOM:
+	case PLATFORM_PROFILE_BALANCED_PERFORMANCE:
+		/* Accept both names: "custom" (matches lenovo-wmi-gamezone) and
+		 * "balanced-performance" (the kernel's standard naming used by
+		 * TLP, power-profiles-daemon, and pre-existing user scripts).
+		 */
 		powermode = LEGION_WMI_POWERMODE_CUSTOM;
 		break;
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 19, 0)
@@ -5362,8 +5367,12 @@ static int legion_platform_profile_probe(void *drvdata, unsigned long *choices)
 	set_bit(PLATFORM_PROFILE_LOW_POWER, choices);
 	set_bit(PLATFORM_PROFILE_BALANCED, choices);
 	set_bit(PLATFORM_PROFILE_PERFORMANCE, choices);
-	if (conf_has_custom_powermode && conf_access_method_powermode == ACCESS_METHOD_WMI)
+	if (conf_has_custom_powermode && conf_access_method_powermode == ACCESS_METHOD_WMI) {
 		set_bit(PLATFORM_PROFILE_CUSTOM, choices);
+		/* Expose "balanced-performance" as an alias so userspace tools
+		 * that pre-date the rename to "custom" keep working unchanged. */
+		set_bit(PLATFORM_PROFILE_BALANCED_PERFORMANCE, choices);
+	}
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 19, 0)
 	if (conf_has_extreme_powermode && conf_access_method_powermode == ACCESS_METHOD_WMI)
 		set_bit(PLATFORM_PROFILE_MAX_POWER, choices);
@@ -5408,6 +5417,10 @@ static int legion_platform_profile_init(struct legion_private *priv)
 	if (priv->conf->has_custom_powermode &&
 	    priv->conf->access_method_powermode == ACCESS_METHOD_WMI) {
 		set_bit(PLATFORM_PROFILE_CUSTOM,
+			priv->platform_profile_handler.choices);
+		/* Expose "balanced-performance" as an alias so userspace tools
+		 * that pre-date the rename to "custom" keep working unchanged. */
+		set_bit(PLATFORM_PROFILE_BALANCED_PERFORMANCE,
 			priv->platform_profile_handler.choices);
 	}
 	if (priv->conf->has_extreme_powermode &&


### PR DESCRIPTION
## Summary

Commit 271707f renamed the fourth Legion power mode from `PLATFORM_PROFILE_BALANCED_PERFORMANCE` to `PLATFORM_PROFILE_CUSTOM` to align with `lenovo-wmi-gamezone`'s naming scheme. While this matches Lenovo's official tooling, it silently broke a set of pre-existing userspace tools and configurations that referenced the kernel's standard `balanced-performance` name — most notably:

- **TLP** — its documentation in `/usr/share/tlp/defaults.conf` lists `balanced-performance` as an example value and many existing `/etc/tlp.conf` files were configured with `PLATFORM_PROFILE_ON_AC=balanced-performance`. Those configs now silently fail on the new driver.
- **power-profiles-daemon** and GNOME UI flows that target the standard kernel profile names.
- User scripts, autostart entries, and muscle memory.

This PR exposes **both** names simultaneously, so the new naming alignment with `lenovo-wmi-gamezone` is preserved and backward-compatible userspace tooling keeps working.

## Changes

Purely additive — no behavior change for existing callers using `custom`.

- **`choices`** (both new probe-callback API and legacy API): set bits for both `PLATFORM_PROFILE_CUSTOM` *and* `PLATFORM_PROFILE_BALANCED_PERFORMANCE`. Both names appear in `/sys/class/platform-profile/platform-profile-0/choices` and both are writable.
- **`legion_platform_profile_set()`**: accepts both enums via fallthrough; both map to `LEGION_WMI_POWERMODE_CUSTOM`. Hardware state is identical regardless of which name was used.
- **`legion_platform_profile_get()`**: unchanged. Reads always return `PLATFORM_PROFILE_CUSTOM`, so `lenovo-wmi-gamezone` and Lenovo Vantage see the canonical name.

## Test plan

Tested on Lenovo LOQ 15IRH8 (LZCN BIOS), Linux 7.0.9 with LenovoLegionLinux master HEAD + this patch applied:

- [x] `cat /sys/class/platform-profile/platform-profile-0/choices` shows both `balanced-performance` and `custom` in the list
- [x] `echo custom > .../profile` works; subsequent read returns `custom`
- [x] `echo balanced-performance > .../profile` works; subsequent read returns `custom` (canonical)
- [x] TLP with `PLATFORM_PROFILE_ON_AC=balanced-performance` correctly switches the LED indicator on plug-in
- [x] AC plug/unplug cycle still drives mode switching via the legion driver's virtual platform device