### PR TITLE
fix(83sc): switch fancurve to WMI3 and fix SFAN buffer size

### DIFF
--- a/kernel_module/legion-laptop.c
+++ b/kernel_module/legion-laptop.c
@@ -1532,7 +1532,7 @@ static const struct model_config model_secn = {
 	.access_method_keyboard = ACCESS_METHOD_WMI2,
 	.access_method_fanspeed = ACCESS_METHOD_WMI3,
 	.access_method_temperature = ACCESS_METHOD_WMI3,
-	.access_method_fancurve = ACCESS_METHOD_EC3,
+	.access_method_fancurve = ACCESS_METHOD_WMI3,
 	.access_method_fanfullspeed = ACCESS_METHOD_WMI3,
 	.access_method_powerlimits = ACCESS_METHOD_WMI3_CLAMPED,
 	.acpi_check_dev = false,
@@ -3956,7 +3956,9 @@ static ssize_t wmi_read_fancurve_custom(const struct model_config *model,
 	fancurve->current_point_i = 0;
 	fancurve->size = size;
 	fancurve->fan_speed_unit = model == &model_n2cn ?
-		FAN_SPEED_UNIT_PERCENT_NEAREST : FAN_SPEED_UNIT_PERCENT;
+		FAN_SPEED_UNIT_PERCENT_NEAREST :
+		model == &model_secn ?
+		FAN_SPEED_UNIT_RPM_HUNDRED : FAN_SPEED_UNIT_PERCENT;
 
 	for (i = 0; i < size; i++) {
 		u32 speed = le32_to_cpu(fan_table.fan_speed[i]);
@@ -3972,7 +3974,7 @@ static ssize_t wmi_read_fancurve_custom(const struct model_config *model,
 static ssize_t wmi_write_fancurve_custom(const struct model_config *model,
 					 const struct fancurve *fancurve)
 {
-	u8 buffer[0x20];
+	u8 buffer[0x40];
 	int err;
 
 	// The buffer is read like this in ACPI firmware


### PR DESCRIPTION
## PR-3: Fix fan curve control on LOQ 83SC

### TL;DR

Switches `model_secn` fancurve from broken EC3 to working WMI3, and fixes the SFAN ACPI buffer overflow (32→64 bytes) that blocked fan curve writes on EC 0x5508/0x5509 firmware.

### Roadmap

| PR | Status | Scope |
|----|--------|-------|
| [PR-1 #494](https://github.com/johnfanv2/LenovoLegionLinux/pull/494) | ✅ Merged | Model recognition + dynamic sysfs base discovery |
| [PR-2-1 #500](https://github.com/johnfanv2/LenovoLegionLinux/pull/500) | ✅ Merged | model_secn config, DMI, WMI3_CLAMPED, PL1/PL2 coupling |
| [PR-2-2 #517](https://github.com/johnfanv2/LenovoLegionLinux/pull/517) | ✅ Merged | CD01-driven power limit clamping, discrete value snapping |
| [PR-2-3 #525](https://github.com/johnfanv2/LenovoLegionLinux/pull/525) | ✅ Merged | Fan unlock, battery conservation, rapid charge paths, fn-lock, flip-to-start |
|  **[PR-3 #526](https://github.com/johnfanv2/LenovoLegionLinux/pull/526)** | 📝 **This PR** | Fan curve EC3 control, custom fan profiles |


### Changes (5 insertions, 3 deletions)

#### 1. EC3 → WMI3 fancurve access

```c
// Before:
.access_method_fancurve = ACCESS_METHOD_EC3,
// After:
.access_method_fancurve = ACCESS_METHOD_WMI3,
```

**Why:** EC3 port I/O (0x4E/0x4F) is blocked on 83SC EC 0x5508. All `ecram_read()` calls return zeros. Windows uses WMI exclusively for fan control on this EC generation. The WMI3 path (`wmi_read/write_fancurve_custom`) already exists in the kernel module.

#### 2. SFAN write buffer: 32 → 64 bytes

```c
// Before:
u8 buffer[0x20];  // 32 bytes — AE_AML_BUFFER_LIMIT on EC 0x5508
// After:
u8 buffer[0x40];  // 64 bytes — matches BIOS SFAN method expectation
```

**Why:** The `\_SB.GZFD.SFAN` ACPI method accesses field `F00F` at byte offset 31 (bit 248/16), which exceeds the 256-bit (32-byte) buffer. EC 0x5508/0x5509 firmware expects 64 bytes. Windows LLT sends 64 bytes for all models. Zero-initialized trailing bytes are harmless for EC 0x5507 models.

#### 3. Fan speed unit for model_secn

```c
fancurve->fan_speed_unit = model == &model_n2cn ?
    FAN_SPEED_UNIT_PERCENT_NEAREST :
    model == &model_secn ?
    FAN_SPEED_UNIT_RPM_HUNDRED : FAN_SPEED_UNIT_PERCENT;
```

**Why:** 83SC uses step-index encoding (0-10) matching the EC3 LOQ `RPM_HUNDRED` convention.

### Related Issues

- #491 — EC 0x5508 fancurve broken across 8+ models (master tracking)
- #507 — 83VK (EC 0x5509) exact same AE_AML_BUFFER_LIMIT error

### Testing

- [x] Fan curve read: 10 points, step indices correct
- [x] Fan curve write via hwmon: EC accepted modified curve
- [x] Fan fullspeed: 3000→4000 RPM
- [x] Fan unlock + fullspeed: 4200 RPM
- [x] fancurve_defaults reset: works
- [x] Build: clean, zero warnings
- [x] Non-regression: all existing sysfs attrs unaffected

---

### Note from @Punch-Pain

With this PR series (PR-1 through PR-3), support for the **Lenovo LOQ Essential 15IRX11 (83SC)** is, to the best of my knowledge, complete. The model is fully recognized, power limits are clamped correctly, fan control works via WMI3, and all the smaller features (battery conservation, fn-lock, flip-to-start, fan unlock, rapid charge) are functional and gated behind model_secn.

Maintenance on this model will slow down going forward since the core feature set is done. If something breaks or a new BIOS changes behavior I'll obviously look into it, but for now I consider the 83SC support wrapped up.