### PR TITLE
feat: add DMI allowlist entry for LOQ 15ARP9 (PQCN)

### DIFF
--- a/kernel_module/legion-laptop.c
+++ b/kernel_module/legion-laptop.c
@@ -1507,6 +1507,15 @@ static const struct dmi_system_id optimistic_allowlist[] = {
 		.driver_data = (void *)&model_nzcn
 	},
 	{
+		//e.g. LOQ 15ARP9 (83JC, AMD Ryzen 7 7435HS + RTX 4050)
+		.ident = "PQCN",
+		.matches = {
+			DMI_MATCH(DMI_SYS_VENDOR, "LENOVO"),
+			DMI_MATCH(DMI_BIOS_VERSION, "PQCN"),
+		},
+		.driver_data = (void *)&model_nzcn
+	},
+	{
 		// e.g. Legion Pro 5 16IRX9 (83DF)
 		.ident = "N0CN",
 		.matches = {


### PR DESCRIPTION
## Summary

Adds support for the **Lenovo LOQ 15ARP9 (83JC)** — AMD Ryzen 7 7435HS + RTX 4050, via a new DMI allowlist entry reusing the existing `model_nzcn` config (identical EC/WMI implementation, no new struct needed).

## Changes

- DMI allowlist entry matching `LENOVO` vendor + `PQCN` BIOS version
- Reuses existing `model_nzcn` config struct — confirmed byte-for-byte identical to what this hardware requires (EC ID, register map, access methods, ACPI paths, fancurve defaults all match)
- Uses **WMI** for powermode, **WMI3** for temperature/fan speed, **EC** direct access for fan curve read/write — no new access-method code paths introduced

## Hardware Details

| Field | Value |
|---|---|
| Model | LOQ 15ARP9 |
| DMI Product | 83JC |
| BIOS | PQCN |
| EC Chip | 0x8227 |
| CPU | AMD Ryzen 7 7435HS |
| GPU | NVIDIA RTX 4050 |

## Testing

Tested on my own LOQ 15ARP9 (83JC). Confirmed working:
- Sensor reads (CPU/GPU temperature, fan speed) via WMI3
- Fan curve read via EC (`/sys/kernel/debug/legion/fancurve`) — all 10 points populated correctly
- Platform profile switching (`low-power`, `balanced`, `performance`, `custom`) via `/sys/class/platform-profile/platform-profile-0/profile`
- Fan curve writes: writable only in `custom` mode — `balanced`/`performance`/`low-power` correctly reject writes and reload their fixed default curves (expected firmware behavior, not a driver issue)
- Custom-mode writes are session-durable (verified with immediate and delayed reads, no drift) but do **not** survive leaving and re-entering `custom` mode — switching profiles resets to a default curve rather than restoring the last-written values

**Note for future users of this model:** the legacy `/sys/firmware/acpi/platform_profile` path returned `EINVAL` when writing `custom` on this system; writing directly to `/sys/class/platform-profile/platform-profile-0/profile` worked correctly.