### PR TITLE
Add Spectrum RGB support via direct USB HID

### DIFF
--- a/python/legion_linux/legion_linux/legion.py
+++ b/python/legion_linux/legion_linux/legion.py
@@ -1,6 +1,8 @@
 # pylint: disable=too-many-lines
 import os
 import glob
+import ctypes
+import fcntl
 from dataclasses import asdict, dataclass
 import shutil
 import time
@@ -627,6 +629,157 @@ class YLogoLight(BoolFileFeature):
 class IOPortLight(BoolFileFeature):
     def __init__(self):
         super().__init__("/sys/class/leds/platform::ioport/brightness")
+
+
+class _USBCtrlTransfer(ctypes.Structure):
+    _fields_ = [
+        ('bRequestType', ctypes.c_uint8),
+        ('bRequest', ctypes.c_uint8),
+        ('wValue', ctypes.c_uint16),
+        ('wIndex', ctypes.c_uint16),
+        ('wLength', ctypes.c_uint16),
+        ('timeout', ctypes.c_uint32),
+        ('data', ctypes.c_void_p),
+    ]
+
+
+class SpectrumRGB:
+    USBDEVFS_CONTROL = (3 << 30) | (ord('U') << 8) | 0 | (ctypes.sizeof(_USBCtrlTransfer) << 16)
+    HIDRAW_GLOB = '/sys/class/hidraw/hidraw*/device/uevent'
+
+    def __init__(self):
+        self._fd = None
+        self._device_path = None
+
+    def _find_device(self):
+        candidates = []
+        for uevent in glob.glob(self.HIDRAW_GLOB):
+            try:
+                with open(uevent) as f:
+                    content = f.read()
+                if 'HID_ID=0003:0000048D:' not in content:
+                    continue
+                # Check report descriptor size — the keyboard RGB controller
+                # has a simple feature-report-only HID (~25 bytes), other ITE
+                # devices (touchpad etc.) have much longer descriptors.
+                rep_desc = os.path.join(os.path.dirname(uevent), 'report_descriptor')
+                if os.path.exists(rep_desc):
+                    with open(rep_desc, 'rb') as f:
+                        desc_len = len(f.read())
+                    if desc_len > 40:
+                        continue
+                hidraw_dir = os.path.dirname(uevent)
+                candidates.append(hidraw_dir)
+            except Exception:
+                continue
+
+        if not candidates:
+            return None
+
+        # For each candidate, find the corresponding USB device path
+        for cand in candidates:
+            try:
+                real = os.path.realpath(cand)
+            except OSError:
+                continue
+            # Walk the resolved path to find the USB device (e.g. 'usb3/3-3')
+            # real looks like: /sys/devices/pci.../usb3/3-3/3-3:1.1/...
+            parts = real.strip('/').split('/')
+            usb_sys = None
+            for i, part in enumerate(parts):
+                if part.startswith('usb') and '-' not in part:
+                    if i + 1 < len(parts):
+                        usb_sys = '/' + '/'.join(parts[:i+2])
+                    break
+            if usb_sys is None:
+                continue
+            try:
+                with open(os.path.join(usb_sys, 'busnum')) as f:
+                    busnum = int(f.read().strip())
+                with open(os.path.join(usb_sys, 'devnum')) as f:
+                    devnum = int(f.read().strip())
+            except Exception:
+                continue
+            usb_dev = f'/dev/bus/usb/{busnum:03d}/{devnum:03d}'
+            if os.path.exists(usb_dev):
+                return usb_dev
+        return None
+
+    def is_available(self):
+        return self._find_device() is not None
+
+    def _send_report(self, data: bytes):
+        if self._fd is None:
+            path = self._find_device()
+            if path is None:
+                return False, "ITE keyboard not found"
+            try:
+                self._fd = os.open(path, os.O_RDWR)
+            except OSError as e:
+                self._fd = None
+                return False, str(e)
+        try:
+            buf = ctypes.create_string_buffer(data)
+            ctrl = _USBCtrlTransfer(
+                bRequestType=0x21,
+                bRequest=0x09,
+                wValue=0x03CC,
+                wIndex=0x0000,
+                wLength=len(data),
+                timeout=5000,
+                data=ctypes.cast(buf, ctypes.c_void_p).value,
+            )
+            fcntl.ioctl(self._fd, self.USBDEVFS_CONTROL, ctrl)
+            return True, None
+        except Exception as e:
+            return False, str(e)
+
+    def _build_report(self, effect, speed=1, brightness=2,
+                      colors=None, wave_ltr=0, wave_rtl=0):
+        buf = bytearray(32)
+        buf[0] = 0xCC
+        buf[1] = 0x16
+        buf[2] = effect
+        buf[3] = speed & 0xFF
+        buf[4] = brightness & 0xFF
+        if colors:
+            for i in range(min(4, len(colors))):
+                c = colors[i].lstrip('#')
+                r, g, b = bytes.fromhex(c[:2] + c[2:4] + c[4:6])
+                buf[5 + i * 3] = r
+                buf[6 + i * 3] = g
+                buf[7 + i * 3] = b
+        buf[18] = wave_rtl & 0xFF
+        buf[19] = wave_ltr & 0xFF
+        return bytes(buf)
+
+    def set_static(self, colors, brightness=2):
+        data = self._build_report(0x01, colors=colors, brightness=brightness)
+        return self._send_report(data)
+
+    def set_breath(self, colors, speed=2, brightness=2):
+        data = self._build_report(0x03, speed=speed, colors=colors, brightness=brightness)
+        return self._send_report(data)
+
+    def set_wave(self, direction="ltr", speed=2, brightness=2):
+        ltr = 1 if direction == "ltr" else 0
+        rtl = 1 if direction == "rtl" else 0
+        data = self._build_report(0x04, speed=speed, brightness=brightness,
+                                  wave_ltr=ltr, wave_rtl=rtl)
+        return self._send_report(data)
+
+    def set_hue(self, speed=2, brightness=2):
+        data = self._build_report(0x06, speed=speed, brightness=brightness)
+        return self._send_report(data)
+
+    def turn_off(self):
+        data = self._build_report(0x01, colors=["#000000"] * 4)
+        return self._send_report(data)
+
+    def close(self):
+        if self._fd is not None:
+            os.close(self._fd)
+            self._fd = None
 
 
 class NVIDIAGPUIsRunning(BoolFileFeature):
