### PR TITLE
fix gpu oc and ppab

### DIFF
--- a/kernel_module/legion-laptop.c
+++ b/kernel_module/legion-laptop.c
@@ -934,6 +934,7 @@ static const struct model_config model_lpcn = {
 	.access_method_temperature = ACCESS_METHOD_WMI3,
 	.access_method_fancurve = ACCESS_METHOD_WMI3,
 	.access_method_fanfullspeed = ACCESS_METHOD_WMI,
+	.access_method_powerlimits = ACCESS_METHOD_WMI3,
 	.acpi_check_dev = true,
 	.ramio_physical_start = 0xFE0B0400,
 	.ramio_size = 0x600,

--- a/kernel_module/legion-laptop.c
+++ b/kernel_module/legion-laptop.c
@@ -5316,6 +5316,10 @@ static ssize_t wmi_common_method_other_store(struct legion_private *priv,
 					     const char *buf, size_t count,
 					     int feature_id)
 {
+	// TODO:  use DEV, TYP, FEA, plus Powermode as key to lookup
+	// on capability data CD0, CD1 for :
+	//  - if feature is enabled for laptop model
+	//  - if value (DAT1) is valid (on/off, exact value, step, range)
 	int err, value, output;
 
 	err = kstrtoint(buf, 0, &value);
@@ -5518,29 +5522,17 @@ static ssize_t gpu_oc_show(struct device *dev, struct device_attribute *attr,
 			   char *buf)
 {
 	int err;
-	struct legion_private *priv = dev_get_drvdata(dev);
 
-	switch (priv->conf->access_method_powerlimits) {
-	case ACCESS_METHOD_WMI3:
-		return wmi_common_method_other_show(priv, buf, OtherMethodFeature_GPU_POWER_BOOST);
-	default:
-		err = show_simple_wmi_attribute(dev, attr, buf,
-						WMI_GUID_LENOVO_GPU_METHOD, 0,
-						WMI_METHOD_ID_GPU_GET_OC_STATUS, false,
-						1);
-	}
+	err = show_simple_wmi_attribute(dev, attr, buf,
+					WMI_GUID_LENOVO_GPU_METHOD, 0,
+					WMI_METHOD_ID_GPU_GET_OC_STATUS, false,
+					1);
 	return err;
 }
 
 static ssize_t gpu_oc_store(struct device *dev, struct device_attribute *attr,
 			    const char *buf, size_t count)
 {
-	struct legion_private *priv = dev_get_drvdata(dev);
-
-	if (priv->conf->access_method_powerlimits == ACCESS_METHOD_WMI3)
-		return wmi_common_method_other_store(priv, buf, count,
-						     OtherMethodFeature_GPU_POWER_BOOST);
-
 	return store_simple_wmi_attribute(dev, attr, buf, count,
 					  WMI_GUID_LENOVO_GPU_METHOD, 0,
 					  WMI_METHOD_ID_GPU_SET_OC_STATUS,
@@ -5557,7 +5549,7 @@ static ssize_t gpu_ppab_powerlimit_show(struct device *dev,
 
 	if (priv->conf->access_method_powerlimits == ACCESS_METHOD_WMI3)
 		return wmi_common_method_other_show(priv, buf,
-						    OtherMethodFeature_GPU_POWER_TARGET_ON_AC_OFFSET_FROM_BASELINE);
+						    OtherMethodFeature_GPU_POWER_BOOST);
 
 	return show_simple_wmi_attribute_from_buffer(
 		dev, attr, buf, WMI_GUID_LENOVO_GPU_METHOD, 0,
@@ -5572,7 +5564,7 @@ static ssize_t gpu_ppab_powerlimit_store(struct device *dev,
 
 	if (priv->conf->access_method_powerlimits == ACCESS_METHOD_WMI3)
 		return wmi_common_method_other_store(priv, buf, count,
-						     OtherMethodFeature_GPU_POWER_TARGET_ON_AC_OFFSET_FROM_BASELINE);
+						     OtherMethodFeature_GPU_POWER_BOOST);
 
 	return store_simple_wmi_attribute(dev, attr, buf, count,
 					  WMI_GUID_LENOVO_GPU_METHOD, 0,

--- a/kernel_module/legion-laptop.c
+++ b/kernel_module/legion-laptop.c
@@ -1358,6 +1358,32 @@ static const struct model_config model_s2cn = {
 	.has_fancurve_defaults = true
 };
 
+static const struct model_config model_m3cn = {
+	.registers = &ec_register_offsets_v0,
+	.check_embedded_controller_id = true,
+	.embedded_controller_id = 0x5507,
+	.memoryio_physical_ec_start = 0xC400,
+	.memoryio_size = 0x300,
+	.has_minifancurve = false,
+	.has_custom_powermode = true,
+	.access_method_powermode = ACCESS_METHOD_WMI,
+	.access_method_keyboard = ACCESS_METHOD_WMI,
+	.access_method_fanspeed = ACCESS_METHOD_WMI3,
+	.access_method_temperature = ACCESS_METHOD_WMI3,
+	.access_method_fancurve = ACCESS_METHOD_WMI3,
+	.access_method_fanfullspeed = ACCESS_METHOD_WMI,
+	.acpi_check_dev = true,
+	.ramio_physical_start = 0xFE0B0400,
+	.ramio_size = 0x600,
+	.acpi_paths = {
+		[ACPI_PATH_STA] = "\\_SB.PCI0.LPC0.EC0.VPC0._STA",
+		[ACPI_PATH_CFG] = "\\_SB.PCI0.LPC0.EC0.VPC0._CFG",
+		[ACPI_PATH_READ_RAPIDCHARGE] = "\\_SB.PCI0.LPC0.EC0.VPC0.GBMD",
+		[ACPI_PATH_WRITE_RAPIDCHARGE] = "\\_SB.PCI0.LPC0.EC0.VPC0.SBMC",
+	},
+	.has_extreme_powermode = true
+};
+
 static const struct dmi_system_id denylist[] = { {} };
 
 static const struct dmi_system_id optimistic_allowlist[] = {
@@ -1605,7 +1631,7 @@ static const struct dmi_system_id optimistic_allowlist[] = {
 			DMI_MATCH(DMI_SYS_VENDOR, "LENOVO"),
 			DMI_MATCH(DMI_BIOS_VERSION, "M3CN"),
 		},
-		.driver_data = (void *)&model_lpcn
+		.driver_data = (void *)&model_m3cn
 	},
 	{
 		// e.g. Legion Y7000p-1060


### PR DESCRIPTION
- leave gpu_oc using only WMI DA7547F1-824D-405F-BE79-D9903E29CED7, some modern laptop models will see value 0,  functionality was removed from WMAD WMI Call.
- gpu_ppab_powerlimit points to GPU_POWER_BOOST(CPU to GPU Dynamic Boost) 0x02010000