### PR TITLE
legion-laptop: add missing RAPIDCHARGE ACPI paths for LZCN (LOQ 15IRH8)

### DIFF
--- a/kernel_module/legion-laptop.c
+++ b/kernel_module/legion-laptop.c
@@ -1261,7 +1261,9 @@ static const struct model_config model_lzcn = {
 	.ramio_size = 0x600,
 	.acpi_paths = {
 		[ACPI_PATH_STA] = "\\_SB.PC00.LPCB.EC0.VPC0._STA",
-		[ACPI_PATH_CFG] = "\\_SB.PC00.LPCB.EC0.VPC0._CFG"
+		[ACPI_PATH_CFG] = "\\_SB.PC00.LPCB.EC0.VPC0._CFG",
+		[ACPI_PATH_READ_RAPIDCHARGE] = "\\_SB.PC00.LPCB.EC0.VPC0.GBMD",
+		[ACPI_PATH_WRITE_RAPIDCHARGE] = "\\_SB.PC00.LPCB.EC0.VPC0.SBMC"
 	},
 	.has_fancurve_defaults = true
 };


### PR DESCRIPTION
## Summary
`model_lzcn` (BIOS `LZCN`, e.g. LOQ 15IRH8) defines `.acpi_paths` for `_STA`/`_CFG` but never got the RAPIDCHARGE read/write paths added, even though it uses the same VPC0 EC device (`\_SB.PC00.LPCB.EC0.VPC0`) as other models that already have this exact pair wired up off the identical base path.

Without it, `legion_rapidcharge_is_supported()` fails its `acpi_method_exists()` check and the `rapidcharge` sysfs attribute is hidden entirely on this hardware — not because the capability is missing, but because the path table entry was never added for this specific model.

## Verification
Confirmed on real `LZCN39WW` hardware:
- `GBMD` correctly reports the rapid-charge bit
- `SBMC` with `FCT_RAPID_CHARGE_ON`/`FCT_RAPID_CHARGE_OFF` (7/8) toggles it
- Before this fix existed, verified the same GBMD/SBMC method directly via `acpi_call` (bypassing the driver) — confirming the underlying ACPI capability genuinely exists on this model, it just wasn't exposed
- After applying this fix locally and rebuilding, `rapidcharge` appears in sysfs and correctly reads/reflects live state
- Real charging current responded correctly to the toggle: ~29W with rapid charge off, ramping past 100W with it on — so this restores actual control of a real hardware capability, not just a cosmetic sysfs fix

## Change
Two lines, following the existing pattern already used by other models on the same EC path:
```c
[ACPI_PATH_READ_RAPIDCHARGE] = "\\_SB.PC00.LPCB.EC0.VPC0.GBMD",
[ACPI_PATH_WRITE_RAPIDCHARGE] = "\\_SB.PC00.LPCB.EC0.VPC0.SBMC"
```