### PR TITLE
legiond: fix wrong/missing fan curve and GPU TDP on battery for performance and extreme

### DIFF
--- a/extra/service/legiond/modules/powerstate.c
+++ b/extra/service/legiond/modules/powerstate.c
@@ -35,7 +35,7 @@ POWER_STATE get_powerstate()
 	}
 	
 	char profile[30];
-	if (fscanf(fp, "%s", profile) != 1) {
+	if (fscanf(fp, "%29s", profile) != 1) {
 		printf("failed to get power_profile\n");
 		fclose(fp);
 		return P_ERROR_PROFILE;
@@ -58,7 +58,25 @@ POWER_STATE get_powerstate()
 
 
 	if (!ac_state && power_state != -1) {
-		power_state++;
+		switch (power_state) {
+		case P_AC_Q:
+			power_state = P_BAT_Q;
+			break;
+		case P_AC_B:
+			power_state = P_BAT_B;
+			break;
+		case P_AC_BP:
+			power_state = P_BAT_BP;
+			break;
+		case P_AC_P:
+			power_state = P_BAT_P;
+			break;
+		case P_AC_E:
+			power_state = P_BAT_E;
+			break;
+		default:
+			break;
+		}
 	}
 
 	return power_state;

--- a/extra/service/legiond/modules/powerstate.h
+++ b/extra/service/legiond/modules/powerstate.h
@@ -9,7 +9,9 @@ typedef enum _POWER_STATE {
 	P_AC_BP = 4,
 	P_BAT_BP = 5,
 	P_AC_P = 6,
-    P_AC_E = 7,
+	P_BAT_P = 7,
+	P_AC_E = 8,
+	P_BAT_E = 9,
 } POWER_STATE;
 
 #define P_ERROR_PROFILE -1

--- a/extra/service/legiond/modules/setapply.c
+++ b/extra/service/legiond/modules/setapply.c
@@ -88,10 +88,17 @@ int set_fancurve(POWER_STATE power_state, LEGIOND_CONFIG *config)
 	case P_AC_P:
 		strcat(cmd, "performance-ac");
 		break;
+	case P_BAT_P:
+		strcat(cmd, "performance-battery");
+		break;
 	case P_AC_E:
 		strcat(cmd, "extreme-ac");
 		break;
-    default:
+	case P_BAT_E:
+		/* no extreme-battery preset exists yet; keep max cooling */
+		strcat(cmd, "extreme-ac");
+		break;
+	default:
 		cmd[0] = '\0';
 		break;
 	}

--- a/extra/service/legiond/modules/setapply.c
+++ b/extra/service/legiond/modules/setapply.c
@@ -125,47 +125,59 @@ int set_gpu(POWER_STATE power_state, LEGIOND_CONFIG *config)
 		printf("skip gpu_control\n");
 		return 0;
 	}
-	char cmd[100];
+
+	const char *tool;
 	if (strcmp(config->gpu_control, "nvidia") == 0) {
-		strcpy(cmd, "/opt/bin/nvidia-smi -pl ");
+		tool = "/opt/bin/nvidia-smi -pl ";
 	} else if (strcmp(config->gpu_control, "radeon") == 0) {
-		strcpy(cmd, "/opt/bin/rocm-smi --setpoweroverdrive ");
+		tool = "/opt/bin/rocm-smi --setpoweroverdrive ";
+	} else {
+		printf("unknown gpu_control value: %s\n", config->gpu_control);
+		printf("skip gpu_control\n");
+		return 0;
 	}
 
+	const char *tdp;
 	switch (power_state) {
 	case P_AC_Q:
-		strcat(cmd, config->gpu_tdp_ac_q);
+		tdp = config->gpu_tdp_ac_q;
 		break;
 	case P_BAT_Q:
-		strcat(cmd, config->gpu_tdp_bat_q);
+		tdp = config->gpu_tdp_bat_q;
 		break;
 	case P_AC_B:
-		strcat(cmd, config->gpu_tdp_ac_b);
+		tdp = config->gpu_tdp_ac_b;
 		break;
 	case P_BAT_B:
-		strcat(cmd, config->gpu_tdp_bat_b);
+		tdp = config->gpu_tdp_bat_b;
 		break;
 	case P_AC_BP:
-		strcat(cmd, config->gpu_tdp_ac_bp);
+		tdp = config->gpu_tdp_ac_bp;
 		break;
 	case P_BAT_BP:
-		strcat(cmd, config->gpu_tdp_bat_bp);
+		tdp = config->gpu_tdp_bat_bp;
 		break;
 	case P_AC_P:
-		strcat(cmd, config->gpu_tdp_ac_p);
+		tdp = config->gpu_tdp_ac_p;
 		break;
 	case P_AC_E:
-		strcat(cmd, config->gpu_tdp_ac_e);
+		tdp = config->gpu_tdp_ac_e;
 		break;
 	default:
-		cmd[0] = 0;
+		tdp = NULL;
 		break;
 	}
 
+	char cmd[100];
 	int result = 0;
 
-	if (cmd[0] != '\0') {
-		result = system(cmd);
+	if (tdp != NULL && tdp[0] != '\0') {
+		int written = snprintf(cmd, sizeof(cmd), "%s%s", tool, tdp);
+		if (written < 0 || written >= (int)sizeof(cmd)) {
+			printf("gpu_control cmd too long, skipping\n");
+		} else {
+			result = system(cmd);
+		}
 	}
 
 	if (result != 0) {


### PR DESCRIPTION
## Problem

`POWER_STATE` paired every AC state with its battery state at `value + 1` (`P_AC_Q`/`P_BAT_Q`, ...), and `get_powerstate()` relied on that invariant by simply incrementing the state when running on battery. `P_AC_E = 7` was appended directly after `P_AC_P = 6` without a battery partner, which breaks the invariant:

| Situation | Resolved state | Effect before this patch |
|---|---|---|
| performance, on battery | `P_AC_E` (6+1) | applies the **extreme-ac** fan curve and the extreme **AC** GPU TDP while unplugged |
| extreme, on battery | `8` (nonexistent) | every switch falls to `default:` → **nothing applied at all** |

Evidence that separate battery handling was intended: the packages ship `performance-battery.yaml`, but no code path could ever select it — there was no `P_BAT_P` anywhere.

## Fix

- Add `P_BAT_P` and `P_BAT_E`, keeping AC/battery pairs adjacent
- Replace the blind `power_state++` with an explicit AC→battery mapping so adding future profiles cannot silently reintroduce the bug
- `set_fancurve()`: `P_BAT_P` → `performance-battery` (now reachable); `P_BAT_E` → `extreme-ac` as an explicit fallback since no `extreme-battery` preset exists yet (open to changing this if you'd prefer a dedicated preset)
- `set_cpu()`/`set_gpu()`: new states intentionally fall through to default as no config fields exist for them yet

## Also included

Hardening of `set_gpu()` found while working here:
- `cmd[100]` was uninitialized and only filled for `nvidia`/`radeon`; any other non-`false` `gpu_control` value made `strcat()` append to uninitialized stack memory and `system()` execute it. Now unknown values are skipped with a message
- Config-provided TDP strings were appended with unbounded `strcat()`; now built with `snprintf()` and truncation-checked
- Bound the `platform_profile` `fscanf()` to the buffer size

## Testing

- Builds warning-free (`make` in `extra/service/legiond`)
- Verified `get_powerstate()` on real hardware (Legion 5 15ACH6H, GKCN65WW): `low-power` + AC correctly resolves to `P_AC_Q`
- Mapping table verified for all 10 states