@@ -1441,6 +1594,7 @@ class LegionModelFacade:
         # light
         self.ylogo_light = YLogoLight()
         self.ioport_light = IOPortLight()
+        self.spectrum_rgb = SpectrumRGB()
 
         # services
         self.power_profiles_deamon_service = PowerProfilesDeamonService()

--- a/python/legion_linux/legion_linux/legion_gui.py
+++ b/python/legion_linux/legion_linux/legion_gui.py
@@ -14,7 +14,8 @@ from PyQt6.QtCore import Qt, QTimer, pyqtSlot, QRunnable, QThreadPool
 from PyQt6.QtGui import QAction, QGuiApplication
 from PyQt6.QtWidgets import QApplication, QMainWindow, QTabWidget, QWidget, QLabel, \
     QVBoxLayout, QGridLayout, QLineEdit, QPushButton, QComboBox, QGroupBox, \
-    QCheckBox, QSystemTrayIcon, QMenu, QScrollArea, QMessageBox, QSpinBox, QTextBrowser, QHBoxLayout, QFileDialog
+    QCheckBox, QSystemTrayIcon, QMenu, QScrollArea, QMessageBox, QSpinBox, \
+    QTextBrowser, QHBoxLayout, QFileDialog, QColorDialog
 # Make it possible to run without installation
 # pylint: disable=# pylint: disable=wrong-import-position
 sys.path.insert(0, os.path.dirname(__file__) + "/..")
@@ -1328,6 +1329,123 @@ class OtherOptionsTab(QWidget):
         self.power_all_layout.addWidget(self.power_note_label)
 
 
