### PR TITLE
fan_control.sh: remove hardcoded personal path

### DIFF
--- a/fan_control.sh
+++ b/fan_control.sh
@@ -3,47 +3,71 @@
 # Legion Fan Control Script
 # Usage: ./fan_control.sh [enable|disable|status]
 
+LEGION_SYS="/sys/module/legion_laptop/drivers/platform:legion"
+
+find_base() {
+	local base
+	for base in "$LEGION_SYS/PNP0C09:00" "$LEGION_SYS/legion"; do
+		[ -d "$base" ] && printf '%s\n' "$base" && return 0
+	done
+	return 1
+}
+
+set_attr() {
+	echo "$2" | sudo tee "$1/$3" > /dev/null
+}
+
+read_attr() {
+	cat "$1/$2" 2>/dev/null || echo "n/a"
+}
+
+show_status() {
+	local base=$1
+	if command -v sensors > /dev/null 2>&1; then
+		sensors -u | grep -A 20 "legion_hwmon" | head -25
+	fi
+	echo ""
+	echo "🎛️ Current Settings:"
+	echo "Fan Full Speed: $(read_attr "$base" fan_fullspeed)"
+	echo "Fan Max Speed:  $(read_attr "$base" fan_maxspeed)"
+	echo "Power Mode:     $(read_attr "$base" powermode)"
+}
+
+BASE=$(find_base) || {
+	echo "Error: legion-laptop sysfs interface not found (is the module loaded?)"
+	exit 1
+}
+
 case "$1" in
-    "enable")
-        echo "🔥 Enabling high-performance fan mode..."
-        echo 1 | sudo tee /sys/module/legion_laptop/drivers/platform:legion/PNP0C09:00/fan_fullspeed > /dev/null
-        echo 1 | sudo tee /sys/module/legion_laptop/drivers/platform:legion/PNP0C09:00/fan_maxspeed > /dev/null
-        echo 2 | sudo tee /sys/module/legion_laptop/drivers/platform:legion/PNP0C09:00/powermode > /dev/null
-        sudo /home/xuananh/Downloads/LenovoLegionLinux/.venv/bin/legion_cli maximumfanspeed-enable
-        echo "✅ High-performance fan mode enabled!"
-        echo "📊 Current fan speeds:"
-        sensors legion_hwmon-isa-0000
-        ;;
-    "disable")
-        echo "🌡️ Disabling high-performance fan mode..."
-        echo 0 | sudo tee /sys/module/legion_laptop/drivers/platform:legion/PNP0C09:00/fan_fullspeed > /dev/null
-        echo 0 | sudo tee /sys/module/legion_laptop/drivers/platform:legion/PNP0C09:00/fan_maxspeed > /dev/null
-        echo 3 | sudo tee /sys/module/legion_laptop/drivers/platform:legion/PNP0C09:00/powermode > /dev/null
-        sudo /home/xuananh/Downloads/LenovoLegionLinux/.venv/bin/legion_cli maximumfanspeed-disable
-        echo "✅ Automatic fan mode restored!"
-        echo "📊 Current fan speeds:"
-        sensors legion_hwmon-isa-0000
-        ;;
-    "status")
-        echo "📊 Current Legion Fan Status:"
-        echo "================================"
-        sensors legion_hwmon-isa-0000
-        echo ""
-        echo "🎛️ Current Settings:"
-        echo "Fan Full Speed: $(cat /sys/module/legion_laptop/drivers/platform:legion/PNP0C09:00/fan_fullspeed)"
-        echo "Fan Max Speed:  $(cat /sys/module/legion_laptop/drivers/platform:legion/PNP0C09:00/fan_maxspeed)"
-        echo "Power Mode:     $(cat /sys/module/legion_laptop/drivers/platform:legion/PNP0C09:00/powermode)"
-        ;;
-    *)
-        echo "Legion Fan Control Script"
-        echo "========================"
-        echo "Usage: $0 [enable|disable|status]"
-        echo ""
-        echo "Commands:"
-        echo "  enable  - Enable high-performance fan mode (~2900 RPM)"
-        echo "  disable - Return to automatic fan control (~2300 RPM)"
-        echo "  status  - Show current fan speeds and settings"
-        echo ""
-        echo "Note: Requires sudo privileges"
-        ;;
+	"enable")
+		echo "🔥 Enabling high-performance fan mode..."
+		set_attr "$BASE" 1 fan_fullspeed
+		set_attr "$BASE" 1 fan_maxspeed
+		echo "✅ High-performance fan mode enabled!"
+		show_status "$BASE"
+		;;
+	"disable")
+		echo "🌡️ Disabling high-performance fan mode..."
+		set_attr "$BASE" 0 fan_fullspeed
+		set_attr "$BASE" 0 fan_maxspeed
+		echo "✅ Automatic fan control restored!"
+		show_status "$BASE"
+		;;
+	"status")
+		echo "📊 Current Legion Fan Status:"
+		echo "================================"
+		show_status "$BASE"
+		;;
+	*)
+		echo "Legion Fan Control Script"
+		echo "========================"
+		echo "Usage: $0 [enable|disable|status]"
+		echo ""
+		echo "Commands:"
+		echo "  enable  - Force maximum fan speed"
+		echo "  disable - Return to automatic fan curve control"
+		echo "  status  - Show current fan speeds and settings"
+		echo ""
+		echo "Note: Requires sudo privileges for enable/disable."
+		;;
 esac


### PR DESCRIPTION
## Problem

`fan_control.sh` could not run on any machine except its original author's:

1. `legion_cli` was invoked through a hardcoded private venv path (`/home/xuananh/Downloads/LenovoLegionLinux/.venv/bin/`), which fails everywhere else — and was redundant anyway, since the script already wrote `fan_fullspeed`/`fan_maxspeed` directly via sysfs right before
2. The sysfs base path was hardcoded to `PNP0C09:00`, which no longer exists on kernels >= 7.0 (interface moved to `platform:legion/legion`) — so even `status` failed there
3. `enable` wrote `powermode 2` (balanced) and `disable` wrote `powermode 3` (performance) — backwards relative to their labels

## Fix

- Auto-detect the sysfs base path: try the legacy `PNP0C09:00` layout first, then the kernel >= 7.0 `legion` layout — works on both
- Remove the foreign venv invocation and the duplicate write; direct sysfs writes are sufficient
- Drop the unrelated power-mode writes so the script does one job (force full fan speed on/off)
- Clear error message when the module interface is missing; `n/a` for unreadable attributes

## Testing

- Ran on Legion 5 15ACH6H (82JU), CachyOS kernel 7.2.0 (`legion` path): `status` reports correct fan RPMs and settings
- `bash -n` syntax check clean