### PR TITLE
Adds acpi paths for config model_v0.

### DIFF
--- a/kernel_module/legion-laptop.c
+++ b/kernel_module/legion-laptop.c
@@ -477,6 +477,8 @@ static const struct model_config model_v0 = {
 	.ramio_physical_start = 0xFE00D400,
 	.ramio_size = 0x600,
 	.acpi_paths = {
+		[ACPI_PATH_STA] = "\\_SB.PCI0.LPC0.EC0.VPC0._STA",
+		[ACPI_PATH_CFG] = "\\_SB.PCI0.LPC0.EC0.VPC0._CFG",
 		[ACPI_PATH_READ_RAPIDCHARGE] = "\\_SB.PCI0.LPC0.EC0.VPC0.GBMD",
 		[ACPI_PATH_WRITE_RAPIDCHARGE] = "\\_SB.PCI0.LPC0.EC0.VPC0.SBMC"
 	}


### PR DESCRIPTION
This should help the issues created for models (GKCN, EFCN, FSCN, HHCN, H1CN, J2CN, JUCN, G9CN) that cannot load the driver  because their `acpi_check_dev = true` needs the paths `_STA` and `_CFG` at initializing, so they no longer need to use `forcereloadmodule` option.