### PR TITLE
fix(legion): correct quiet-mode check, fan2 rpm typo, and CLI exit codes

### DIFF
--- a/python/legion_linux/legion_linux/legion.py
+++ b/python/legion_linux/legion_linux/legion.py
@@ -453,9 +453,10 @@ class BatteryConservation(BoolFileFeature):
         return super().set(value)
 
     def set_if_not_set(self, value: bool) -> None:
-        if value is not self.get():
+        if value != self.get():
             self.set(value)
-        print(f"Already has value {value} - skip setting again.")
+        else:
+            print(f"Already has value {value} - skip setting again.")
 
 
 class RapidChargingFeature(BoolFileFeature):
@@ -919,7 +920,7 @@ class FanCurveIO(Feature):
 
     def get_fan_2_speed_rpm(self, point_id):
         pwm = self.get_fan_2_speed_pwm(point_id)
-        return round(((pwm * self.get_fan_2_max_rpm() + (100 * 225) - 1) // (100 * 255)) * 100, ndigits=2)
+        return round(((pwm * self.get_fan_2_max_rpm() + (100 * 255) - 1) // (100 * 255)) * 100, ndigits=2)
 
     def get_lower_cpu_temperature(self, point_id):
         point_id = self._validate_point_id(point_id)
@@ -1385,7 +1386,7 @@ class NVIDIAGPUOnQuietMode(Monitor):
 
     def run(self) -> List[DiagnosticMsg]:
         is_gpu_running = self.gpu_is_running.get()
-        is_quiet_mode = self.platform_profile.get() == "quiet"
+        is_quiet_mode = self.platform_profile.get() == "low-power"
         diag = DiagnosticMsg()
         if is_gpu_running and is_quiet_mode:
             diag.value = True

--- a/python/legion_linux/legion_linux/legion_cli.py
+++ b/python/legion_linux/legion_linux/legion_cli.py
@@ -418,7 +418,7 @@ def create_argparser()->argparse.ArgumentParser:
     monitor_cmd = subcommands.add_parser(
         'monitor', help='Run monitors with notifications')
     monitor_cmd.add_argument(
-        'period', type=int, help='Monitoring period in seconds', default=60)
+        'period', type=int, nargs='?', help='Monitoring period in seconds', default=60)
     monitor_cmd.set_defaults(
         func=monitor)
 
@@ -498,8 +498,8 @@ def main():
         if "preset_dir" in args and args.preset_dir is not None:
             legion.set_preset_folder(args.preset_dir)
 
-        args.func(legion, **vars(args))
+        return args.func(legion, **vars(args))
 
 
 if __name__ == '__main__':
-    main()
+    sys.exit(main())


### PR DESCRIPTION
Identified during a code review of the Python package. Five small functional fixes across `legion.py` and `legion_cli.py`:

### `legion.py`
1. **`NVIDIAGPUOnQuietMode` monitor was dead code** — compared the platform profile against `"quiet"`, but the valid `PlatformProfileFeature` values are `low-power/balanced/performance/custom/max-power`, so `is_quiet_mode` was always `False` and the "Running on quiet mode with dGPU on" battery warning never fired. Now compares against `"low-power"`.
2. **Fan2 RPM readback typo** — `get_fan_2_speed_rpm` used `(100 * 225)` while fan1 and both writers use `(100 * 255)`, producing inconsistent/wrong fan2 speed values. Now consistent.
3. **`BatteryConservation.set_if_not_set` identity comparison** — `value is not self.get()` was object identity, so `0`/`1` args compared as not-equal even when the state already matched, forcing redundant writes. Now uses `!=`, and the "already has value" log only prints when actually skipping.

### `legion_cli.py`
4. **Exit codes were silently discarded** — `main()` called `args.func(...)` but ignored its return (handlers like `set_feature` return `-2`, feature commands return `-10`), so `legion_cli` always exited 0 even on error. Now returns the handler code and `sys.exit(main())` propagates it. Verified: a bad `set-feature` now exits `254` instead of `0`.
5. **`legion monitor` required a period** — `period` was a positional with `default=60`, but positionals ignore `default`, so `legion monitor` errored "required: period". Now uses `nargs='?'` and the 60s default is honored.

All files compile and `tests/test_python_cli.sh` passes.