### PR TITLE
fix(83KY Fans)

### DIFF
--- a/extra/smartfan/README.md
+++ b/extra/smartfan/README.md
@@ -20,13 +20,12 @@ A shell-based smart fan control daemon for Lenovo Legion 7 (Gen 10+) laptops usi
 
 ## Fan Speed Ranges by Mode
 
-| Mode | Idle RPM | Load RPM | LED Color |
-|------|----------|----------|-----------|
-| Quiet | ~2000 | ~3500 | Blue |
-| Balanced | ~3000 | ~4000 | White |
-| Performance | ~3900 | ~5000 | Red |
-| Extreme | ~5000 | ~5500+ | Red (pulse) |
-
+Quiet, balanced, performance and extreme
+Default is balanced, if you need more agressive fan curves run sudo smartfan performance
+You can tweak it in your bath, which is in /usr/local/bin/smartfan | just look for the string with the fan speeds and cpu temps
+The daemon starts in balanced, adjust on the fly and they do not persist, so just edit the .service file and reinstall, it's much easier.
+  NOTE IF YOU'RE HAVING ISSUES:
+    This entire repo is a mess honestly, this worked for my 83KY while the GUI didn't, so if you're having trouble i recommend using this smartfan and ignore all the rest.
 ## Installation
 
 ```bash

--- a/extra/smartfan/smartfan.service
+++ b/extra/smartfan/smartfan.service
@@ -5,7 +5,7 @@ Wants=acpi_call.service
 
 [Service]
 Type=forking
-ExecStart=/usr/local/bin/smartfan start quiet
+ExecStart=/usr/local/bin/smartfan start balanced
 ExecStop=/usr/local/bin/smartfan stop
 PIDFile=/tmp/smartfan.pid
 Restart=on-failure

--- a/extra/smartfan/smartfan.sh
+++ b/extra/smartfan/smartfan.sh
@@ -6,35 +6,73 @@ MODEFILE="/tmp/smartfan_mode"
 PIDFILE="/tmp/smartfan.pid"
 ACPI_CALL="/proc/acpi/call"
 STOPFILE="/tmp/smartfan_stop"
+LOG="/tmp/smartfan.log"
+#DEBUG=1  # Set to 1 for verbose logging
 
+log() {
+    echo "$(date '+%Y-%m-%d %H:%M:%S'): $1" >> "$LOG"
+    [ "$DEBUG" = "1" ] && echo "$1"
+}
+
+# Check for acpi_call
 if [ ! -f "$ACPI_CALL" ]; then
     modprobe acpi_call 2>/dev/null
+    sleep 1
     if [ ! -f "$ACPI_CALL" ]; then
         echo "Error: acpi_call module not available"
+        echo "Try: sudo modprobe acpi_call"
         exit 1
     fi
 fi
 
+# Find correct hwmon path
+find_hwmon() {
+    for hwmon in /sys/class/hwmon/hwmon*; do
+        if [ -f "$hwmon/name" ]; then
+            name=$(cat "$hwmon/name")
+            if [[ "$name" == *"coretemp"* ]] || [[ "$name" == *"k10temp"* ]] || [[ "$name" == *"zenpower"* ]]; then
+                CPU_HWMON="$hwmon"
+                log "Found CPU hwmon: $hwmon ($name)"
+            fi
+            if [[ "$name" == *"amdgpu"* ]] || [[ "$name" == *"nouveau"* ]]; then
+                GPU_HWMON="$hwmon"
+                log "Found GPU hwmon: $hwmon ($name)"
+            fi
+        fi
+    done
+    
+    # Fallback to hwmon9 if not found
+    [ -z "$CPU_HWMON" ] && CPU_HWMON="/sys/class/hwmon/hwmon9"
+    [ -z "$GPU_HWMON" ] && GPU_HWMON="/sys/class/hwmon/hwmon9"
+}
+
 get_profile() {
     case "$1" in
         quiet)
-            TEMP_LOW=75; TEMP_MED=85; TEMP_HIGH=92
-            FAN_LOW=20; FAN_MED=35; FAN_HIGH=50; FAN_MAX=70
+            # 10 temperature points for smooth curve
+            TEMP_POINTS="40 50 60 65 70 75 80 85 90 95"
+            FAN_POINTS="20 20 20 25 30 35 40 50 60 70"
             RAMP_DOWN_DELAY=3
             ;;
         balanced)
-            TEMP_LOW=70; TEMP_MED=80; TEMP_HIGH=90
-            FAN_LOW=30; FAN_MED=45; FAN_HIGH=55; FAN_MAX=60
+            TEMP_POINTS="40 50 60 65 70 75 80 85 90 95"
+            FAN_POINTS="25 25 30 35 40 45 50 55 60 70"
             RAMP_DOWN_DELAY=3
             ;;
         performance)
-            TEMP_LOW=60; TEMP_MED=70; TEMP_HIGH=80
-            FAN_LOW=45; FAN_MED=60; FAN_HIGH=75; FAN_MAX=85
+            TEMP_POINTS="40 50 60 65 70 75 80 85 90 95"
+            FAN_POINTS="35 40 45 50 55 60 65 75 85 95"
             RAMP_DOWN_DELAY=3
             ;;
         extreme)
-            TEMP_LOW=50; TEMP_MED=60; TEMP_HIGH=70
-            FAN_LOW=60; FAN_MED=75; FAN_HIGH=90; FAN_MAX=100
+            TEMP_POINTS="40 50 60 65 70 75 80 85 90 95"
+            FAN_POINTS="50 60 65 70 75 80 85 90 95 100"
+            RAMP_DOWN_DELAY=3
+            ;;
+        *)
+            log "Invalid profile: $1, using performance"
+            TEMP_POINTS="40 50 60 65 70 75 80 85 90 95"
+            FAN_POINTS="35 40 45 50 55 60 65 75 85 95"
             RAMP_DOWN_DELAY=3
             ;;
     esac
@@ -42,208 +80,324 @@ get_profile() {
 
 set_fan_speed() {
     local pct=$1
-    if [ "$pct" -le 0 ]; then
-        pct=20
-    fi
+    # Ensure valid range
+    if [ "$pct" -lt 20 ]; then pct=20; fi
+    if [ "$pct" -gt 100 ]; then pct=100; fi
+    
     local val=$((pct * 100))
     local b0=$(printf '0x%02x' $((val & 0xFF)))
-    local b1=$(printf '0x%02x' $(( (val >> 8) & 0xFF)))
-    local b2=$(printf '0x%02x' $(( (val >> 16) & 0xFF)))
-    local b3=$(printf '0x%02x' $(( (val >> 24) & 0xFF)))
-    echo "\_SB_.GZFD.WMAE 0 0x12 {0x01, 0x00, 0x03, 0x04, $b0, $b1, $b2, $b3}" > "$ACPI_CALL"
-    cat "$ACPI_CALL" > /dev/null 2>&1
-    echo "\_SB_.GZFD.WMAE 0 0x12 {0x02, 0x00, 0x03, 0x04, $b0, $b1, $b2, $b3}" > "$ACPI_CALL"
-    cat "$ACPI_CALL" > /dev/null 2>&1
+    local b1=$(printf '0x%02x' $(((val >> 8) & 0xFF)))
+    local b2=$(printf '0x%02x' $(((val >> 16) & 0xFF)))
+    local b3=$(printf '0x%02x' $(((val >> 24) & 0xFF)))
+    
+    # Try both fan channels
+    echo "\_SB_.GZFD.WMAE 0 0x12 {0x01, 0x00, 0x03, 0x04, $b0, $b1, $b2, $b3}" > "$ACPI_CALL" 2>/dev/null
+    sleep 0.1
+    echo "\_SB_.GZFD.WMAE 0 0x12 {0x02, 0x00, 0x03, 0x04, $b0, $b1, $b2, $b3}" > "$ACPI_CALL" 2>/dev/null
 }
 
-TEMP_HISTORY=""
-TEMP_SAMPLES=8
-RAMP_UP_COUNT=0
-RAMP_UP_NEEDED=3
-
 get_max_temp() {
-    local cpu_temp=$(cat /sys/class/hwmon/hwmon9/temp1_input 2>/dev/null)
-    local gpu_temp=$(cat /sys/class/hwmon/hwmon9/temp2_input 2>/dev/null)
+    local cpu_temp=0
+    local gpu_temp=0
+    local cpu_file="$CPU_HWMON/temp1_input"
+    local gpu_file="$GPU_HWMON/temp1_input"
+    
+    # Try different temp files
+    [ -f "$cpu_file" ] && cpu_temp=$(cat "$cpu_file" 2>/dev/null)
+    [ -z "$cpu_temp" ] && [ -f "$GPU_HWMON/temp2_input" ] && cpu_temp=$(cat "$GPU_HWMON/temp2_input" 2>/dev/null)
+    
+    [ -f "$gpu_file" ] && gpu_temp=$(cat "$gpu_file" 2>/dev/null)
+    [ -z "$gpu_temp" ] && [ -f "$CPU_HWMON/temp2_input" ] && gpu_temp=$(cat "$CPU_HWMON/temp2_input" 2>/dev/null)
+    
+    # Convert to Celsius
     cpu_temp=$((cpu_temp / 1000))
     gpu_temp=$((gpu_temp / 1000))
-    local raw
-    if [ "$cpu_temp" -gt "$gpu_temp" ]; then
-        raw=$cpu_temp
-    else
-        raw=$gpu_temp
-    fi
-    if [ "$raw" -gt 90 ]; then
-        raw=90
-    fi
-    TEMP_HISTORY="$TEMP_HISTORY $raw"
-    local count=$(echo $TEMP_HISTORY | wc -w)
-    if [ "$count" -gt "$TEMP_SAMPLES" ]; then
-        TEMP_HISTORY=$(echo $TEMP_HISTORY | cut -d' ' -f2-)
-    fi
-    local sum=0
-    for t in $TEMP_HISTORY; do
-        sum=$((sum + t))
-    done
-    count=$(echo $TEMP_HISTORY | wc -w)
-    echo $((sum / count))
+    
+    # Clamp to reasonable range
+    [ "$cpu_temp" -gt 100 ] && cpu_temp=100
+    [ "$gpu_temp" -gt 100 ] && gpu_temp=100
+    [ "$cpu_temp" -lt 0 ] && cpu_temp=0
+    [ "$gpu_temp" -lt 0 ] && gpu_temp=0
+    
+    local raw=$cpu_temp
+    [ "$gpu_temp" -gt "$raw" ] && raw=$gpu_temp
+    
+    echo "$raw"
 }
 
 get_target_pct() {
     local temp=$1
-    if [ "$temp" -le "$TEMP_LOW" ]; then
-        echo "$FAN_LOW"
-    elif [ "$temp" -le "$TEMP_MED" ]; then
-        local range=$((TEMP_MED - TEMP_LOW))
-        local offset=$((temp - TEMP_LOW))
-        echo $(( FAN_LOW + (FAN_MED - FAN_LOW) * offset / range ))
-    elif [ "$temp" -le "$TEMP_HIGH" ]; then
-        local range=$((TEMP_HIGH - TEMP_MED))
-        local offset=$((temp - TEMP_MED))
-        echo $(( FAN_MED + (FAN_HIGH - FAN_MED) * offset / range ))
-    else
-        echo "$FAN_MAX"
+    local temps=($TEMP_POINTS)
+    local fans=($FAN_POINTS)
+    local target=${fans[0]}
+    
+    # If below first point, use first fan speed
+    if [ "$temp" -le "${temps[0]}" ]; then
+        echo "${fans[0]}"
+        return
     fi
-}
-
-stop_daemon() {
-    # Signal any running daemon to stop via stop file
-    touch "$STOPFILE"
-    # Also kill by PID file as backup
-    if [ -f "$PIDFILE" ]; then
-        local oldpid=$(cat "$PIDFILE")
-        kill "$oldpid" 2>/dev/null
-        sleep 1
-        kill -9 "$oldpid" 2>/dev/null
+    
+    # If above last point, use last fan speed
+    local last_idx=$((${#temps[@]} - 1))
+    if [ "$temp" -ge "${temps[$last_idx]}" ]; then
+        echo "${fans[$last_idx]}"
+        return
     fi
-    # Wait for it to actually die
-    sleep 1
-    rm -f "$PIDFILE" "$STOPFILE"
-    # Restore EC auto
-    set_fan_speed 0
+    
+    # Find which two points we're between and interpolate
+    for ((i=0; i<last_idx; i++)); do
+        local t1=${temps[$i]}
+        local t2=${temps[$((i+1))]}
+        local f1=${fans[$i]}
+        local f2=${fans[$((i+1))]}
+        
+        if [ "$temp" -ge "$t1" ] && [ "$temp" -le "$t2" ]; then
+            # Linear interpolation between points
+            local temp_range=$((t2 - t1))
+            local temp_offset=$((temp - t1))
+            local fan_range=$((f2 - f1))
+            
+            if [ "$temp_range" -gt 0 ]; then
+                target=$((f1 + (fan_range * temp_offset) / temp_range))
+            else
+                target=$f1
+            fi
+            break
+        fi
+    done
+    
+    echo "$target"
 }
 
 run_daemon() {
     local mode="$1"
     echo "$$" > "$PIDFILE"
     echo "$mode" > "$MODEFILE"
-    chmod 666 "$MODEFILE"
     rm -f "$STOPFILE"
-
+    
+    find_hwmon
     get_profile "$mode"
-
-    local current_pct=$FAN_LOW
+    
+    local current_pct=$(echo $FAN_POINTS | awk '{print $1}')
     local down_count=0
-    local LOG="/tmp/smartfan.log"
-    echo "$(date): daemon started, mode=$mode pid=$$" > "$LOG"
+    local ramp_up_count=0
+    local temp_history=""
+    local temp_samples=5
+    local last_temp=0
+    
+    log "Daemon started: mode=$mode, PID=$$, CPU_HWMON=$CPU_HWMON, GPU_HWMON=$GPU_HWMON"
     set_fan_speed "$current_pct"
-
-    trap 'set_fan_speed 0; rm -f "$PIDFILE"; echo "$(date): stopped" >> "$LOG"; exit 0' TERM INT
-
+    
+    trap 'log "Stopping daemon"; set_fan_speed 0; rm -f "$PIDFILE"; exit 0' TERM INT
+    
+    local iteration=0
     while true; do
-        # Check if we should stop
+        # Check stop file
         if [ -f "$STOPFILE" ]; then
+            log "Stop file detected"
             set_fan_speed 0
-            rm -f "$PIDFILE"
-            echo "$(date): stopped by signal" >> "$LOG"
+            rm -f "$PIDFILE" "$STOPFILE"
             exit 0
         fi
-
-        # Re-read mode in case it was changed
-        if [ -f "$MODEFILE" ]; then
-            local new_mode=$(cat "$MODEFILE")
-            if [ "$new_mode" != "$mode" ]; then
-                mode="$new_mode"
-                get_profile "$mode"
-                # Pre-fill history with current temp to avoid spike reaction
-                TEMP_HISTORY=""
-                local fill_temp=$(cat /sys/class/hwmon/hwmon9/temp1_input 2>/dev/null)
-                fill_temp=$((fill_temp / 1000))
-                if [ "$fill_temp" -gt 90 ]; then fill_temp=90; fi
-                for i in $(seq 1 $TEMP_SAMPLES); do
-                    TEMP_HISTORY="$TEMP_HISTORY $fill_temp"
-                done
-                current_pct=$FAN_LOW
-                down_count=0
-                RAMP_UP_COUNT=0
-                set_fan_speed "$current_pct"
-                echo "$(date): mode changed to $mode, reset fans" >> "$LOG"
-            fi
-        fi
-
-        local temp=$(get_max_temp)
-        local target_pct=$(get_target_pct "$temp")
-
-        if [ "$target_pct" -gt "$current_pct" ]; then
-            RAMP_UP_COUNT=$((RAMP_UP_COUNT + 1))
-            if [ "$RAMP_UP_COUNT" -ge "$RAMP_UP_NEEDED" ]; then
-                current_pct=$target_pct
-                set_fan_speed "$current_pct"
-                echo "$(date): temp=${temp}C -> ${current_pct}%" >> "$LOG"
-                RAMP_UP_COUNT=0
-            fi
+        
+        # Check mode changes
+        local new_mode=$(cat "$MODEFILE" 2>/dev/null)
+        if [ -n "$new_mode" ] && [ "$new_mode" != "$mode" ]; then
+            mode="$new_mode"
+            get_profile "$mode"
+            current_pct=$(echo $FAN_POINTS | awk '{print $1}')
             down_count=0
-        elif [ "$target_pct" -lt "$current_pct" ]; then
-            RAMP_UP_COUNT=0
-            down_count=$((down_count + 1))
-            if [ "$temp" -le "$((TEMP_LOW - 5))" ] && [ "$down_count" -ge 3 ]; then
-                current_pct=$target_pct
-                set_fan_speed "$current_pct"
-                echo "$(date): temp=${temp}C snap to ${current_pct}%" >> "$LOG"
-                down_count=0
-            elif [ "$down_count" -ge "$RAMP_DOWN_DELAY" ]; then
-                current_pct=$((current_pct - 10))
-                if [ "$current_pct" -lt "$target_pct" ]; then
+            ramp_up_count=0
+            temp_history=""
+            set_fan_speed "$current_pct"
+            log "Mode changed to $mode"
+        fi
+        
+        # Get temperature
+        local temp=$(get_max_temp)
+        if [ -z "$temp" ] || [ "$temp" -eq 0 ]; then
+            temp=$last_temp
+            log "Warning: Could not read temperature, using last known: $temp"
+        fi
+        last_temp=$temp
+        
+        # Apply smoothing
+        temp_history="$temp_history $temp"
+        local count=$(echo "$temp_history" | wc -w)
+        if [ "$count" -gt "$temp_samples" ]; then
+            temp_history=$(echo "$temp_history" | cut -d' ' -f2-)
+        fi
+        
+        # Calculate average
+        local sum=0
+        for t in $temp_history; do
+            sum=$((sum + t))
+        done
+        count=$(echo "$temp_history" | wc -w)
+        temp=$((sum / count))
+        
+        # Get target speed
+        local target_pct=$(get_target_pct "$temp")
+        
+        # Fan control logic with smooth transitions
+        if [ "$target_pct" -gt "$current_pct" ]; then
+            # Temperature increased - ramp up faster
+            ramp_up_count=$((ramp_up_count + 1))
+            if [ "$ramp_up_count" -ge 2 ]; then
+                # Increase by up to 5% at a time for smoothness
+                local diff=$((target_pct - current_pct))
+                if [ "$diff" -gt 5 ]; then
+                    current_pct=$((current_pct + 5))
+                else
                     current_pct=$target_pct
                 fi
                 set_fan_speed "$current_pct"
-                echo "$(date): temp=${temp}C ramp DOWN to ${current_pct}%" >> "$LOG"
-                down_count=$((RAMP_DOWN_DELAY - 2))
+                log "Temp: ${temp}C, increasing fan to ${current_pct}%"
+                ramp_up_count=0
+            fi
+            down_count=0
+        elif [ "$target_pct" -lt "$current_pct" ]; then
+            # Temperature decreased - ramp down slower
+            ramp_up_count=0
+            down_count=$((down_count + 1))
+            
+            if [ "$temp" -le 45 ] && [ "$down_count" -ge 3 ]; then
+                # Snap to low if very cool
+                current_pct=$target_pct
+                set_fan_speed "$current_pct"
+                log "Temp: ${temp}C, dropping fan to ${current_pct}%"
+                down_count=0
+            elif [ "$down_count" -ge "$RAMP_DOWN_DELAY" ]; then
+                # Decrease by 3% at a time for smoothness
+                local diff=$((current_pct - target_pct))
+                if [ "$diff" -gt 3 ]; then
+                    current_pct=$((current_pct - 3))
+                else
+                    current_pct=$target_pct
+                fi
+                set_fan_speed "$current_pct"
+                log "Temp: ${temp}C, ramping down to ${current_pct}%"
+                down_count=0
             fi
         else
+            # Temperature stable
             down_count=0
-            RAMP_UP_COUNT=0
+            ramp_up_count=0
         fi
-
+        
+        # Debug info every 10 iterations
+        iteration=$((iteration + 1))
+        if [ $((iteration % 10)) -eq 0 ]; then
+            log "Status: temp=${temp}C, fan=${current_pct}%, mode=$mode"
+        fi
+        
         sleep 2
     done
+}
+
+stop_daemon() {
+    log "Stopping daemon..."
+    
+    # Create stop file
+    touch "$STOPFILE"
+    
+    # Kill by PID
+    if [ -f "$PIDFILE" ]; then
+        local pid=$(cat "$PIDFILE" 2>/dev/null)
+        if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+            kill -TERM "$pid" 2>/dev/null
+            # Wait for graceful shutdown
+            for i in {1..5}; do
+                kill -0 "$pid" 2>/dev/null || break
+                sleep 1
+            done
+            # Force kill if still running
+            kill -0 "$pid" 2>/dev/null && kill -9 "$pid" 2>/dev/null
+        fi
+    fi
+    
+    # Cleanup
+    rm -f "$PIDFILE" "$STOPFILE" "$MODEFILE"
+    set_fan_speed 0
+    log "Daemon stopped"
 }
 
 case "$1" in
     start)
         mode="${2:-performance}"
         stop_daemon
+        sleep 1
         echo "Starting smart fan daemon in '$mode' mode..."
-        run_daemon "$mode" &
-        disown
-        echo "Smart fan running (PID: $!)"
+        nohup "$0" daemon "$mode" > /dev/null 2>&1 &
+        sleep 2
+        if [ -f "$PIDFILE" ] && kill -0 "$(cat "$PIDFILE")" 2>/dev/null; then
+            echo "Smart fan running (PID: $(cat "$PIDFILE"))"
+        else
+            echo "Failed to start daemon. Check $LOG for details"
+        fi
+        ;;
+    daemon)
+        # Internal command for running as daemon
+        run_daemon "$2"
         ;;
     stop)
-        echo "Stopping smart fan daemon..."
         stop_daemon
-        echo "Fans restored to EC auto control"
         ;;
     mode)
         if [ -z "$2" ]; then
-            echo "Current mode: $(cat $MODEFILE 2>/dev/null || echo 'not running')"
+            if [ -f "$MODEFILE" ]; then
+                echo "Current mode: $(cat "$MODEFILE")"
+            else
+                echo "Not running"
+            fi
         else
-            echo "$2" > "$MODEFILE"
-            echo "Mode changed to: $2 (takes effect within 2s)"
+            case "$2" in
+                quiet|balanced|performance|extreme)
+                    echo "$2" > "$MODEFILE"
+                    echo "Mode changed to: $2"
+                    ;;
+                *)
+                    echo "Invalid mode. Use: quiet, balanced, performance, extreme"
+                    ;;
+            esac
         fi
         ;;
     status)
-        if [ -f "$PIDFILE" ] && kill -0 "$(cat $PIDFILE)" 2>/dev/null; then
-            echo "Smart fan: RUNNING (PID $(cat $PIDFILE))"
-            echo "Mode: $(cat $MODEFILE 2>/dev/null)"
-            echo "CPU: $(($(cat /sys/class/hwmon/hwmon9/temp1_input) / 1000))°C"
-            echo "GPU: $(($(cat /sys/class/hwmon/hwmon9/temp2_input) / 1000))°C"
-            echo "Fan1: $(cat /sys/class/hwmon/hwmon9/fan1_input) RPM"
-            echo "Fan2: $(cat /sys/class/hwmon/hwmon9/fan2_input) RPM"
+        if [ -f "$PIDFILE" ] && kill -0 "$(cat "$PIDFILE")" 2>/dev/null; then
+            echo "Smart fan: RUNNING (PID $(cat "$PIDFILE"))"
+            echo "Mode: $(cat "$MODEFILE" 2>/dev/null)"
+            
+            find_hwmon
+            cpu_temp=$(cat "$CPU_HWMON/temp1_input" 2>/dev/null)
+            gpu_temp=$(cat "$GPU_HWMON/temp1_input" 2>/dev/null)
+            
+            [ -n "$cpu_temp" ] && echo "CPU: $((cpu_temp / 1000))°C"
+            [ -n "$gpu_temp" ] && echo "GPU: $((gpu_temp / 1000))°C"
+            
+            fan1=$(cat /sys/class/hwmon/hwmon*/fan1_input 2>/dev/null | head -1)
+            fan2=$(cat /sys/class/hwmon/hwmon*/fan2_input 2>/dev/null | head -1)
+            
+            [ -n "$fan1" ] && echo "Fan1: $fan1 RPM"
+            [ -n "$fan2" ] && echo "Fan2: $fan2 RPM"
+            
+            echo "Log: $LOG"
         else
             echo "Smart fan: NOT RUNNING"
         fi
         ;;
+    debug)
+        echo "Debug information:"
+        echo "ACPI call file: $ACPI_CALL"
+        find_hwmon
+        echo "CPU HWMON: $CPU_HWMON"
+        echo "GPU HWMON: $GPU_HWMON"
+        echo "Available hwmon devices:"
+        for hwmon in /sys/class/hwmon/hwmon*; do
+            echo "  $hwmon: $(cat "$hwmon/name" 2>/dev/null)"
+        done
+        ;;
     *)
-        echo "Usage: smartfan {start [mode]|stop|mode [name]|status}"
+        echo "Usage: $0 {start [mode]|stop|mode [name]|status|debug}"
         echo "Modes: quiet, balanced, performance, extreme"
         ;;
 esac


### PR DESCRIPTION
Regression since adding support for the 83KY,
The fans stayed on the same RPM, even under load, atleast for this model. 

Always the same story with this model for almost a year since I bought it, so now after these changes it works, 
The daemon could read the temperature fully without issue before, even without the modules loaded, now as explained in the readme it adjust per the temperature without the bash script crashing constantly, with no logs just a sigterm, with more granular fan control, it is also editable, this commit is focused merely on the support for my laptop, which this has caused so much damage.
I am almost sure this works for other models so i encourage to use this only if the conventional methods are not working. 

Changes: readme updated with more information, workmode is useless, and for my use case use I recommend utilizing smartfan by itself, as it works much better, we can just read the temps and adjust accordingly, it adjust in 10 step increments, editable.
I recommend editing the smartfan file with your curve, running it(It kills the previous smartfan instance) and testing it if you want a different curve. 
This has been working perfectly after these changes.