### PR TITLE
Add LOQ 83SC support: model recognition + dynamic sysfs base discovery

### DIFF
--- a/kernel_module/legion-laptop.c
+++ b/kernel_module/legion-laptop.c
@@ -1357,6 +1357,32 @@ static const struct model_config model_s2cn = {
 	.has_fancurve_defaults = true
 };
 
+static const struct model_config model_secn = {
+	.registers = &ec_register_offsets_loq_v1,
+	.check_embedded_controller_id = true,
+	.embedded_controller_id = 0x5508,
+	.memoryio_physical_ec_start = 0xC400,
+	.memoryio_size = 0x300,
+	.has_minifancurve = true,
+	.has_custom_powermode = true,
+	.has_extreme_powermode = true,
+	.access_method_powermode = ACCESS_METHOD_WMI,
+	.access_method_keyboard = ACCESS_METHOD_WMI2,
+	.access_method_fanspeed = ACCESS_METHOD_WMI3,
+	.access_method_temperature = ACCESS_METHOD_WMI3,
+	.access_method_fancurve = ACCESS_METHOD_EC3,
+	.access_method_fanfullspeed = ACCESS_METHOD_WMI3,
+	.acpi_check_dev = false,
+	.ramio_physical_start = 0xFE0B0F00,
+	.ramio_size = 0x600,
+	.acpi_paths = {
+		[ACPI_PATH_STA] = "\\_SB.PC00.LPCB.EC0.VPC0._STA",
+		[ACPI_PATH_CFG] = "\\_SB.PC00.LPCB.EC0.VPC0._CFG"
+	},
+	.has_fancurve_defaults = true,
+	.skip_oc_controls = true
+};
+
 static const struct dmi_system_id denylist[] = { {} };
 
 static const struct dmi_system_id optimistic_allowlist[] = {
@@ -1823,6 +1849,15 @@ static const struct dmi_system_id optimistic_allowlist[] = {
 			DMI_MATCH(DMI_BIOS_VERSION, "S2CN"),
 		},
 		.driver_data = (void *)&model_s2cn
+	},
+	{
+		// LOQ Essential 15IRX11 (83SC), BIOS SECN, EC 0x5508
+		.ident = "SECN",
+		.matches = {
+			DMI_MATCH(DMI_SYS_VENDOR, "LENOVO"),
+			DMI_MATCH(DMI_BIOS_VERSION, "SECN"),
+		},
+		.driver_data = (void *)&model_secn
 	},
 	{
 		// e.g. Legion 5 16IRX9 (83DG)


### PR DESCRIPTION
# PR-1 — LOQ 83SC: model recognition (kernel) + dynamic sysfs base discovery (toolkit)

## Kernel change (\`kernel_module/legion-laptop.c\`)
Adds 83SC to the driver so the sysfs interface is created for this model:
- New \`model_secn\` config (legion-laptop.c:1360) with \`.skip_oc_controls = true\`
  (legion-laptop.c:1383).
- DMI allowlist entry (legion-laptop.c:1854-1860): LOQ Essential 15IRX11 (83SC),
  BIOS SECN, EC 0x5508 → \`driver_data = &model_secn\`.
- On the submitter's 83SC the legion platform driver binds and creates the
  \`/sys/bus/platform/drivers/legion/...\` interface (verified on hardware by the
  user; the DMI/allowlist logic was reviewed in source). On this model the OC/power
  nodes (incl. \`gpu_oc\`) are gated off by \`skip_oc_controls\`; the \`is_visible\`
  logic (legion-laptop.c:6002+) was reviewed in source and the resulting behavior
  confirmed on the user's 83SC hardware.

## Toolkit change (\`python/\` — from PR-1)
Replaces the hardcoded kernel-version switch for \`LEGION_SYS_BASEPATH\` with
\`_discover_legion_sys_baspath()\`, which globs the legion driver's bound
directory (\`/sys/bus/platform/drivers/legion/*\`) and returns the first
subdirectory (falling back to the old fixed paths). It anchors on the driver
directory itself — NOT on a specific feature node — so it works as soon as the
kernel recognizes the model (DMI + \`model_secn\` bind the device). Every
\`Feature\` joins this base via \`os.path.join\`, so the fix flows to all of them.
Model-agnostic — benefits every supported model, and is required for 83SC where
the interface binds under \`VPC2004:00\` rather than \`PNP0C09:00\`.

## Verification
- Model recognition and sysfs node visibility were confirmed on the submitter's 83SC hardware and reviewed in source.
- Toolkit/python changes were reviewed in source and exercised on the 83SC hardware by the user.
- \`tests/test_fancurve.py\` passes 3/3 (agent-run): proves \`FanCurveIO\` never touches \`pwm2_*\` on a single-fan model and covers the fan2-rpm conversion fix.