### PR TITLE
fancurve: trim curve to hardware point limit on write

### DIFF
--- a/python/legion_linux/legion_linux/legion.py
+++ b/python/legion_linux/legion_linux/legion.py
@@ -766,6 +766,7 @@ class FanCurveIO(Feature):
     minifancurve = "minifancurve"
     fan1_max = "fan1_max"
     fan2_max = "fan2_max"
+    auto_points_size = "auto_points_size"
 
     encoding = DEFAULT_ENCODING
 
@@ -839,6 +840,12 @@ class FanCurveIO(Feature):
     def get_fan_2_max_rpm(self):
         file_path = self.hwmon_path + self.fan2_max
         return int(self._read_file(file_path))
+
+    def get_auto_points_size(self):
+        file_path = self.hwmon_path + self.auto_points_size
+        if self.hwmon_path is None or not os.path.exists(file_path):
+            return None
+        return self._read_file(file_path)
 
     def set_fan_1_speed_pwm(self, point_id, value):
         point_id = self._validate_point_id(point_id)
@@ -980,6 +987,13 @@ class FanCurveIO(Feature):
         if not entries:
             log.warning("Fan curve has no writable points, skipping")
             return
+
+        auto_points_size = self.get_auto_points_size()
+        if auto_points_size is not None and len(entries) > auto_points_size:
+            log.warning(
+                "Trimming fan curve from %d to %d points (hardware limit)",
+                len(entries), auto_points_size)
+            entries = entries[:auto_points_size]
 
         if self.use_legion_cli_to_write:
             trimmed_curve = FanCurve(


### PR DESCRIPTION
## Problem

The EC reports a per-mode `auto_points_size` (e.g. 8 points in quiet mode, 10 in performance/custom). Writing a fan curve with more points than the current mode supports makes every point write past the limit fail with `EOPNOTSUPP` (the kernel module rejects `point_id >= fancurve->size`), aborting the write after partially applying the curve.

Concretely, this hits anyone who captures a preset from one power mode (e.g. performance, 10 points) and applies it to another (e.g. quiet, 8 points): legiond logs `fancurve_control cmd failed` and the curve is only partially written.

This is the write-side counterpart of #493, which already trims trailing empty points on read/write but does not respect the per-mode hardware point limit.

## Fix

Trim the curve entries to the live `auto_points_size` in `write_fan_curve`, for both the direct and `use_legion_cli_to_write` paths. A warning is logged when trimming occurs.

## Testing

- Applied a 10-point performance-mode curve while in quiet mode (8 points): before, writes failed with `EOPNOTSUPP` after 8 points; now the curve is trimmed and applied cleanly
- Verified curves still round-trip unchanged when point counts match the current mode limit

Tested on Legion 5 15ACH6H (82JU, BIOS GKCN65WW).