### PR TITLE
Add Lenovo Legion 7 16IAX7 (82TD) to supported models list

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ It allows you to control features like the fan curve, power mode, power limits, 
 - Lenovo Legion 5 17ACH6 (BIOS HHCN31WW): sensors, fan curve, power profile
 - Lenovo Legion 7i 16ITHG6 (BIOS H1CN35WW): sensors, fan curve, power profile
 - Lenovo Legion 7 Pro 16ARX8H (BIOS LPCN47WW): sensors, fan curve, power profile
+- Lenovo Legion 7 16IAX7 (82TD) (BIOS K1CN48WW): sensors, fan curve (write works; WMI readback returns empty buffer), power profile
 
 *Note:* Features that are not confirmed probably also work. They were just not tested.
 

--- a/kernel_module/legion-laptop.c
+++ b/kernel_module/legion-laptop.c
@@ -1336,7 +1336,7 @@ static const struct dmi_system_id optimistic_allowlist[] = {
 		.driver_data = (void *)&model_bhcn
 	},
 	{
-		// e.g. Lenovo 7 16IAX7
+		// e.g. Lenovo Legion 7 16IAX7 (82TD) (BIOS K1CN48WW)
 		.ident = "K1CN",
 		.matches = {
 			DMI_MATCH(DMI_SYS_VENDOR, "LENOVO"),


### PR DESCRIPTION
The K1CN BIOS family (e.g. K1CN48WW) used by the Legion 7 16IAX7 (product 82TD) is already matched by model_k1cn. Expand the DMI comment and add the machine to the README so users know it is confirmed working.

Tested on Ubuntu 26.04 (kernel 7.0.0-27-generic):
- Module auto-loads without force=1
- EC ID 0x5263 matches model_k1cn
- sensors, fan curve write, and power profile work
- WMI fan-curve readback returns an empty buffer (pre-existing)