### PR TITLE
fix: replace GNU long options with POSIX short options for BSD userland compatibility

### DIFF
--- a/kernel_module/Makefile
+++ b/kernel_module/Makefile
@@ -1,5 +1,5 @@
 SHELL := /bin/bash
-KERNELVERSION  ?= $(shell uname --kernel-release)
+KERNELVERSION  ?= $(shell uname -r)
 KSRC := /lib/modules/$(KERNELVERSION)/build
 
 #install dir for kernel drivers
@@ -22,15 +22,15 @@ clean:
 	make -C $(KSRC) M=$(shell pwd) clean
 
 install: all
-	@rm --force --verbose $(INSTALLDIR)/legion-laptop.ko
-	@mkdir --parent --verbose $(MODDESTDIR)
-	@install --preserve-timestamps -D --mode=644 *.ko $(INSTALLDIR)
-	@depmod --all $(KVER)
+	@rm -fv $(INSTALLDIR)/legion-laptop.ko
+	@mkdir -pv $(MODDESTDIR)
+	@install -p -D -m 644 *.ko $(INSTALLDIR)
+	@depmod -a $(KVER)
 	@printf "%s\n" "Installion finished."
 
 uninstall:
 	@rm -f $(INSTALLDIR)/legion-laptop.ko
-	@depmod --all
+	@depmod -a
 	@printf "%s\n" "Uninstall finished."
 
 install_forcereload:
@@ -41,45 +41,45 @@ install_forcereload:
 reloadmodule:
 	rmmod legion-laptop.ko || true
 	insmod legion-laptop.ko
-	dmesg --ctime
+	dmesg
 	bash -c "./issue-warning.sh"
 
 forcereloadmodule:
 	rmmod legion-laptop.ko || true
 	insmod legion-laptop.ko force=1
-	dmesg --ctime
+	dmesg
 	bash -c "./issue-warning.sh"
 
 forcereloadmodulereadonly:
 	rmmod legion-laptop.ko || true
 	insmod legion-laptop.ko force=1 ec_readonly=1
-	dmesg --ctime
+	dmesg
 	bash -c "./issue-warning.sh"
 
 reloadmodule_disableplatformprofile:
 	rmmod legion-laptop.ko || true
 	insmod legion-laptop.ko enable_platformprofile=0
-	dmesg --ctime
+	dmesg
 	bash -c "./issue-warning.sh"
 
 forcereloadmodule_disableplatformprofile:
 	rmmod legion-laptop.ko || true
 	insmod legion-laptop.ko force=1 enable_platformprofile=0
-	dmesg --ctime
+	dmesg
 	bash -c "./issue-warning.sh"
 
 dkms: all
 	if [ -d $(DKMSDIR) ]; then\
-    	rm --recursive $(DKMSDIR)/*;\
-        cp --recursive * $(DKMSDIR)/;\
+    	rm -r $(DKMSDIR)/*;\
+        cp -r * $(DKMSDIR)/;\
 	else \
-		mkdir --verbose $(DKMSDIR);\
-        cp --recursive * $(DKMSDIR);\
+		mkdir -v $(DKMSDIR);\
+        cp -r * $(DKMSDIR);\
 		dkms add -m LenovoLegionLinux -v 1.0.0;\
 	fi
 	dkms build LenovoLegionLinux --force -v 1.0.0
 	dkms install LenovoLegionLinux --force -v 1.0.0
 	printf "%s\n" "Loading module"
 	modprobe legion_laptop
-	dmesg --ctime | grep legion_laptop
+	dmesg | grep legion_laptop
 	bash -c "./issue-warning.sh"

--- a/setmyfancurve.sh
+++ b/setmyfancurve.sh
@@ -7,7 +7,11 @@ echo "BIOS"
 dmidecode -s bios-version
 echo ""
 
-hwmondir=`find /sys/module/legion_laptop/drivers/platform:legion/PNP0C09:00/hwmon -mindepth 1 -name "hwmon*"`
+hwmondir=$(find /sys/class/hwmon -mindepth 1 -maxdepth 1 -name "hwmon*" -exec sh -c 'cat "$1/name" 2>/dev/null | grep -q legion_hwmon && echo "$1"' _ {} \;)
+if [ -z "${hwmondir}" ]; then
+    echo "Error: Could not find legion hwmon directory. Is the legion_laptop module loaded?"
+    exit 1
+fi
 echo "Using hwmon directory: ${hwmondir}" 
 
 # Disable (0) or Enable (1) switching to minifancurve when everything seems very cool


### PR DESCRIPTION
During the installation of this project, I faced some compilation/installation errors under my software/hardware. In this pull request I submit the changes I had to make, which maintain backwards compatibility while enabling broader compatibility with other platforms. 

---

Some Linux distributions (such as Chimera Linux, the one I'm using) use a BSD userland instead of GNU coreutils.
BSD implementations of `uname`, `rm`, `mkdir`, `install`, `depmod`, and `dmesg` do not support GNU-style `--long-options`, causing the build and install targets to fail.

This PR replaces all GNU long options with their POSIX short equivalents, maintaining support for existing GNU platforms while enabling support for BSD userland tools:

**`Makefile`**
```
- uname --kernel-release -> uname -r
- rm --force --verbose -> rm -fv
- mkdir --parent --verbose -> mkdir -pv
- install --preserve-timestamps -D --mode=644 -> install -p -D -m 644
- depmod --all -> depmod -a
- rm --recursive -> rm -r
- mkdir --verbose -> mkdir -v
- cp --recursive -> cp -r
- dmesg --ctime -> dmesg (BSD dmesg does not support human-readable timestamps)
```

---

I also introduced code that searches and matches `legion_hwmon` by name, instead of the previous hardcoded value:

**`setmyfancurve.sh`**
- Replaced the hardcoded `PNP0C09:00` hwmon path with a portable search via `/sys/class/hwmon` that matches by name (legion_hwmon)
  - This makes it work regardless of ACPI device naming differences across systems. As a side effect, this adds an error message if the module isn't loaded, which is nice.

Tested on Chimera Linux (BSD userland, Linux kernel) with a Lenovo Legion 7 16ARHA7.
Existing behavior on GNU/coreutils systems should be unchanged, as all substituted short options are identical in behavior to their current `--long-option` GNU counterparts.