+class KeyboardTab(QWidget):
+    def __init__(self, controller: LegionController):
+        super().__init__()
+        self.controller = controller
+        self.init_ui()
+
+    def init_ui(self):
+        self.rgb_group = QGroupBox("Spectrum RGB")
+        self.rgb_layout = QVBoxLayout()
+        self.rgb_group.setLayout(self.rgb_layout)
+
+        self.rgb_mode = QComboBox()
+        self.rgb_mode.addItems(["Off", "Static", "Breath", "Wave", "Hue"])
+        self.rgb_brightness = QComboBox()
+        self.rgb_brightness.addItems(["Low", "High"])
+
+        mode_row = QHBoxLayout()
+        mode_row.addWidget(QLabel("Mode:"))
+        mode_row.addWidget(self.rgb_mode)
+        mode_row.addWidget(QLabel("Brightness:"))
+        mode_row.addWidget(self.rgb_brightness)
+        mode_row.addStretch()
+        self.rgb_layout.addLayout(mode_row)
+
+        self.rgb_color_btns = []
+        self.rgb_color_labels = ["#ff0000", "#00ff00", "#0000ff", "#ffffff"]
+        color_row = QHBoxLayout()
+        for i in range(4):
+            btn = QPushButton(f"Zone {i+1}")
+            btn.setStyleSheet(f"background-color: {self.rgb_color_labels[i]}; min-width: 50px;")
+            btn.clicked.connect(lambda checked, idx=i: self._pick_rgb_color(idx))
+            self.rgb_color_btns.append(btn)
+            color_row.addWidget(btn)
+        color_row.addStretch()
+        self.rgb_layout.addLayout(color_row)
+        self._update_rgb_color_visibility()
+
+        extra_row = QHBoxLayout()
+        self.rgb_speed_label = QLabel("Speed (1-4):")
+        self.rgb_speed = QSpinBox()
+        self.rgb_speed.setMinimum(1)
+        self.rgb_speed.setMaximum(4)
+        self.rgb_speed.setValue(2)
+        extra_row.addWidget(self.rgb_speed_label)
+        extra_row.addWidget(self.rgb_speed)
+        self.rgb_dir_label = QLabel("Direction:")
+        self.rgb_direction = QComboBox()
+        self.rgb_direction.addItems(["Left", "Right"])
+        extra_row.addWidget(self.rgb_dir_label)
+        extra_row.addWidget(self.rgb_direction)
+        extra_row.addStretch()
+        self.rgb_layout.addLayout(extra_row)
+
+        self.rgb_apply = QPushButton("Apply")
+        self.rgb_apply.clicked.connect(self._apply_rgb)
+        self.rgb_layout.addWidget(self.rgb_apply)
+
+        self.rgb_status = QLabel("")
+        self.rgb_layout.addWidget(self.rgb_status)
+
+        self.rgb_mode.currentTextChanged.connect(self._on_rgb_mode_changed)
+        self._on_rgb_mode_changed(self.rgb_mode.currentText())
+
+        self.main_layout = QVBoxLayout()
+        self.main_layout.addWidget(self.rgb_group)
+        self.main_layout.addStretch()
+        self.setLayout(self.main_layout)
+
+    def _update_rgb_color_visibility(self):
+        mode = self.rgb_mode.currentText()
+        visible = mode in ("Static", "Breath")
+        for btn in self.rgb_color_btns:
+            btn.setVisible(visible)
+
+    def _on_rgb_mode_changed(self, mode):
+        is_speed = mode in ("Breath", "Wave", "Hue")
+        is_direction = mode == "Wave"
+        self.rgb_speed_label.setVisible(is_speed)
+        self.rgb_speed.setVisible(is_speed)
+        self.rgb_dir_label.setVisible(is_direction)
+        self.rgb_direction.setVisible(is_direction)
+        self._update_rgb_color_visibility()
+
+    def _pick_rgb_color(self, idx):
+        color = QColorDialog.getColor()
+        if color.isValid():
+            self.rgb_color_labels[idx] = color.name()
+            self.rgb_color_btns[idx].setStyleSheet(
+                f"background-color: {color.name()}; min-width: 50px;")
+
+    def _apply_rgb(self):
+        mode = self.rgb_mode.currentText()
+        brightness = 2 if self.rgb_brightness.currentIndex() else 1
+        speed = self.rgb_speed.value()
+        direction = "ltr" if self.rgb_direction.currentText() == "Left" else "rtl"
+        colors = self.rgb_color_labels[:4]
+
+        ok, err = None, "not available"
+        if mode == "Off":
+            ok, err = self.controller.model.spectrum_rgb.turn_off()
+        elif mode == "Static":
+            ok, err = self.controller.model.spectrum_rgb.set_static(colors, brightness)
+        elif mode == "Breath":
+            ok, err = self.controller.model.spectrum_rgb.set_breath(colors, speed, brightness)
+        elif mode == "Wave":
+            ok, err = self.controller.model.spectrum_rgb.set_wave(direction, speed, brightness)
+        elif mode == "Hue":
+            ok, err = self.controller.model.spectrum_rgb.set_hue(speed, brightness)
+
+        if ok:
+            self.rgb_status.setText("Applied successfully")
+            self.rgb_status.setStyleSheet("color: green;")
+        else:
+            self.rgb_status.setText(f"Error: {err}")
+            self.rgb_status.setStyleSheet("color: red;")
+
+
 class AutomationTab(QWidget):
     def __init__(self, controller: LegionController):
         super().__init__()
@@ -1441,6 +1559,7 @@ class Tabs(QTabWidget):
         self.tabs = (
             ("Fan Curve", FanCurveTab(controller)),
             ("Other Options", OtherOptionsTab(controller)),
+            ("Keyboard", KeyboardTab(controller)),
             ("Automation", AutomationTab(controller)),
             ("Log", LogTab(controller)),
             ("About", AboutTab(controller))


### PR DESCRIPTION
Adds a new **Keyboard** tab to the GUI with full Spectrum RGB control for 4-zone ITE keyboard controllers (048d:c965 etc.).

### Model (legion.py)
- New `SpectrumRGB` class communicating directly via USB HID feature reports (32-byte protocol)
- No external dependencies — uses ctypes + fcntl for USB control transfers
- Dynamically discovers the ITE device by scanning HID report descriptors (no hardcoded PID list)
- Supports Static, Breath, Wave, Hue modes + Off
- 4-zone color control, brightness (Low/High), speed, wave direction

### GUI (legion_gui.py)
- New `KeyboardTab` widget added after "Other Options"
- Mode selector, zone color pickers (QColorDialog), speed spinbox, direction dropdown
- Dynamic show/hide of relevant controls based on selected mode
- Apply button with success/error feedback

The device is found at runtime by matching VID 0x048D and filtering by HID report descriptor length (~25 bytes for the RGB controller vs 179+ for other ITE chips).