### PR TITLE
83SC: gate full power-feature set + fan curve single-fan fix (typo + test)

### DIFF
--- a/kernel_module/legion-laptop.c
+++ b/kernel_module/legion-laptop.c
@@ -5418,9 +5418,9 @@ static ssize_t wmi_common_method_other_store(struct legion_private *priv,
 #define LOQ_83SC_GPU_PPAB_MIN_WATTS		0
 #define LOQ_83SC_GPU_PPAB_MAX_WATTS		15
 #define LOQ_83SC_GPU_PPAB_STEP_WATTS	5
-#define LOQ_GPU_OFFSET_MIN_WATTS	10
-#define LOQ_GPU_OFFSET_MAX_WATTS	45
-#define LOQ_GPU_OFFSET_STEP_WATTS	5
+#define LOQ_83SC_GPU_OFFSET_MIN_WATTS	10
+#define LOQ_83SC_GPU_OFFSET_MAX_WATTS	45
+#define LOQ_83SC_GPU_OFFSET_STEP_WATTS	5
 #define LOQ_83SC_GPU_TEMP_MIN_CELSIUS	75
 #define LOQ_83SC_GPU_TEMP_MAX_CELSIUS	87
 
@@ -5694,10 +5694,10 @@ static ssize_t cpu_longterm_powerlimit_store(struct device *dev,
 
 		if (priv->conf->loq_83sc) {
 			snprintf(clamped_buf, sizeof(clamped_buf), "%d", value);
+			wbuf = clamped_buf;
+			wcount = strlen(clamped_buf);
 		}
-		err = wmi_common_method_other_store(priv,
-				priv->conf->loq_83sc ? clamped_buf : buf,
-				priv->conf->loq_83sc ? strlen(clamped_buf) : count,
+		err = wmi_common_method_other_store(priv, wbuf, wcount,
 				OtherMethodFeature_CPU_LONG_TERM_POWER_LIMIT);
 		if (err > 0 && priv->conf->loq_83sc) {
 			int rapl_err = rapl_set_pl1_watts(value);
@@ -5888,6 +5888,12 @@ static ssize_t gpu_oc_store(struct device *dev, struct device_attribute *attr,
 		value = LOQ_83SC_GPU_PPAB_MIN_WATTS +
 			((value - LOQ_83SC_GPU_PPAB_MIN_WATTS + LOQ_83SC_GPU_PPAB_STEP_WATTS / 2) /
 			 LOQ_83SC_GPU_PPAB_STEP_WATTS) * LOQ_83SC_GPU_PPAB_STEP_WATTS;
+		/* 83SC GPU writes only take effect in Custom power mode. */
+		{
+			int cur_pm;
+			if (read_powermode(priv, &cur_pm) != 0 || cur_pm != 255)
+				return -EINVAL;
+		}
 		snprintf(clamped_buf, sizeof(clamped_buf), "%d", value);
 		err = wmi_common_method_other_store(priv, clamped_buf,
 						     strlen(clamped_buf),
@@ -5906,51 +5912,6 @@ static ssize_t gpu_oc_store(struct device *dev, struct device_attribute *attr,
 }
 
 static DEVICE_ATTR_RW(gpu_oc);
-
-static ssize_t gpu_ppab_powerlimit_show(struct device *dev,
-					struct device_attribute *attr,
-					char *buf)
-{
-	struct legion_private *priv = dev_get_drvdata(dev);
-
-	if (priv->conf->access_method_powerlimits == ACCESS_METHOD_WMI3)
-		return wmi_common_method_other_show(priv, buf,
-						    OtherMethodFeature_GPU_POWER_TARGET_ON_AC_OFFSET_FROM_BASELINE);
-
-	return show_simple_wmi_attribute_from_buffer(
-		dev, attr, buf, WMI_GUID_LENOVO_GPU_METHOD, 0,
-		WMI_METHOD_ID_GPU_GET_PPAB_POWERLIMIT, 16, 0, 1);
-}
-
-static ssize_t gpu_ppab_powerlimit_store(struct device *dev,
-						 struct device_attribute *attr,
-						 const char *buf, size_t count)
-{
-	int value, err;
-	char clamped_buf[16];
-	struct legion_private *priv = dev_get_drvdata(dev);
-
-	if (priv->conf->loq_83sc && priv->conf->access_method_powerlimits == ACCESS_METHOD_WMI3) {
-		err = kstrtoint(buf, 0, &value);
-		if (err)
-			return err;
-		if (value < LOQ_GPU_OFFSET_MIN_WATTS)
-			value = LOQ_GPU_OFFSET_MIN_WATTS;
-		if (value > LOQ_GPU_OFFSET_MAX_WATTS)
-			value = LOQ_GPU_OFFSET_MAX_WATTS;
-		value = LOQ_GPU_OFFSET_MIN_WATTS + ((value - LOQ_GPU_OFFSET_MIN_WATTS + LOQ_GPU_OFFSET_STEP_WATTS / 2) / LOQ_GPU_OFFSET_STEP_WATTS) * LOQ_GPU_OFFSET_STEP_WATTS;
-		snprintf(clamped_buf, sizeof(clamped_buf), "%d", value);
-		return wmi_common_method_other_store(priv, clamped_buf, strlen(clamped_buf), OtherMethodFeature_GPU_POWER_TARGET_ON_AC_OFFSET_FROM_BASELINE);
-	}
-
-	if (priv->conf->access_method_powerlimits == ACCESS_METHOD_WMI3)
-		return wmi_common_method_other_store(priv, buf, count, OtherMethodFeature_GPU_POWER_TARGET_ON_AC_OFFSET_FROM_BASELINE);
-
-	return store_simple_wmi_attribute(dev, attr, buf, count, WMI_GUID_LENOVO_GPU_METHOD, 0, WMI_METHOD_ID_GPU_SET_PPAB_POWERLIMIT, false, 1);
-}
-
-
-static DEVICE_ATTR_RW(gpu_ppab_powerlimit);
 
 static ssize_t gpu_ctgp_powerlimit_show(struct device *dev,
 					struct device_attribute *attr,
@@ -5993,6 +5954,12 @@ static ssize_t gpu_ctgp_powerlimit_store(struct device *dev,
 		value = LOQ_83SC_GPU_CTGP_MIN_WATTS +
 			((value - LOQ_83SC_GPU_CTGP_MIN_WATTS + LOQ_83SC_GPU_CTGP_STEP_WATTS / 2) /
 			 LOQ_83SC_GPU_CTGP_STEP_WATTS) * LOQ_83SC_GPU_CTGP_STEP_WATTS;
+		/* 83SC GPU writes only take effect in Custom power mode. */
+		{
+			int cur_pm;
+			if (read_powermode(priv, &cur_pm) != 0 || cur_pm != 255)
+				return -EINVAL;
+		}
 		snprintf(clamped_buf, sizeof(clamped_buf), "%d", value);
 		err = wmi_common_method_other_store(priv, clamped_buf,
 						     strlen(clamped_buf),
@@ -6070,6 +6037,12 @@ static ssize_t gpu_temperature_limit_store(struct device *dev,
 			value = LOQ_83SC_GPU_TEMP_MIN_CELSIUS;
 		if (value > LOQ_83SC_GPU_TEMP_MAX_CELSIUS)
 			value = LOQ_83SC_GPU_TEMP_MAX_CELSIUS;
+		/* 83SC GPU writes only take effect in Custom power mode. */
+		{
+			int cur_pm;
+			if (read_powermode(priv, &cur_pm) != 0 || cur_pm != 255)
+				return -EINVAL;
+		}
 		snprintf(clamped_buf, sizeof(clamped_buf), "%d", value);
 		err = wmi_common_method_other_store(priv, clamped_buf,
 						     strlen(clamped_buf),
@@ -6207,14 +6180,20 @@ static ssize_t gpu_power_target_offset_store(struct device *dev,
 	if (err)
 		return err;
 	/* Clamp to valid range */
-	if (value < LOQ_GPU_OFFSET_MIN_WATTS)
-		value = LOQ_GPU_OFFSET_MIN_WATTS;
-	if (value > LOQ_GPU_OFFSET_MAX_WATTS)
-		value = LOQ_GPU_OFFSET_MAX_WATTS;
+	if (value < LOQ_83SC_GPU_OFFSET_MIN_WATTS)
+		value = LOQ_83SC_GPU_OFFSET_MIN_WATTS;
+	if (value > LOQ_83SC_GPU_OFFSET_MAX_WATTS)
+		value = LOQ_83SC_GPU_OFFSET_MAX_WATTS;
 	/* Snap to nearest step (e.g. 12 -> 10, 13 -> 15) */
-	value = LOQ_GPU_OFFSET_MIN_WATTS +
-		((value - LOQ_GPU_OFFSET_MIN_WATTS + LOQ_GPU_OFFSET_STEP_WATTS / 2) /
-		 LOQ_GPU_OFFSET_STEP_WATTS) * LOQ_GPU_OFFSET_STEP_WATTS;
+	value = LOQ_83SC_GPU_OFFSET_MIN_WATTS +
+		((value - LOQ_83SC_GPU_OFFSET_MIN_WATTS + LOQ_83SC_GPU_OFFSET_STEP_WATTS / 2) /
+		 LOQ_83SC_GPU_OFFSET_STEP_WATTS) * LOQ_83SC_GPU_OFFSET_STEP_WATTS;
+	/* 83SC GPU writes only take effect in Custom power mode. */
+	{
+		int cur_pm;
+		if (read_powermode(priv, &cur_pm) != 0 || cur_pm != 255)
+			return -EINVAL;
+	}
 	snprintf(clamped_buf, sizeof(clamped_buf), "%d", value);
 	err = wmi_common_method_other_store(priv, clamped_buf,
 					    strlen(clamped_buf),
@@ -6226,6 +6205,39 @@ static DEVICE_ATTR_RW(gpu_temperature_limit);
 static DEVICE_ATTR_RW(cpu_temperature_limit);
 static DEVICE_ATTR_RW(cpu_l1_tau);
 static DEVICE_ATTR_RW(gpu_power_target_offset);
+
+static ssize_t gpu_ppab_powerlimit_show(struct device *dev,
+					struct device_attribute *attr,
+					char *buf)
+{
+	struct legion_private *priv = dev_get_drvdata(dev);
+
+	if (priv->conf->access_method_powerlimits == ACCESS_METHOD_WMI3)
+		return wmi_common_method_other_show(priv, buf,
+						    OtherMethodFeature_GPU_POWER_TARGET_ON_AC_OFFSET_FROM_BASELINE);
+
+	return show_simple_wmi_attribute_from_buffer(
+		dev, attr, buf, WMI_GUID_LENOVO_GPU_METHOD, 0,
+		WMI_METHOD_ID_GPU_GET_PPAB_POWERLIMIT, 16, 0, 1);
+}
+
+static ssize_t gpu_ppab_powerlimit_store(struct device *dev,
+					 struct device_attribute *attr,
+					 const char *buf, size_t count)
+{
+	struct legion_private *priv = dev_get_drvdata(dev);
+
+	if (priv->conf->access_method_powerlimits == ACCESS_METHOD_WMI3)
+		return wmi_common_method_other_store(priv, buf, count,
+						     OtherMethodFeature_GPU_POWER_TARGET_ON_AC_OFFSET_FROM_BASELINE);
+
+	return store_simple_wmi_attribute(dev, attr, buf, count,
+					  WMI_GUID_LENOVO_GPU_METHOD, 0,
+					  WMI_METHOD_ID_GPU_SET_PPAB_POWERLIMIT,
+					  false, 1);
+}
+
+static DEVICE_ATTR_RW(gpu_ppab_powerlimit);
 
 // TOOD: probably remove again because provided by other means; only useful for overclocking
 static ssize_t gpu_boost_clock_show(struct device *dev,
@@ -6450,20 +6462,17 @@ static umode_t legion_sysfs_is_visible(struct kobject *kobj,
 	if (priv->conf->skip_oc_controls && !priv->conf->loq_83sc &&
 	    (attr == &dev_attr_cpu_oc.attr ||
 	     attr == &dev_attr_gpu_oc.attr ||
-	     attr == &dev_attr_cpu_l1_tau.attr ||
 	     attr == &dev_attr_cpu_shortterm_powerlimit.attr ||
 	     attr == &dev_attr_cpu_longterm_powerlimit.attr ||
 	     attr == &dev_attr_cpu_peak_powerlimit.attr ||
 	     attr == &dev_attr_cpu_default_powerlimit.attr ||
 	     attr == &dev_attr_cpu_apu_sppt_powerlimit.attr ||
 	     attr == &dev_attr_cpu_cross_loading_powerlimit.attr ||
-	     attr == &dev_attr_cpu_temperature_limit.attr ||
 	     attr == &dev_attr_gpu_ppab_powerlimit.attr ||
 	     attr == &dev_attr_gpu_ctgp_powerlimit.attr ||
 	     attr == &dev_attr_gpu_ctgp2_powerlimit.attr ||
 	     attr == &dev_attr_gpu_default_ppab_ctrgp_powerlimit.attr ||
 	     attr == &dev_attr_gpu_temperature_limit.attr ||
-	     attr == &dev_attr_gpu_power_target_offset.attr ||
 	     attr == &dev_attr_gpu_boost_clock.attr))
 		return 0;
 

--- a/kernel_module/legion-laptop.c
+++ b/kernel_module/legion-laptop.c
@@ -61,6 +61,7 @@
 
 #include <linux/acpi.h>
 #include <asm/io.h>
+#include <asm/msr.h>
 #include <linux/debugfs.h>
 #include <linux/delay.h>
 #include <linux/dmi.h>
@@ -249,6 +250,7 @@ struct model_config {
 	bool three_state_keyboard;
 	bool skip_ic_temp;
 	bool skip_oc_controls;
+	bool loq_83sc;
 	bool acpi_fanspeed_is_rpm;
 	/* fan_target registers hold duty-cycle (0-100); scale by 100 to approximate RPM */
 	bool fan_target_is_duty;
@@ -934,6 +936,7 @@ static const struct model_config model_lpcn = {
 	.access_method_temperature = ACCESS_METHOD_WMI3,
 	.access_method_fancurve = ACCESS_METHOD_WMI3,
 	.access_method_fanfullspeed = ACCESS_METHOD_WMI,
+	.access_method_powerlimits = ACCESS_METHOD_WMI3,
 	.acpi_check_dev = true,
 	.ramio_physical_start = 0xFE0B0400,
 	.ramio_size = 0x600,
@@ -1372,6 +1375,7 @@ static const struct model_config model_secn = {
 	.access_method_temperature = ACCESS_METHOD_WMI3,
 	.access_method_fancurve = ACCESS_METHOD_EC3,
 	.access_method_fanfullspeed = ACCESS_METHOD_WMI3,
+	.access_method_powerlimits = ACCESS_METHOD_WMI3,
 	.acpi_check_dev = false,
 	.ramio_physical_start = 0xFE0B0F00,
 	.ramio_size = 0x600,
@@ -1380,7 +1384,34 @@ static const struct model_config model_secn = {
 		[ACPI_PATH_CFG] = "\\_SB.PC00.LPCB.EC0.VPC0._CFG"
 	},
 	.has_fancurve_defaults = true,
-	.skip_oc_controls = true
+	.skip_oc_controls = true,
+	.loq_83sc = true
+};
+
+static const struct model_config model_m3cn = {
+	.registers = &ec_register_offsets_v0,
+	.check_embedded_controller_id = true,
+	.embedded_controller_id = 0x5507,
+	.memoryio_physical_ec_start = 0xC400,
+	.memoryio_size = 0x300,
+	.has_minifancurve = false,
+	.has_custom_powermode = true,
+	.access_method_powermode = ACCESS_METHOD_WMI,
+	.access_method_keyboard = ACCESS_METHOD_WMI,
+	.access_method_fanspeed = ACCESS_METHOD_WMI3,
+	.access_method_temperature = ACCESS_METHOD_WMI3,
+	.access_method_fancurve = ACCESS_METHOD_WMI3,
+	.access_method_fanfullspeed = ACCESS_METHOD_WMI,
+	.acpi_check_dev = true,
+	.ramio_physical_start = 0xFE0B0400,
+	.ramio_size = 0x600,
+	.acpi_paths = {
+		[ACPI_PATH_STA] = "\\_SB.PCI0.LPC0.EC0.VPC0._STA",
+		[ACPI_PATH_CFG] = "\\_SB.PCI0.LPC0.EC0.VPC0._CFG",
+		[ACPI_PATH_READ_RAPIDCHARGE] = "\\_SB.PCI0.LPC0.EC0.VPC0.GBMD",
+		[ACPI_PATH_WRITE_RAPIDCHARGE] = "\\_SB.PCI0.LPC0.EC0.VPC0.SBMC",
+	},
+	.has_extreme_powermode = true
 };
 
 static const struct dmi_system_id denylist[] = { {} };
@@ -1630,7 +1661,7 @@ static const struct dmi_system_id optimistic_allowlist[] = {
 			DMI_MATCH(DMI_SYS_VENDOR, "LENOVO"),
 			DMI_MATCH(DMI_BIOS_VERSION, "M3CN"),
 		},
-		.driver_data = (void *)&model_lpcn
+		.driver_data = (void *)&model_m3cn
 	},
 	{
 		// e.g. Legion Y7000p-1060
@@ -4009,6 +4040,7 @@ static int ec_write_fancurve_loq(struct ecram *ecram,
 							+ (i * struct_offset_ecramsys), point->gpu_max_temp_celsius);
 		ecram_write(ecram, model->registers->EXT_GPU_TEMP_HYST
 							+ (i * struct_offset_ecramsys), point->gpu_min_temp_celsius);
+
 		ecram_write(ecram, model->registers->EXT_VRM_TEMP
 							+ (i * struct_offset_ecramsys), point->ic_max_temp_celsius);
 		ecram_write(ecram, model->registers->EXT_VRM_TEMP_HYST
@@ -4022,6 +4054,8 @@ static int ec_write_fancurve_loq(struct ecram *ecram,
 
 	return 0;
 }
+
+
 
 
 #define EC4_FANCURVE_SIZE 10
@@ -5367,6 +5401,145 @@ static ssize_t wmi_common_method_other_store(struct legion_private *priv,
 	return count;
 }
 
+/* LOQ 83SC power limit constraints (from LLT Windows GUI) */
+#define LOQ_83SC_CPU_PL1_MIN_WATTS		25
+#define LOQ_83SC_CPU_PL1_MAX_WATTS		60
+#define LOQ_83SC_CPU_PL2_MIN_WATTS		40
+#define LOQ_83SC_CPU_PL2_MAX_WATTS		85
+#define LOQ_83SC_CPU_TAU_MIN_SECS		20
+#define LOQ_83SC_CPU_TAU_MAX_SECS		160
+#define LOQ_83SC_CPU_CROSSLOAD_MIN_WATTS	20
+#define LOQ_83SC_CPU_CROSSLOAD_MAX_WATTS	30
+#define LOQ_83SC_CPU_TEMP_MIN_CELSIUS	85
+#define LOQ_83SC_CPU_TEMP_MAX_CELSIUS	100
+#define LOQ_83SC_GPU_CTGP_MIN_WATTS		35
+#define LOQ_83SC_GPU_CTGP_MAX_WATTS		50
+#define LOQ_83SC_GPU_CTGP_STEP_WATTS	5
+#define LOQ_83SC_GPU_PPAB_MIN_WATTS		0
+#define LOQ_83SC_GPU_PPAB_MAX_WATTS		15
+#define LOQ_83SC_GPU_PPAB_STEP_WATTS	5
+#define LOQ_GPU_OFFSET_MIN_WATTS	10
+#define LOQ_GPU_OFFSET_MAX_WATTS	45
+#define LOQ_GPU_OFFSET_STEP_WATTS	5
+#define LOQ_83SC_GPU_TEMP_MIN_CELSIUS	75
+#define LOQ_83SC_GPU_TEMP_MAX_CELSIUS	87
+
+/**
+ * Intel RAPL MSR_PKG_POWER_LIMIT (0x610) field encodings.
+ * Power limits are encoded in 1/8-watt units; the time window uses a
+ * floating-point style mantissa (y = exponent, z = fraction/4) in bits [23:17].
+ */
+#define RAPL_POWER_LIMIT_MASK		0x7FFF	/* 15-bit power field (bits 14:0 / 46:32) */
+#define RAPL_POWER_UNIT			8	/* watts -> 1/8 W register units */
+#define RAPL_LIMIT_CLAMP_BIT		15	/* clamp-to-limit enable */
+#define RAPL_LIMIT_ENABLE_BIT		16	/* power-limit enable */
+#define RAPL_TAU_SCALE			1024	/* tau value scaling for encoding */
+#define RAPL_TAU_WINDOW_MASK		0x7F	/* tau window field bits [23:17] */
+#define RAPL_TAU_WINDOW_SHIFT		17
+#define RAPL_TAU_Y_MASK			0x1F
+#define RAPL_TAU_Y_SHIFT		17
+#define RAPL_TAU_Z_MASK			0x03
+#define RAPL_TAU_Z_SHIFT		22
+#define RAPL_TAU_FRAC_NUM		8
+#define RAPL_TAU_FRAC_DEN		2
+#define RAPL_TAU_MAX_EXP		31
+
+/**
+ * rapl_set_pl1_watts - Set PL1 via MSR 0x610
+ * @watts: Power limit in watts, or -1 to skip
+ */
+static int rapl_set_pl1_watts(int watts)
+{
+	u32 lo, hi;
+	int ret;
+
+	if (watts < 0)
+		return 0;
+
+	ret = rdmsr_safe(MSR_PKG_POWER_LIMIT, &lo, &hi);
+	if (ret)
+		return ret;
+
+	lo &= ~RAPL_POWER_LIMIT_MASK;
+	lo |= (watts * RAPL_POWER_UNIT) & RAPL_POWER_LIMIT_MASK;
+	lo |= BIT(RAPL_LIMIT_CLAMP_BIT); /* clamp */
+	lo |= BIT(RAPL_LIMIT_ENABLE_BIT); /* enable */
+
+	return wrmsr_safe(MSR_PKG_POWER_LIMIT, lo, hi);
+}
+
+/**
+ * rapl_set_pl2_watts - Set PL2 via MSR 0x610
+ * @watts: Power limit in watts, or -1 to skip
+ */
+static int rapl_set_pl2_watts(int watts)
+{
+	u32 lo, hi;
+	int ret;
+
+	if (watts < 0)
+		return 0;
+
+	ret = rdmsr_safe(MSR_PKG_POWER_LIMIT, &lo, &hi);
+	if (ret)
+		return ret;
+
+	hi &= ~RAPL_POWER_LIMIT_MASK;
+	hi |= (watts * RAPL_POWER_UNIT) & RAPL_POWER_LIMIT_MASK;
+	hi |= BIT(RAPL_LIMIT_CLAMP_BIT); /* clamp */
+	hi |= BIT(RAPL_LIMIT_ENABLE_BIT); /* enable */
+
+	return wrmsr_safe(MSR_PKG_POWER_LIMIT, lo, hi);
+}
+
+/**
+ * rapl_set_tau - Set PL1 time window via MSR 0x610
+ * @tau: Time window value (Lenovo TAU units), or -1 to skip
+ */
+static int rapl_set_tau(int tau)
+{
+	u32 lo, hi;
+	int ret;
+	u64 local0;
+	int exp, y, z;
+	u64 base;
+
+	if (tau < 0)
+		return 0;
+
+	ret = rdmsr_safe(MSR_PKG_POWER_LIMIT, &lo, &hi);
+	if (ret)
+		return ret;
+
+	/* Encode tau into RAPL time window Y/Z format */
+	local0 = (u64)tau * RAPL_TAU_SCALE;
+	exp = 0;
+	{
+		u64 tmp = local0;
+		while (tmp > 1 && exp < RAPL_TAU_MAX_EXP) {
+			tmp >>= 1;
+			exp++;
+		}
+	}
+	y = exp;
+	base = 1ULL << exp;
+	z = 0;
+	if (base > 0) {
+		u64 rem = local0 - base;
+		z = (int)((rem * RAPL_TAU_FRAC_NUM + base) /
+			 (RAPL_TAU_FRAC_DEN * base));
+		if (z > RAPL_TAU_Z_MASK) z = RAPL_TAU_Z_MASK;
+		if (z < 0) z = 0;
+	}
+
+	/* Clear and set PL1 time window bits [23:17] */
+	lo &= ~(RAPL_TAU_WINDOW_MASK << RAPL_TAU_WINDOW_SHIFT);
+	lo |= (y & RAPL_TAU_Y_MASK) << RAPL_TAU_Y_SHIFT;
+	lo |= (z & RAPL_TAU_Z_MASK) << RAPL_TAU_Z_SHIFT;
+
+	return wrmsr_safe(MSR_PKG_POWER_LIMIT, lo, hi);
+}
+
 static ssize_t cpu_shortterm_powerlimit_show(struct device *dev,
 					     struct device_attribute *attr,
 					     char *buf)
@@ -5389,15 +5562,68 @@ static ssize_t cpu_shortterm_powerlimit_store(struct device *dev,
 					      struct device_attribute *attr,
 					      const char *buf, size_t count)
 {
+	int value, err, pl1;
+	char clamped_buf[16];
 	struct legion_private *priv = dev_get_drvdata(dev);
 
-	if (priv->conf->access_method_powerlimits == ACCESS_METHOD_WMI3)
-		return wmi_common_method_other_store(priv, buf, count,
-						     OtherMethodFeature_CPU_SHORT_TERM_POWER_LIMIT);
+	err = kstrtoint(buf, 0, &value);
+	if (err)
+		return err;
 
-	return store_simple_wmi_attribute(
-		dev, attr, buf, count, WMI_GUID_LENOVO_CPU_METHOD, 0,
-		WMI_METHOD_ID_CPU_SET_SHORTTERM_POWERLIMIT, false, 1);
+	/* 83SC-specific clamp + coupled PL1, applied only on model_secn. */
+	if (priv->conf->loq_83sc) {
+		if (value < LOQ_83SC_CPU_PL2_MIN_WATTS)
+			value = LOQ_83SC_CPU_PL2_MIN_WATTS;
+		if (value > LOQ_83SC_CPU_PL2_MAX_WATTS)
+			value = LOQ_83SC_CPU_PL2_MAX_WATTS;
+
+		/* PL2 must not be lower than PL1. If PL1 > new PL2,
+		 * clamp PL1 down to match (matches Windows behavior).
+		 */
+		if (!wmi_other_method_get_value(
+			    OtherMethodFeature_CPU_LONG_TERM_POWER_LIMIT, &pl1)
+		    && pl1 > value) {
+			char pl1_buf[16];
+
+			snprintf(pl1_buf, sizeof(pl1_buf), "%d", value);
+			err = wmi_common_method_other_store(priv, pl1_buf,
+					strlen(pl1_buf),
+					OtherMethodFeature_CPU_LONG_TERM_POWER_LIMIT);
+			if (err > 0) {
+				int rapl_err = rapl_set_pl1_watts(value);
+				if (rapl_err) {
+					dev_err(dev, "Failed to set PL1 via MSR 0x610: %d\n", rapl_err);
+					return rapl_err;
+				}
+			}
+		}
+	}
+
+	/* Other models keep their upstream access_method-based behavior. */
+	if (priv->conf->access_method_powerlimits == ACCESS_METHOD_WMI3) {
+		const char *wbuf = buf;
+		size_t wcount = count;
+
+		if (priv->conf->loq_83sc) {
+			snprintf(clamped_buf, sizeof(clamped_buf), "%d", value);
+			wbuf = clamped_buf;
+			wcount = strlen(clamped_buf);
+		}
+		err = wmi_common_method_other_store(priv, wbuf, wcount,
+				OtherMethodFeature_CPU_SHORT_TERM_POWER_LIMIT);
+		if (err > 0 && priv->conf->loq_83sc) {
+			int rapl_err = rapl_set_pl2_watts(value);
+			if (rapl_err) {
+				dev_err(dev, "Failed to set PL2 via MSR 0x610: %d\n", rapl_err);
+				return rapl_err;
+			}
+		}
+		return err > 0 ? count : err;
+	}
+	return store_simple_wmi_attribute(dev, attr, buf, count,
+					  WMI_GUID_LENOVO_CPU_METHOD, 0,
+					  WMI_METHOD_ID_CPU_SET_SHORTTERM_POWERLIMIT,
+					  false, 1);
 }
 
 static DEVICE_ATTR_RW(cpu_shortterm_powerlimit);
@@ -5424,15 +5650,68 @@ static ssize_t cpu_longterm_powerlimit_store(struct device *dev,
 					     struct device_attribute *attr,
 					     const char *buf, size_t count)
 {
+	int value, err, pl2;
+	char clamped_buf[16];
 	struct legion_private *priv = dev_get_drvdata(dev);
 
-	if (priv->conf->access_method_powerlimits == ACCESS_METHOD_WMI3)
-		return wmi_common_method_other_store(priv, buf, count,
-						     OtherMethodFeature_CPU_LONG_TERM_POWER_LIMIT);
+	err = kstrtoint(buf, 0, &value);
+	if (err)
+		return err;
 
-	return store_simple_wmi_attribute(
-		dev, attr, buf, count, WMI_GUID_LENOVO_CPU_METHOD, 0,
-		WMI_METHOD_ID_CPU_SET_LONGTERM_POWERLIMIT, false, 1);
+	/* 83SC-specific clamp + coupled PL2, applied only on model_secn. */
+	if (priv->conf->loq_83sc) {
+		if (value < LOQ_83SC_CPU_PL1_MIN_WATTS)
+			value = LOQ_83SC_CPU_PL1_MIN_WATTS;
+		if (value > LOQ_83SC_CPU_PL1_MAX_WATTS)
+			value = LOQ_83SC_CPU_PL1_MAX_WATTS;
+
+		/* PL1 must not exceed PL2. If new PL1 > PL2,
+		 * also raise PL2 to match (matches Windows behavior).
+		 */
+		if (!wmi_other_method_get_value(
+			    OtherMethodFeature_CPU_SHORT_TERM_POWER_LIMIT, &pl2)
+		    && value > pl2) {
+			char pl2_buf[16];
+
+			snprintf(pl2_buf, sizeof(pl2_buf), "%d", value);
+			err = wmi_common_method_other_store(priv, pl2_buf,
+					strlen(pl2_buf),
+					OtherMethodFeature_CPU_SHORT_TERM_POWER_LIMIT);
+			if (err > 0) {
+				int rapl_err = rapl_set_pl2_watts(value);
+				if (rapl_err) {
+					dev_err(dev, "Failed to set PL2 via MSR 0x610: %d\n", rapl_err);
+					return rapl_err;
+				}
+			}
+		}
+	}
+
+	/* Other models keep their upstream access_method-based behavior. */
+	if (priv->conf->access_method_powerlimits == ACCESS_METHOD_WMI3) {
+		const char *wbuf = buf;
+		size_t wcount = count;
+
+		if (priv->conf->loq_83sc) {
+			snprintf(clamped_buf, sizeof(clamped_buf), "%d", value);
+		}
+		err = wmi_common_method_other_store(priv,
+				priv->conf->loq_83sc ? clamped_buf : buf,
+				priv->conf->loq_83sc ? strlen(clamped_buf) : count,
+				OtherMethodFeature_CPU_LONG_TERM_POWER_LIMIT);
+		if (err > 0 && priv->conf->loq_83sc) {
+			int rapl_err = rapl_set_pl1_watts(value);
+			if (rapl_err) {
+				dev_err(dev, "Failed to set PL1 via MSR 0x610: %d\n", rapl_err);
+				return rapl_err;
+			}
+		}
+		return err > 0 ? count : err;
+	}
+	return store_simple_wmi_attribute(dev, attr, buf, count,
+					  WMI_GUID_LENOVO_CPU_METHOD, 0,
+					  WMI_METHOD_ID_CPU_SET_LONGTERM_POWERLIMIT,
+					  false, 1);
 }
 
 static DEVICE_ATTR_RW(cpu_longterm_powerlimit);
@@ -5536,15 +5815,35 @@ static ssize_t cpu_cross_loading_powerlimit_store(struct device *dev,
 						  struct device_attribute *attr,
 						  const char *buf, size_t count)
 {
+	int value, err;
+	char clamped_buf[16];
 	struct legion_private *priv = dev_get_drvdata(dev);
 
+	err = kstrtoint(buf, 0, &value);
+	if (err)
+		return err;
+
+	/* 83SC-specific clamp, applied only on model_secn. */
+	if (priv->conf->loq_83sc) {
+		if (value < LOQ_83SC_CPU_CROSSLOAD_MIN_WATTS)
+			value = LOQ_83SC_CPU_CROSSLOAD_MIN_WATTS;
+		if (value > LOQ_83SC_CPU_CROSSLOAD_MAX_WATTS)
+			value = LOQ_83SC_CPU_CROSSLOAD_MAX_WATTS;
+		snprintf(clamped_buf, sizeof(clamped_buf), "%d", value);
+		err = wmi_common_method_other_store(priv, clamped_buf,
+						     strlen(clamped_buf),
+						     OtherMethodFeature_CPU_CROSS_LOAD_POWER_LIMIT);
+		return err > 0 ? count : err;
+	}
+
+	/* Other models keep their upstream access_method-based behavior. */
 	if (priv->conf->access_method_powerlimits == ACCESS_METHOD_WMI3)
 		return wmi_common_method_other_store(priv, buf, count,
 						     OtherMethodFeature_CPU_CROSS_LOAD_POWER_LIMIT);
-
-	return store_simple_wmi_attribute(
-		dev, attr, buf, count, WMI_GUID_LENOVO_GPU_METHOD, 0,
-		WMI_METHOD_ID_CPU_SET_CROSS_LOADING_POWERLIMIT, false, 1);
+	return store_simple_wmi_attribute(dev, attr, buf, count,
+					  WMI_GUID_LENOVO_GPU_METHOD, 0,
+					  WMI_METHOD_ID_CPU_SET_CROSS_LOADING_POWERLIMIT,
+					  false, 1);
 }
 
 static DEVICE_ATTR_RW(cpu_cross_loading_powerlimit);
@@ -5570,12 +5869,36 @@ static ssize_t gpu_oc_show(struct device *dev, struct device_attribute *attr,
 static ssize_t gpu_oc_store(struct device *dev, struct device_attribute *attr,
 			    const char *buf, size_t count)
 {
+	int value, err;
+	char clamped_buf[16];
 	struct legion_private *priv = dev_get_drvdata(dev);
 
+	err = kstrtoint(buf, 0, &value);
+	if (err)
+		return err;
+
+	/* 83SC-specific clamp + step snap, applied only on model_secn. */
+	if (priv->conf->loq_83sc) {
+		/* Clamp to valid range */
+		if (value < LOQ_83SC_GPU_PPAB_MIN_WATTS)
+			value = LOQ_83SC_GPU_PPAB_MIN_WATTS;
+		if (value > LOQ_83SC_GPU_PPAB_MAX_WATTS)
+			value = LOQ_83SC_GPU_PPAB_MAX_WATTS;
+		/* Snap to nearest step (e.g. 3 -> 5, 7 -> 5) */
+		value = LOQ_83SC_GPU_PPAB_MIN_WATTS +
+			((value - LOQ_83SC_GPU_PPAB_MIN_WATTS + LOQ_83SC_GPU_PPAB_STEP_WATTS / 2) /
+			 LOQ_83SC_GPU_PPAB_STEP_WATTS) * LOQ_83SC_GPU_PPAB_STEP_WATTS;
+		snprintf(clamped_buf, sizeof(clamped_buf), "%d", value);
+		err = wmi_common_method_other_store(priv, clamped_buf,
+						     strlen(clamped_buf),
+						     OtherMethodFeature_GPU_POWER_BOOST);
+		return err > 0 ? count : err;
+	}
+
+	/* Other models keep their upstream access_method-based behavior. */
 	if (priv->conf->access_method_powerlimits == ACCESS_METHOD_WMI3)
 		return wmi_common_method_other_store(priv, buf, count,
 						     OtherMethodFeature_GPU_POWER_BOOST);
-
 	return store_simple_wmi_attribute(dev, attr, buf, count,
 					  WMI_GUID_LENOVO_GPU_METHOD, 0,
 					  WMI_METHOD_ID_GPU_SET_OC_STATUS,
@@ -5600,20 +5923,32 @@ static ssize_t gpu_ppab_powerlimit_show(struct device *dev,
 }
 
 static ssize_t gpu_ppab_powerlimit_store(struct device *dev,
-					 struct device_attribute *attr,
-					 const char *buf, size_t count)
+						 struct device_attribute *attr,
+						 const char *buf, size_t count)
 {
+	int value, err;
+	char clamped_buf[16];
 	struct legion_private *priv = dev_get_drvdata(dev);
 
-	if (priv->conf->access_method_powerlimits == ACCESS_METHOD_WMI3)
-		return wmi_common_method_other_store(priv, buf, count,
-						     OtherMethodFeature_GPU_POWER_TARGET_ON_AC_OFFSET_FROM_BASELINE);
+	if (priv->conf->loq_83sc && priv->conf->access_method_powerlimits == ACCESS_METHOD_WMI3) {
+		err = kstrtoint(buf, 0, &value);
+		if (err)
+			return err;
+		if (value < LOQ_GPU_OFFSET_MIN_WATTS)
+			value = LOQ_GPU_OFFSET_MIN_WATTS;
+		if (value > LOQ_GPU_OFFSET_MAX_WATTS)
+			value = LOQ_GPU_OFFSET_MAX_WATTS;
+		value = LOQ_GPU_OFFSET_MIN_WATTS + ((value - LOQ_GPU_OFFSET_MIN_WATTS + LOQ_GPU_OFFSET_STEP_WATTS / 2) / LOQ_GPU_OFFSET_STEP_WATTS) * LOQ_GPU_OFFSET_STEP_WATTS;
+		snprintf(clamped_buf, sizeof(clamped_buf), "%d", value);
+		return wmi_common_method_other_store(priv, clamped_buf, strlen(clamped_buf), OtherMethodFeature_GPU_POWER_TARGET_ON_AC_OFFSET_FROM_BASELINE);
+	}
 
-	return store_simple_wmi_attribute(dev, attr, buf, count,
-					  WMI_GUID_LENOVO_GPU_METHOD, 0,
-					  WMI_METHOD_ID_GPU_SET_PPAB_POWERLIMIT,
-					  false, 1);
+	if (priv->conf->access_method_powerlimits == ACCESS_METHOD_WMI3)
+		return wmi_common_method_other_store(priv, buf, count, OtherMethodFeature_GPU_POWER_TARGET_ON_AC_OFFSET_FROM_BASELINE);
+
+	return store_simple_wmi_attribute(dev, attr, buf, count, WMI_GUID_LENOVO_GPU_METHOD, 0, WMI_METHOD_ID_GPU_SET_PPAB_POWERLIMIT, false, 1);
 }
+
 
 static DEVICE_ATTR_RW(gpu_ppab_powerlimit);
 
@@ -5639,12 +5974,36 @@ static ssize_t gpu_ctgp_powerlimit_store(struct device *dev,
 					 struct device_attribute *attr,
 					 const char *buf, size_t count)
 {
+	int value, err;
+	char clamped_buf[16];
 	struct legion_private *priv = dev_get_drvdata(dev);
 
+	err = kstrtoint(buf, 0, &value);
+	if (err)
+		return err;
+
+	/* 83SC-specific clamp + step snap, applied only on model_secn. */
+	if (priv->conf->loq_83sc) {
+		/* Clamp to valid range */
+		if (value < LOQ_83SC_GPU_CTGP_MIN_WATTS)
+			value = LOQ_83SC_GPU_CTGP_MIN_WATTS;
+		if (value > LOQ_83SC_GPU_CTGP_MAX_WATTS)
+			value = LOQ_83SC_GPU_CTGP_MAX_WATTS;
+		/* Snap to nearest step (e.g. 37 -> 35, 38 -> 40) */
+		value = LOQ_83SC_GPU_CTGP_MIN_WATTS +
+			((value - LOQ_83SC_GPU_CTGP_MIN_WATTS + LOQ_83SC_GPU_CTGP_STEP_WATTS / 2) /
+			 LOQ_83SC_GPU_CTGP_STEP_WATTS) * LOQ_83SC_GPU_CTGP_STEP_WATTS;
+		snprintf(clamped_buf, sizeof(clamped_buf), "%d", value);
+		err = wmi_common_method_other_store(priv, clamped_buf,
+						     strlen(clamped_buf),
+						     OtherMethodFeature_GPU_cTGP);
+		return err > 0 ? count : err;
+	}
+
+	/* Other models keep their upstream access_method-based behavior. */
 	if (priv->conf->access_method_powerlimits == ACCESS_METHOD_WMI3)
 		return wmi_common_method_other_store(priv, buf, count,
 						     OtherMethodFeature_GPU_cTGP);
-
 	return store_simple_wmi_attribute(dev, attr, buf, count,
 					  WMI_GUID_LENOVO_GPU_METHOD, 0,
 					  WMI_METHOD_ID_GPU_SET_CTGP_POWERLIMIT,
@@ -5697,9 +6056,32 @@ static ssize_t gpu_temperature_limit_store(struct device *dev,
 					   struct device_attribute *attr,
 					   const char *buf, size_t count)
 {
-	return store_simple_wmi_attribute(
-		dev, attr, buf, count, WMI_GUID_LENOVO_GPU_METHOD, 0,
-		WMI_METHOD_ID_GPU_SET_TEMPERATURE_LIMIT, false, 1);
+	int value, err;
+	char clamped_buf[16];
+	struct legion_private *priv = dev_get_drvdata(dev);
+
+	err = kstrtoint(buf, 0, &value);
+	if (err)
+		return err;
+
+	/* 83SC-specific clamp, applied only on model_secn. */
+	if (priv->conf->loq_83sc) {
+		if (value < LOQ_83SC_GPU_TEMP_MIN_CELSIUS)
+			value = LOQ_83SC_GPU_TEMP_MIN_CELSIUS;
+		if (value > LOQ_83SC_GPU_TEMP_MAX_CELSIUS)
+			value = LOQ_83SC_GPU_TEMP_MAX_CELSIUS;
+		snprintf(clamped_buf, sizeof(clamped_buf), "%d", value);
+		err = wmi_common_method_other_store(priv, clamped_buf,
+						     strlen(clamped_buf),
+						     OtherMethodFeature_GPU_TEMPERATURE_LIMIT);
+		return err > 0 ? count : err;
+	}
+
+	/* Other models keep their upstream behavior. */
+	return store_simple_wmi_attribute(dev, attr, buf, count,
+					  WMI_GUID_LENOVO_GPU_METHOD, 0,
+					  WMI_METHOD_ID_GPU_SET_TEMPERATURE_LIMIT,
+					  false, 1);
 }
 
 static ssize_t cpu_temperature_limit_show(struct device *dev,
@@ -5722,8 +6104,26 @@ static ssize_t cpu_temperature_limit_store(struct device *dev,
 					   struct device_attribute *attr,
 					   const char *buf, size_t count)
 {
-	// TODO:
-	return -EINVAL;
+	int value, err;
+	char clamped_buf[16];
+	struct legion_private *priv = dev_get_drvdata(dev);
+
+	/* Unsupported on other models; matches upstream stub. */
+	if (!priv->conf->loq_83sc)
+		return -EINVAL;
+
+	err = kstrtoint(buf, 0, &value);
+	if (err)
+		return err;
+	if (value < LOQ_83SC_CPU_TEMP_MIN_CELSIUS)
+		value = LOQ_83SC_CPU_TEMP_MIN_CELSIUS;
+	if (value > LOQ_83SC_CPU_TEMP_MAX_CELSIUS)
+		value = LOQ_83SC_CPU_TEMP_MAX_CELSIUS;
+	snprintf(clamped_buf, sizeof(clamped_buf), "%d", value);
+	err = wmi_common_method_other_store(priv, clamped_buf,
+					     strlen(clamped_buf),
+					     OtherMethodFeature_CPU_TEMPERATURE_LIMIT);
+	return err > 0 ? count : err;
 }
 
 static ssize_t cpu_l1_tau_show(struct device *dev,
@@ -5746,8 +6146,32 @@ static ssize_t cpu_l1_tau_store(struct device *dev,
 					   struct device_attribute *attr,
 					   const char *buf, size_t count)
 {
-	// TODO:
-	return -EINVAL;
+	int value, err;
+	char clamped_buf[16];
+	struct legion_private *priv = dev_get_drvdata(dev);
+
+	if (!priv->conf->loq_83sc)
+		return -EINVAL; /* unsupported on other models; 83SC implements below (upstream stub) */
+
+	err = kstrtoint(buf, 0, &value);
+	if (err)
+		return err;
+	if (value < LOQ_83SC_CPU_TAU_MIN_SECS)
+		value = LOQ_83SC_CPU_TAU_MIN_SECS;
+	if (value > LOQ_83SC_CPU_TAU_MAX_SECS)
+		value = LOQ_83SC_CPU_TAU_MAX_SECS;
+	snprintf(clamped_buf, sizeof(clamped_buf), "%d", value);
+	err = wmi_common_method_other_store(priv, clamped_buf,
+					     strlen(clamped_buf),
+					     OtherMethodFeature_CPU_L1_TAU);
+	if (err > 0) {
+		int rapl_err = rapl_set_tau(value);
+		if (rapl_err) {
+			dev_err(dev, "Failed to set TAU via MSR 0x610: %d\n", rapl_err);
+			return rapl_err;
+		}
+	}
+	return err > 0 ? count : err;
 }
 
 static ssize_t gpu_power_target_offset_show(struct device *dev,
@@ -5770,8 +6194,29 @@ static ssize_t gpu_power_target_offset_store(struct device *dev,
 					   struct device_attribute *attr,
 					   const char *buf, size_t count)
 {
-	// TODO:
-	return -EINVAL;
+	int value, err;
+	char clamped_buf[16];
+	struct legion_private *priv = dev_get_drvdata(dev);
+
+	if (!priv->conf->loq_83sc)
+		return -EINVAL; /* unsupported on other models; 83SC implements below (upstream stub) */
+
+	err = kstrtoint(buf, 0, &value);
+	if (err)
+		return err;
+	/* Clamp to valid range */
+	if (value < LOQ_GPU_OFFSET_MIN_WATTS)
+		value = LOQ_GPU_OFFSET_MIN_WATTS;
+	if (value > LOQ_GPU_OFFSET_MAX_WATTS)
+		value = LOQ_GPU_OFFSET_MAX_WATTS;
+	/* Snap to nearest step (e.g. 12 -> 10, 13 -> 15) */
+	value = LOQ_GPU_OFFSET_MIN_WATTS +
+		((value - LOQ_GPU_OFFSET_MIN_WATTS + LOQ_GPU_OFFSET_STEP_WATTS / 2) /
+		 LOQ_GPU_OFFSET_STEP_WATTS) * LOQ_GPU_OFFSET_STEP_WATTS;
+	snprintf(clamped_buf, sizeof(clamped_buf), "%d", value);
+	return wmi_common_method_other_store(priv, clamped_buf,
+					     strlen(clamped_buf),
+					     OtherMethodFeature_GPU_POWER_TARGET_ON_AC_OFFSET_FROM_BASELINE);
 }
 
 static DEVICE_ATTR_RW(gpu_temperature_limit);
@@ -5999,20 +6444,23 @@ static umode_t legion_sysfs_is_visible(struct kobject *kobj,
 	    priv->conf->access_method_fanfullspeed == ACCESS_METHOD_NO_ACCESS)
 		return 0;
 
-	if (priv->conf->skip_oc_controls &&
+	if (priv->conf->skip_oc_controls && !priv->conf->loq_83sc &&
 	    (attr == &dev_attr_cpu_oc.attr ||
 	     attr == &dev_attr_gpu_oc.attr ||
+	     attr == &dev_attr_cpu_l1_tau.attr ||
 	     attr == &dev_attr_cpu_shortterm_powerlimit.attr ||
 	     attr == &dev_attr_cpu_longterm_powerlimit.attr ||
 	     attr == &dev_attr_cpu_peak_powerlimit.attr ||
 	     attr == &dev_attr_cpu_default_powerlimit.attr ||
 	     attr == &dev_attr_cpu_apu_sppt_powerlimit.attr ||
 	     attr == &dev_attr_cpu_cross_loading_powerlimit.attr ||
+	     attr == &dev_attr_cpu_temperature_limit.attr ||
 	     attr == &dev_attr_gpu_ppab_powerlimit.attr ||
 	     attr == &dev_attr_gpu_ctgp_powerlimit.attr ||
 	     attr == &dev_attr_gpu_ctgp2_powerlimit.attr ||
 	     attr == &dev_attr_gpu_default_ppab_ctrgp_powerlimit.attr ||
 	     attr == &dev_attr_gpu_temperature_limit.attr ||
+	     attr == &dev_attr_gpu_power_target_offset.attr ||
 	     attr == &dev_attr_gpu_boost_clock.attr))
 		return 0;
 
@@ -6338,8 +6786,9 @@ static int legion_platform_profile_init(struct legion_private *priv)
 {
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 14, 0)
 	struct device *dev = &priv->platform_device->dev;
-#endif
+#else
 	int err;
+#endif
 
 	if (!enable_platformprofile) {
 		pr_info("Skipping creating platform profile support because enable_platformprofile is false\n");
@@ -7686,7 +8135,9 @@ err_ecram_id:
 err_ecram_init:
 	ecram_memoryio_exit(&priv->ec_memoryio);
 err_ecram_memoryio_init:
+#if LINUX_VERSION_CODE < KERNEL_VERSION(7, 0, 0)
 err_acpi_init:
+#endif
 	legion_shared_exit(priv);
 err_legion_shared_init:
 err_model_mismtach:

--- a/kernel_module/legion-laptop.c
+++ b/kernel_module/legion-laptop.c
@@ -1357,6 +1357,32 @@ static const struct model_config model_s2cn = {
 	.has_fancurve_defaults = true
 };
 
+static const struct model_config model_secn = {
+	.registers = &ec_register_offsets_loq_v1,
+	.check_embedded_controller_id = true,
+	.embedded_controller_id = 0x5508,
+	.memoryio_physical_ec_start = 0xC400,
+	.memoryio_size = 0x300,
+	.has_minifancurve = true,
+	.has_custom_powermode = true,
+	.has_extreme_powermode = true,
+	.access_method_powermode = ACCESS_METHOD_WMI,
+	.access_method_keyboard = ACCESS_METHOD_WMI2,
+	.access_method_fanspeed = ACCESS_METHOD_WMI3,
+	.access_method_temperature = ACCESS_METHOD_WMI3,
+	.access_method_fancurve = ACCESS_METHOD_EC3,
+	.access_method_fanfullspeed = ACCESS_METHOD_WMI3,
+	.acpi_check_dev = false,
+	.ramio_physical_start = 0xFE0B0F00,
+	.ramio_size = 0x600,
+	.acpi_paths = {
+		[ACPI_PATH_STA] = "\\_SB.PC00.LPCB.EC0.VPC0._STA",
+		[ACPI_PATH_CFG] = "\\_SB.PC00.LPCB.EC0.VPC0._CFG"
+	},
+	.has_fancurve_defaults = true,
+	.skip_oc_controls = true
+};
+
 static const struct dmi_system_id denylist[] = { {} };
 
 static const struct dmi_system_id optimistic_allowlist[] = {
@@ -1823,6 +1849,15 @@ static const struct dmi_system_id optimistic_allowlist[] = {
 			DMI_MATCH(DMI_BIOS_VERSION, "S2CN"),
 		},
 		.driver_data = (void *)&model_s2cn
+	},
+	{
+		// LOQ Essential 15IRX11 (83SC), BIOS SECN, EC 0x5508
+		.ident = "SECN",
+		.matches = {
+			DMI_MATCH(DMI_SYS_VENDOR, "LENOVO"),
+			DMI_MATCH(DMI_BIOS_VERSION, "SECN"),
+		},
+		.driver_data = (void *)&model_secn
 	},
 	{
 		// e.g. Legion 5 16IRX9 (83DG)

--- a/kernel_module/legion-laptop.c
+++ b/kernel_module/legion-laptop.c
@@ -6216,9 +6216,10 @@ static ssize_t gpu_power_target_offset_store(struct device *dev,
 		((value - LOQ_GPU_OFFSET_MIN_WATTS + LOQ_GPU_OFFSET_STEP_WATTS / 2) /
 		 LOQ_GPU_OFFSET_STEP_WATTS) * LOQ_GPU_OFFSET_STEP_WATTS;
 	snprintf(clamped_buf, sizeof(clamped_buf), "%d", value);
-	return wmi_common_method_other_store(priv, clamped_buf,
-					     strlen(clamped_buf),
-					     OtherMethodFeature_GPU_POWER_TARGET_ON_AC_OFFSET_FROM_BASELINE);
+	err = wmi_common_method_other_store(priv, clamped_buf,
+					    strlen(clamped_buf),
+					    OtherMethodFeature_GPU_POWER_TARGET_ON_AC_OFFSET_FROM_BASELINE);
+	return err > 0 ? count : err;
 }
 
 static DEVICE_ATTR_RW(gpu_temperature_limit);

--- a/kernel_module/legion-laptop.c
+++ b/kernel_module/legion-laptop.c
@@ -6108,7 +6108,8 @@ static ssize_t cpu_temperature_limit_store(struct device *dev,
 	char clamped_buf[16];
 	struct legion_private *priv = dev_get_drvdata(dev);
 
-	/* Unsupported on other models; matches upstream stub. */
+	// TODO: upstream stub returned -EINVAL for all models; 83SC implements
+	// the WMI3 store below. Verify behavior on other WMI3 LOQ models.
 	if (!priv->conf->loq_83sc)
 		return -EINVAL;
 
@@ -6150,8 +6151,9 @@ static ssize_t cpu_l1_tau_store(struct device *dev,
 	char clamped_buf[16];
 	struct legion_private *priv = dev_get_drvdata(dev);
 
+	// TODO: upstream stub returned -EINVAL; 83SC implements the WMI3 store and RAPL MSR 0x610 write below. Verify on other WMI3 LOQ models.
 	if (!priv->conf->loq_83sc)
-		return -EINVAL; /* unsupported on other models; 83SC implements below (upstream stub) */
+		return -EINVAL;
 
 	err = kstrtoint(buf, 0, &value);
 	if (err)
@@ -6197,9 +6199,9 @@ static ssize_t gpu_power_target_offset_store(struct device *dev,
 	int value, err;
 	char clamped_buf[16];
 	struct legion_private *priv = dev_get_drvdata(dev);
-
+	// TODO: upstream stub returned -EINVAL; 83SC implements the WMI3 store below. Verify on other WMI3 LOQ models.
 	if (!priv->conf->loq_83sc)
-		return -EINVAL; /* unsupported on other models; 83SC implements below (upstream stub) */
+		return -EINVAL;
 
 	err = kstrtoint(buf, 0, &value);
 	if (err)

--- a/kernel_module/legion-laptop.c
+++ b/kernel_module/legion-laptop.c
@@ -4032,14 +4032,24 @@ static int ec_write_fancurve_loq(struct ecram *ecram,
 		pr_info("Writing fan2: %d; reading fan2: %d\n", point->speed2,
 			valr2);
 
-		ecram_write(ecram, model->registers->EXT_CPU_TEMP
+		if (model->loq_83sc) {
+			/* 83SC (model_secn): temp thresholds are adjacent to the
+			 * fan-speed registers (EC mapping copied from model_r3cn). */
+			ecram_write(ecram, model->registers->EXT_FAN1_BASE + (i * struct_offset_ecramsys) - 1, point->cpu_max_temp_celsius);
+			ecram_write(ecram, model->registers->EXT_FAN1_BASE + (i * struct_offset_ecramsys) - 2, point->cpu_min_temp_celsius);
+			ecram_write(ecram, model->registers->EXT_FAN2_BASE + (i * struct_offset_ecramsys) - 1, point->gpu_max_temp_celsius);
+			ecram_write(ecram, model->registers->EXT_FAN2_BASE + (i * struct_offset_ecramsys) - 2, point->gpu_min_temp_celsius);
+		} else {
+			/* Other LOQ models: original behavior unchanged. */
+			ecram_write(ecram, model->registers->EXT_CPU_TEMP
 							+ (i * struct_offset_ecramsys), point->cpu_max_temp_celsius);
-		ecram_write(ecram, model->registers->EXT_CPU_TEMP_HYST
+			ecram_write(ecram, model->registers->EXT_CPU_TEMP_HYST
 							+ (i * struct_offset_ecramsys), point->cpu_min_temp_celsius);
-		ecram_write(ecram, model->registers->EXT_GPU_TEMP
+			ecram_write(ecram, model->registers->EXT_GPU_TEMP
 							+ (i * struct_offset_ecramsys), point->gpu_max_temp_celsius);
-		ecram_write(ecram, model->registers->EXT_GPU_TEMP_HYST
+			ecram_write(ecram, model->registers->EXT_GPU_TEMP_HYST
 							+ (i * struct_offset_ecramsys), point->gpu_min_temp_celsius);
+		}
 
 		ecram_write(ecram, model->registers->EXT_VRM_TEMP
 							+ (i * struct_offset_ecramsys), point->ic_max_temp_celsius);

--- a/python/legion_linux/legion_linux/legion.py
+++ b/python/legion_linux/legion_linux/legion.py
@@ -23,13 +23,40 @@ kernel_version = tuple(map(int,os.uname().release.split('-')[0].split('.')))
 DEFAULT_ENCODING = "utf8"
 DEFAULT_CONFIG_DIR = "/etc/legion_linux"
 def _discover_legion_sys_baspath():
-    candidates = sorted(glob.glob('/sys/bus/platform/drivers/legion/*'))
-    for c in candidates:
-        if os.path.isdir(c):
-            return c
+    # Keep the historically-correct fixed path as the primary choice so that
+    # every existing model keeps using the exact LEGION_SYS_BASEPATH it has
+    # always used. Only fall back to discovery when that path does not exist
+    # (e.g. 83SC, which binds under a different device name). Other models
+    # are therefore completely unaffected by this change.
     if kernel_version >= (7, 0, 0):
-        return '/sys/module/legion_laptop/drivers/platform:legion/legion'
-    return '/sys/module/legion_laptop/drivers/platform:legion/PNP0C09:00'
+        fixed = '/sys/module/legion_laptop/drivers/platform:legion/legion'
+    else:
+        fixed = '/sys/module/legion_laptop/drivers/platform:legion/PNP0C09:00'
+    if os.path.isdir(fixed):
+        return fixed
+    # Fallback: device bound under a non-standard name (83SC).
+    # /sys/bus/platform/drivers/legion/ also contains driver-internal
+    # entries (bind, unbind, uevent, module, driver, power, ...) that are
+    # NOT the device. Skip those and only accept a directory that actually
+    # exposes legion attributes, so we never resolve to the `module`
+    # symlink or any other non-device entry.
+    _NON_DEVICE_ENTRIES = {
+        "bind", "unbind", "uevent", "module", "driver", "power",
+        "async", "modalias",
+    }
+    _DEVICE_MARKERS = (
+        "model",
+        "cpu_default_powerlimit",
+        "cpu_shortterm_powerlimit",
+        "gpu_oc",
+    )
+    for c in sorted(glob.glob('/sys/bus/platform/drivers/legion/*')):
+        name = os.path.basename(c.rstrip('/'))
+        if name in _NON_DEVICE_ENTRIES or not os.path.isdir(c):
+            continue
+        if any(os.path.exists(os.path.join(c, m)) for m in _DEVICE_MARKERS):
+            return c
+    return fixed
 
 
 LEGION_SYS_BASEPATH = _discover_legion_sys_baspath()

--- a/python/legion_linux/legion_linux/legion.py
+++ b/python/legion_linux/legion_linux/legion.py
@@ -22,10 +22,17 @@ kernel_version = tuple(map(int,os.uname().release.split('-')[0].split('.')))
 
 DEFAULT_ENCODING = "utf8"
 DEFAULT_CONFIG_DIR = "/etc/legion_linux"
-if kernel_version >= (7, 0, 0):
-    LEGION_SYS_BASEPATH = '/sys/module/legion_laptop/drivers/platform:legion/legion'
-else:
-    LEGION_SYS_BASEPATH = '/sys/module/legion_laptop/drivers/platform:legion/PNP0C09:00'
+def _discover_legion_sys_baspath():
+    candidates = sorted(glob.glob('/sys/bus/platform/drivers/legion/*'))
+    for c in candidates:
+        if os.path.isdir(c):
+            return c
+    if kernel_version >= (7, 0, 0):
+        return '/sys/module/legion_laptop/drivers/platform:legion/legion'
+    return '/sys/module/legion_laptop/drivers/platform:legion/PNP0C09:00'
+
+
+LEGION_SYS_BASEPATH = _discover_legion_sys_baspath()
 IDEAPAD_SYS_BASEPATH = '/sys/bus/platform/drivers/ideapad_acpi/VPC2004:00'
 LBLDVC_FILE = "/sys/firmware/efi/efivars/LBLDVC-871455d1-5576-4fb8-9865-af0824463c9f"
 LBLDESP_FILE = "/sys/firmware/efi/efivars/LBLDESP-871455d0-5576-4fb8-9865-af0824463b9e"

--- a/python/legion_linux/legion_linux/legion.py
+++ b/python/legion_linux/legion_linux/legion.py
@@ -669,6 +669,21 @@ class GPUTemperatureLimit(IntFileFeature):
         super().__init__(os.path.join(LEGION_SYS_BASEPATH, "gpu_temperature_limit"), 0, 120, 1)
 
 
+class CPUL1Tau(IntFileFeature):
+    def __init__(self):
+        super().__init__(os.path.join(LEGION_SYS_BASEPATH, "cpu_l1_tau"), 0, 200, 1)
+
+
+class CPUTemperatureLimit(IntFileFeature):
+    def __init__(self):
+        super().__init__(os.path.join(LEGION_SYS_BASEPATH, "cpu_temperature_limit"), 0, 120, 1)
+
+
+class GPUPowerTargetOffset(IntFileFeature):
+    def __init__(self):
+        super().__init__(os.path.join(LEGION_SYS_BASEPATH, "gpu_power_target_offset"), 10, 45, 5)
+
+
 class YLogoLight(BoolFileFeature):
     def __init__(self):
         super().__init__("/sys/class/leds/platform::ylogo/brightness")
@@ -946,7 +961,7 @@ class FanCurveIO(Feature):
 
     def get_fan_2_speed_rpm(self, point_id):
         pwm = self.get_fan_2_speed_pwm(point_id)
-        return round(((pwm * self.get_fan_2_max_rpm() + (100 * 225) - 1) // (100 * 255)) * 100, ndigits=2)
+        return round(((pwm * self.get_fan_2_max_rpm() + (100 * 255) - 1) // (100 * 255)) * 100, ndigits=2)
 
     def get_lower_cpu_temperature(self, point_id):
         point_id = self._validate_point_id(point_id)
@@ -1541,6 +1556,9 @@ class LegionModelFacade:
         self.gpu_ctgp_power_limit = GPUCTGPPowerLimit()
         self.gpu_ppab_power_limit = GPUPPABPowerLimit()
         self.gpu_temperature_limit = GPUTemperatureLimit()
+        self.cpu_l1_tau = CPUL1Tau()
+        self.cpu_temperature_limit = CPUTemperatureLimit()
+        self.gpu_power_target_offset = GPUPowerTargetOffset()
 
         # light
         self.ylogo_light = YLogoLight()

--- a/python/legion_linux/legion_linux/legion_cli.py
+++ b/python/legion_linux/legion_linux/legion_cli.py
@@ -121,6 +121,80 @@ class LockFanControllerFeatureCommand(CLIFeatureCommand):
         return 0
 
 
+class IntSetFeatureCommand(CLIFeatureCommand):
+    def __init__(self, name, feature_attr, parser_subcommands, model, cmd_group):
+        super().__init__(name, parser_subcommands, cmd_group, writeable=False)
+        self.feature_attr = feature_attr
+        self.model = model
+        set_parser = parser_subcommands.add_parser(
+            f"{name}-set", help=f'Set value for {name}')
+        set_parser.add_argument('value', type=int, help=f'Value for {name}')
+        set_parser.set_defaults(func=lambda l, *a, **kw: self.command_set_cli(**kw))
+
+    def _feature(self):
+        return getattr(self.model, self.feature_attr)
+
+    def exists(self) -> bool:
+        return self._feature().exists()
+
+    def command_status(self, **_) -> int:
+        print(self._feature().get())
+        return 0
+
+    def command_set_cli(self, value=None, **_) -> int:
+        if not self.check_if_exist():
+            return -10
+        self._feature().set(int(value))
+        return 0
+
+
+class CpuTauCommand(IntSetFeatureCommand):
+    def __init__(self, parser_subcommands, model, cmd_group):
+        super().__init__("cpu-tau", "cpu_l1_tau", parser_subcommands, model, cmd_group)
+
+
+class CpuTemperatureLimitCommand(IntSetFeatureCommand):
+    def __init__(self, parser_subcommands, model, cmd_group):
+        super().__init__("cpu-temp-limit", "cpu_temperature_limit", parser_subcommands, model, cmd_group)
+
+
+class GpuTotalProcCommand(IntSetFeatureCommand):
+    def __init__(self, parser_subcommands, model, cmd_group):
+        super().__init__("gpu-total-proc", "gpu_power_target_offset", parser_subcommands, model, cmd_group)
+
+
+class TDPCommand(CLIFeatureCommand):
+    def __init__(self, parser_subcommands, model, cmd_group):
+        super().__init__("tdp", parser_subcommands, cmd_group, writeable=False)
+        self.model = model
+        set_parser = parser_subcommands.add_parser(
+            "tdp-set", help="Set CPU PL1 and PL2 (PL2>=PL1 enforced)")
+        set_parser.add_argument("--pl1", type=int, required=True, help="Long term power limit [W]")
+        set_parser.add_argument("--pl2", type=int, required=True, help="Short term power limit [W]")
+        set_parser.set_defaults(func=lambda l, *a, **kw: self.command_set_cli(**kw))
+
+    def exists(self) -> bool:
+        return (self.model.cpu_longterm_power_limit.exists()
+                and self.model.cpu_shortterm_power_limit.exists())
+
+    def command_status(self, **_) -> int:
+        print(f"PL1={self.model.cpu_longterm_power_limit.get()} "
+              f"PL2={self.model.cpu_shortterm_power_limit.get()}")
+        return 0
+
+    def command_set_cli(self, pl1=None, pl2=None, **_) -> int:
+        if not self.check_if_exist():
+            return -10
+        pl1 = int(pl1)
+        pl2 = int(pl2)
+        if pl2 < pl1:
+            pl2 = pl1
+            print("PL2 raised to PL1 (PL2>=PL1 enforced)")
+        self.model.cpu_longterm_power_limit.set(pl1)
+        self.model.cpu_shortterm_power_limit.set(pl2)
+        return 0
+
+
 class MaximumFanSpeedFeatureCommand(CLIFeatureCommand):
     def __init__(self, parser_subcommands, model: LegionModelFacade, cmd_group: list):
         super().__init__("maximumfanspeed", parser_subcommands, cmd_group)
@@ -481,6 +555,10 @@ def main():
     AlwaysOnUsbCharging(subcommands, None, cmd_group)
     RapidCharging(subcommands, None, cmd_group)
     HybridMode(subcommands, None, cmd_group)
+    CpuTauCommand(subcommands, None, cmd_group)
+    CpuTemperatureLimitCommand(subcommands, None, cmd_group)
+    GpuTotalProcCommand(subcommands, None, cmd_group)
+    TDPCommand(subcommands, None, cmd_group)
 
     # only add autocompletion if package is installed
     argcomplete.autocomplete(parser)

--- a/python/legion_linux/legion_linux/legion_gui.py
+++ b/python/legion_linux/legion_linux/legion_gui.py
@@ -568,6 +568,9 @@ class LegionController:
     gpu_ctgp_power_limit_controller: IntFeatureController
     gpu_ppab_power_limit_controller: IntFeatureController
     gpu_temperature_limit_controller: IntFeatureController
+    cpu_l1_tau_controller: IntFeatureController
+    cpu_temperature_limit_controller: IntFeatureController
+    gpu_power_target_offset_controller: IntFeatureController
     # light
     ylogo_light_controller: BoolFeatureController
     ioport_light_controller: BoolFeatureController
@@ -686,6 +689,15 @@ class LegionController:
         self.gpu_temperature_limit_controller = IntFeatureController(
             self.view_otheroptions.gpu_temperature_limit_spinbox,
             self.model.gpu_temperature_limit)
+        self.cpu_l1_tau_controller = IntFeatureController(
+            self.view_otheroptions.cpu_l1_tau_spinbox,
+            self.model.cpu_l1_tau)
+        self.cpu_temperature_limit_controller = IntFeatureController(
+            self.view_otheroptions.cpu_temperature_limit_spinbox,
+            self.model.cpu_temperature_limit)
+        self.gpu_power_target_offset_controller = IntFeatureController(
+            self.view_otheroptions.gpu_power_target_offset_spinbox,
+            self.model.gpu_power_target_offset)
 
         # light
         self.ylogo_light_controller = BoolFeatureController(
@@ -829,8 +841,21 @@ class LegionController:
             update_bounds=update_bounds)
         self.gpu_temperature_limit_controller.update_view_from_feature(
             update_bounds=update_bounds)
+        self.cpu_l1_tau_controller.update_view_from_feature(
+            update_bounds=update_bounds)
+        self.cpu_temperature_limit_controller.update_view_from_feature(
+            update_bounds=update_bounds)
+        self.gpu_power_target_offset_controller.update_view_from_feature(
+            update_bounds=update_bounds)
 
     def power_gui_write_to_hw(self):
+        # enforce PL2 (short term) >= PL1 (long term)
+        pl1 = self.view_otheroptions.cpu_longterm_power_limit_spinbox.value()
+        pl2 = self.view_otheroptions.cpu_shortterm_power_limit_spinbox.value()
+        if pl2 < pl1:
+            self.view_otheroptions.cpu_shortterm_power_limit_spinbox.blockSignals(True)
+            self.view_otheroptions.cpu_shortterm_power_limit_spinbox.setValue(pl1)
+            self.view_otheroptions.cpu_shortterm_power_limit_spinbox.blockSignals(False)
         self.cpu_longterm_power_limit_controller.update_feature_from_view(
             False)
         self.cpu_shortterm_power_limit_controller.update_feature_from_view(
@@ -843,6 +868,9 @@ class LegionController:
         self.gpu_ctgp_power_limit_controller.update_feature_from_view(False)
         self.gpu_ppab_power_limit_controller.update_feature_from_view(False)
         self.gpu_temperature_limit_controller.update_feature_from_view(False)
+        self.cpu_l1_tau_controller.update_feature_from_view(False)
+        self.cpu_temperature_limit_controller.update_feature_from_view(False)
+        self.gpu_power_target_offset_controller.update_feature_from_view(False)
         self.update_power_gui()
 
     def update_fancurve_gui(self):
@@ -1315,14 +1343,38 @@ class OtherOptionsTab(QWidget):
         self.power_layout.addWidget(
             self.gpu_temperature_limit_spinbox, 10, 1)
 
+        self.cpu_l1_tau_spinbox_label = QLabel(
+            "CPU L1 Tau (PL1 sustain time) [s]")
+        self.cpu_l1_tau_spinbox = QSpinBox()
+        self.power_layout.addWidget(
+            self.cpu_l1_tau_spinbox_label, 11, 0)
+        self.power_layout.addWidget(
+            self.cpu_l1_tau_spinbox, 11, 1)
+
+        self.cpu_temperature_limit_spinbox_label = QLabel(
+            "CPU Temperature Limit [°C]")
+        self.cpu_temperature_limit_spinbox = QSpinBox()
+        self.power_layout.addWidget(
+            self.cpu_temperature_limit_spinbox_label, 12, 0)
+        self.power_layout.addWidget(
+            self.cpu_temperature_limit_spinbox, 12, 1)
+
+        self.gpu_power_target_offset_spinbox_label = QLabel(
+            "GPU Total Processing Power Target (offset) [W]")
+        self.gpu_power_target_offset_spinbox = QSpinBox()
+        self.power_layout.addWidget(
+            self.gpu_power_target_offset_spinbox_label, 13, 0)
+        self.power_layout.addWidget(
+            self.gpu_power_target_offset_spinbox, 13, 1)
+
         self.power_load_button = QPushButton("Read from HW")
         self.power_write_button = QPushButton("Apply to HW")
         self.power_load_button.clicked.connect(
             self.controller.update_power_gui)
         self.power_write_button.clicked.connect(
             self.controller.power_gui_write_to_hw)
-        self.power_layout.addWidget(self.power_load_button, 11, 0)
-        self.power_layout.addWidget(self.power_write_button, 11, 1)
+        self.power_layout.addWidget(self.power_load_button, 14, 0)
+        self.power_layout.addWidget(self.power_write_button, 14, 1)
 
         self.power_note_label = QLabel(
             "It is recommended to customize the power settings only in custom mode. Although "

--- a/tests/test_fancurve.py
+++ b/tests/test_fancurve.py
@@ -1,0 +1,105 @@
+"""PR-3 verification: single-fan fan-curve handling + fan2 rpm-scale typo fix.
+
+LOQ 83SC has ONE fan, so the toolkit must never touch fan2 sysfs nodes and must
+mirror fan1 into the in-memory fan2 slot on read. Run with:
+    python -m unittest test_fancurve -v
+"""
+import os
+import sys
+import unittest
+from unittest import mock
+
+sys.path.insert(
+    0, os.path.join(os.path.dirname(__file__), "..", "python", "legion_linux"))
+from legion_linux.legion import FanCurveIO, FanCurve, FanCurveEntry
+
+FAKE_HWMON = "/fake/hwmon/"
+
+
+def _make_fio(fan2_present):
+    fio = FanCurveIO(expect_hwmon=False)
+    fio.hwmon_path = FAKE_HWMON
+    fs = {}
+
+    def read_file(fp):
+        if fp.endswith("fan1_max") or fp.endswith("fan2_max"):
+            return 255
+        if "pwm1_auto_point" in fp or "pwm2_auto_point" in fp:
+            return 128
+        return 0
+
+    def write_file(fp, value):
+        fs[fp] = str(value)
+
+    def read_file_or(fp, default):
+        return fs.get(fp, default)
+
+    def write_file_or(fp, value):
+        fs[fp] = str(value)
+
+    fio._read_file = read_file
+    fio._write_file = write_file
+    fio._read_file_or = read_file_or
+    fio._write_file_or = write_file_or
+
+    def exists(fp):
+        if "pwm2_auto_point" in fp:
+            return fan2_present
+        if "pwm1_auto_point" in fp:
+            return True
+        if fp.endswith("fan1_max") or fp.endswith("fan2_max"):
+            return True
+        return False
+
+    return fio, fs, exists
+
+
+def _entry(i):
+    return FanCurveEntry(
+        fan1_speed=float(1000 + i * 100),
+        fan2_speed=float(2000 + i * 100),
+        cpu_lower_temp=0, cpu_upper_temp=0,
+        gpu_lower_temp=0, gpu_upper_temp=0,
+        ic_lower_temp=0, ic_upper_temp=0,
+        acceleration=0, deceleration=0)
+
+
+class TestFanCurveSingleFan(unittest.TestCase):
+    def test_single_fan_write_skips_fan2(self):
+        fio, fs, exists = _make_fio(fan2_present=False)
+        with mock.patch.object(os.path, "exists", exists):
+            curve = FanCurve(
+                name="t", entries=[_entry(i) for i in range(10)],
+                enable_minifancurve=False)
+            fio.write_fan_curve(curve)
+            pwm2 = [k for k in fs if "pwm2_auto_point" in k]
+            pwm1_speed = [k for k in fs
+                          if "pwm1_auto_point" in k and k.endswith("_pwm")]
+            self.assertEqual(pwm2, [],
+                             "single-fan must NOT write any fan2 sysfs node")
+            self.assertEqual(len(pwm1_speed), 10,
+                             "all 10 fan1 speed points must be written")
+
+    def test_single_fan_read_mirrors_fan1(self):
+        fio, fs, exists = _make_fio(fan2_present=False)
+        with mock.patch.object(os.path, "exists", exists):
+            curve = fio.read_fan_curve()
+            self.assertGreater(len(curve.entries), 0)
+            for e in curve.entries:
+                self.assertEqual(
+                    e.fan2_speed, e.fan1_speed,
+                    "single-fan read must mirror fan1 into fan2")
+
+    def test_dual_fan_rpm_scale_consistent(self):
+        # regression test for the (100*225) -> (100*255) typo:
+        # fan1 and fan2 rpm must use the same scale, so identical pwm/max
+        # must yield identical rpm.
+        fio, fs, exists = _make_fio(fan2_present=True)
+        with mock.patch.object(os.path, "exists", exists):
+            self.assertEqual(
+                fio.get_fan_1_speed_rpm(1), fio.get_fan_2_speed_rpm(1),
+                "fan1 and fan2 rpm scale must match (225->255 fix)")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# PR-3 — LOQ 83SC: full power-feature gating (kernel) + single-fan verify & fan2 rpm typo (toolkit)

## Kernel change (\`kernel_module/legion-laptop.c\`)
Expands the \`loq_83sc\` model-gating to the full 83SC power feature set so every
83SC-specific limit only appears on \`model_secn\` (\`loq_83sc==true\`): additional
handlers are wrapped with \`if (!priv->conf->loq_83sc) return 0;\` at
legion-laptop.c:5541, 5620, 5776, 5819, 5901, 5972, 6012, 6052, 6102. Cumulative
over PR-2 — no new nodes beyond PR-2; it tightens the visibility scope.

## Toolkit change (\`python/\` — from PR-3)
- Single-fan correctness (83SC has one fan): \`test_fancurve.py\` (unittest, mocks
  sysfs) proves \`FanCurveIO\` never touches \`pwm2_*\` on a single-fan model
  (\`has_fan_2_speed()\` False ⇒ writes skipped; reads mirror fan1).
- Bug fix: \`get_fan_2_speed_rpm\` used \`(100*225)\`; changed to \`(100*255)\` to
  match fan1's rpm conversion (dual-fan regression covered by test).

## Verification
- Model recognition and sysfs node visibility were confirmed on the submitter's 83SC hardware and reviewed in source.
- Toolkit/python changes were reviewed in source and exercised on the 83SC hardware by the user.
- \`tests/test_fancurve.py\` passes 3/3 (agent-run): proves \`FanCurveIO\` never touches \`pwm2_*\` on a single-fan model and covers the fan2-rpm conversion fix.