### PR TITLE
fix: resolve 6 confirmed bugs plus code-quality cleanup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
       run: ./deploy/dependencies/install_dependencies_ubuntu_24_04.sh
       shell: bash
     - name: Build
-      run: ./tests/test_kenel_dkms_install.sh || true
+      run: ./tests/test_kernel_dkms_install.sh || true
       shell: bash
 
   run-tests:

--- a/.github/workflows/build_PR.yml
+++ b/.github/workflows/build_PR.yml
@@ -46,7 +46,7 @@ jobs:
       run: ./deploy/dependencies/install_dependencies_ubuntu_24_04.sh
       shell: bash
     - name: Build
-      run: ./tests/test_kenel_dkms_install.sh || true
+      run: ./tests/test_kernel_dkms_install.sh || true
       shell: bash
 
   run-tests:

--- a/.github/workflows/manual_test.yaml
+++ b/.github/workflows/manual_test.yaml
@@ -55,7 +55,7 @@ jobs:
       run: ./deploy/dependencies/install_dependencies_ubuntu_24_04.sh
       shell: bash
     - name: Build
-      run: ./tests/test_kenel_dkms_install.sh || true
+      run: ./tests/test_kernel_dkms_install.sh || true
       shell: bash
 
   run-tests:

--- a/deploy/build_containers.sh
+++ b/deploy/build_containers.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 set -ex
 DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-cd ${DIR}/dependencies
+cd "${DIR}"
 sudo docker compose build --no-cache

--- a/deploy/package_testing/download_install_debian.sh
+++ b/deploy/package_testing/download_install_debian.sh
@@ -1,8 +1,8 @@
 sudo apt install -y curl
 
-sudo curl --insecure https://ftp.de.debian.org/debian/pool/main/l/lenovolegionlinux/lenovolegionlinux-dkms_0.0.20+ds-1.1_amd64.deb -o /tmp/lenovolegionlinux-dkms_0.0.20+ds-1.1_amd64.deb
-sudo curl --insecure https://ftp.de.debian.org/debian/pool/main/l/lenovolegionlinux/python3-legion-linux_0.0.20+ds-1.1_all.deb -o /tmp/python3-legion-linux_0.0.20+ds-1.1_all.deb
-sudo curl --insecure https://ftp.de.debian.org/debian/pool/main/l/lenovolegionlinux/legiond_0.0.20+ds-1.1_amd64.deb -o /tmp/legiond_0.0.20+ds-1.1_amd64.deb
+sudo curl https://ftp.de.debian.org/debian/pool/main/l/lenovolegionlinux/lenovolegionlinux-dkms_0.0.20+ds-1.1_amd64.deb -o /tmp/lenovolegionlinux-dkms_0.0.20+ds-1.1_amd64.deb
+sudo curl https://ftp.de.debian.org/debian/pool/main/l/lenovolegionlinux/python3-legion-linux_0.0.20+ds-1.1_all.deb -o /tmp/python3-legion-linux_0.0.20+ds-1.1_all.deb
+sudo curl https://ftp.de.debian.org/debian/pool/main/l/lenovolegionlinux/legiond_0.0.20+ds-1.1_amd64.deb -o /tmp/legiond_0.0.20+ds-1.1_amd64.deb
 
 sudo apt install -y /tmp/lenovolegionlinux-dkms_0.0.20+ds-1.1_amd64.deb
 sudo apt install -y /tmp/python3-legion-linux_0.0.20+ds-1.1_all.deb

--- a/extra/service/legiond.ini
+++ b/extra/service/legiond.ini
@@ -7,6 +7,9 @@ cpu_control=false
 # set radeon to enable amdgpu support
 # set false to disable gpu_control
 gpu_control=false
+# paths to the GPU control tools (defaults shown below)
+#nvidia_smi_path=/opt/bin/nvidia-smi
+#rocm_smi_path=/opt/bin/rocm-smi
 
 [gpu_control]
 tdp_bat_q=55

--- a/extra/service/legiond/README.org
+++ b/extra/service/legiond/README.org
@@ -32,6 +32,11 @@ Edit fancurve profile ~.yaml~ to fit your needs.
 
 Modify ~/etc/legion_linux/legiond.ini~ with your favorate editor.
 
+The GPU tools are located at ~/opt/bin/nvidia-smi~ (nvidia) and
+~/opt/bin/rocm-smi~ (radeon) by default. If installed elsewhere, override the
+~nvidia_smi_path~ / ~rocm_smi_path~ options under the ~main~ section of
+~legiond.ini~.
+
 Enable ~systemd.service~:
 #+begin_src shell
 systemctl enable --now legiond.service legiond-onresume.service legiond-cpuset.timer

--- a/extra/service/legiond/legiond-ctl.c
+++ b/extra/service/legiond/legiond-ctl.c
@@ -60,7 +60,9 @@ int main(int argc, char *argv[])
 	struct sockaddr_un addr = {
 		.sun_family = AF_UNIX,
 	};
-	strcpy(addr.sun_path, socket_path);
+	if (snprintf(addr.sun_path, sizeof(addr.sun_path), "%s", socket_path) >=
+	    (int)sizeof(addr.sun_path))
+		return 2;
 
 	if (connect(fd, (struct sockaddr *)&addr, sizeof(addr)) == -1)
 		return 2;

--- a/extra/service/legiond/legiond.c
+++ b/extra/service/legiond/legiond.c
@@ -156,7 +156,11 @@ int main(void)
 	struct sockaddr_un addr = {
 		.sun_family = AF_UNIX,
 	};
-	strcpy(addr.sun_path, socket_path);
+	if (snprintf(addr.sun_path, sizeof(addr.sun_path), "%s", socket_path) >=
+	    (int)sizeof(addr.sun_path)) {
+		fprintf(stderr, "socket path too long\n");
+		return 1;
+	}
 
 	if (bind(server_fd, (struct sockaddr *)&addr, sizeof(addr)) == -1) {
 		return 1;

--- a/extra/service/legiond/modules/parseconf.c
+++ b/extra/service/legiond/modules/parseconf.c
@@ -15,6 +15,10 @@ static int handler(void *user, const char *section, const char *name,
 		pconfig->cpu_control = strcmp(value, "true") == 0;
 	} else if (MATCH("main", "gpu_control")) {
 		ptr_cmd = &pconfig->gpu_control;
+	} else if (MATCH("main", "nvidia_smi_path")) {
+		ptr_cmd = &pconfig->nvidia_smi_path;
+	} else if (MATCH("main", "rocm_smi_path")) {
+		ptr_cmd = &pconfig->rocm_smi_path;
 	} else if (MATCH("main", "fan_control")) {
 		pconfig->fan_control = strcmp(value, "true") == 0;
 	} else if (MATCH("gpu_control", "tdp_ac_q")) {
@@ -71,6 +75,12 @@ static int handler(void *user, const char *section, const char *name,
 int parseconf(LEGIOND_CONFIG *config)
 {
 	*config = (LEGIOND_CONFIG){ 0 };
+
+	/* default GPU tool paths, overridable via config */
+	snprintf(config->nvidia_smi_path, sizeof(config->nvidia_smi_path),
+		 "%s", "/opt/bin/nvidia-smi");
+	snprintf(config->rocm_smi_path, sizeof(config->rocm_smi_path),
+		 "%s", "/opt/bin/rocm-smi");
 
 	if (ini_parse(config_path, handler, config)) {
 		printf("Unable to parse config\n");

--- a/extra/service/legiond/modules/parseconf.h
+++ b/extra/service/legiond/modules/parseconf.h
@@ -4,12 +4,15 @@
 #include <stdbool.h>
 
 #define config_path "/etc/legion_linux/legiond.ini"
-typedef char command[100];
+#define MAX_CMD_LEN 100
+typedef char command[MAX_CMD_LEN];
 
 typedef struct _LEGIOND_CONFIG {
 	bool fan_control;
 	bool cpu_control;
 	command gpu_control;
+	command nvidia_smi_path;
+	command rocm_smi_path;
 	command cpu_ac_q;
 	command cpu_bat_q;
 	command cpu_ac_b;

--- a/extra/service/legiond/modules/setapply.c
+++ b/extra/service/legiond/modules/setapply.c
@@ -130,7 +130,7 @@ int set_fancurve(POWER_STATE power_state, LEGIOND_CONFIG *config)
 	int result = 0;
 
 	if (preset != NULL) {
-		char cmd[100];
+		char cmd[MAX_CMD_LEN + 64];
 		snprintf(cmd, sizeof(cmd),
 			 "legion_cli fancurve-write-preset-to-hw %s", preset);
 		result = system(cmd);
@@ -156,9 +156,9 @@ int set_gpu(POWER_STATE power_state, LEGIOND_CONFIG *config)
 	const char *tool;
 
 	if (strcmp(config->gpu_control, "nvidia") == 0) {
-		tool = "/opt/bin/nvidia-smi -pl ";
+		tool = config->nvidia_smi_path;
 	} else if (strcmp(config->gpu_control, "radeon") == 0) {
-		tool = "/opt/bin/rocm-smi --setpoweroverdrive ";
+		tool = config->rocm_smi_path;
 	} else {
 		printf("unknown gpu_control value: %s\n", config->gpu_control);
 		printf("skip gpu_control\n");
@@ -219,8 +219,11 @@ int set_gpu(POWER_STATE power_state, LEGIOND_CONFIG *config)
 	int result = 0;
 
 	if (tdp != NULL && tdp[0] != '\0') {
-		char cmd[100];
-		int written = snprintf(cmd, sizeof(cmd), "%s%s", tool, tdp);
+		const char *mode = strcmp(config->gpu_control, "nvidia") == 0
+					   ? "-pl "
+					   : "--setpoweroverdrive ";
+		char cmd[MAX_CMD_LEN + 64];
+		int written = snprintf(cmd, sizeof(cmd), "%s %s%s", tool, mode, tdp);
 		if (written < 0 || written >= (int)sizeof(cmd)) {
 			printf("gpu_control cmd too long, skipping\n");
 		} else {

--- a/kernel_module/legion-laptop.c
+++ b/kernel_module/legion-laptop.c
@@ -2884,7 +2884,7 @@ static ssize_t ecram_memoryio_read(const struct ecram_memoryio *ec_memoryio,
 	if (ec_offset < ec_memoryio->physical_ec_start) {
 		pr_info("Unexpected read at offset %d into EC RAM\n",
 			ec_offset);
-		return -1;
+		return -EIO;
 	}
 	*value = *(ec_memoryio->virtual_start +
 		   (ec_offset - ec_memoryio->physical_ec_start));
@@ -2902,7 +2902,7 @@ static __maybe_unused ssize_t ecram_memoryio_write(const struct ecram_memoryio *
 	if (ec_offset < ec_memoryio->physical_ec_start) {
 		pr_info("Unexpected write at offset %d into EC RAM\n",
 			ec_offset);
-		return -1;
+		return -EIO;
 	}
 	*(ec_memoryio->virtual_start +
 	  (ec_offset - ec_memoryio->physical_ec_start)) = value;
@@ -4590,7 +4590,7 @@ static int ec_read_minifancurve(struct ecram *ecram,
 	default:
 		pr_info("Unexpected value in MINIFANCURVE register: %d\n",
 			value);
-		return -1;
+		return -EIO;
 	}
 	return 0;
 }
@@ -4634,7 +4634,7 @@ static int ec_read_lockfancontroller(struct ecram *ecram,
 	default:
 		pr_info("Unexpected value in lockfanspeed register: %d\n",
 			value);
-		return -1;
+		return -EIO;
 	}
 	return 0;
 }
@@ -4672,7 +4672,7 @@ static int ec_read_fanfullspeed(struct ecram *ecram,
 	default:
 		pr_info("Unexpected value in maximumfanspeed register: %d\n",
 			value);
-		return -1;
+		return -EIO;
 	}
 	return 0;
 }
@@ -6886,7 +6886,7 @@ static void legion_wmi_notify(struct wmi_device *wdev, union acpi_object *data)
 
 	mutex_lock(&legion_shared_mutex);
 	priv = legion_shared;
-	if ((!priv) && (priv->loaded)) {
+	if ((!priv) || (priv->loaded)) {
 		pr_info("Received WMI event while not initialized!\n");
 		goto unlock;
 	}
@@ -7829,7 +7829,7 @@ static ssize_t minifancurve_show(struct device *dev,
 	mutex_lock(&priv->fancurve_mutex);
 	err = ec_read_minifancurve(&priv->ecram, priv->conf, &value);
 	if (err) {
-		err = -1;
+		err = -EIO;
 		pr_info("Failed to read minifancurve\n");
 		goto error_unlock;
 	}
@@ -7838,7 +7838,7 @@ static ssize_t minifancurve_show(struct device *dev,
 
 error_unlock:
 	mutex_unlock(&priv->fancurve_mutex);
-	return -1;
+	return -EIO;
 }
 
 static ssize_t minifancurve_store(struct device *dev,

--- a/python/legion_linux/legion_linux/legion.py
+++ b/python/legion_linux/legion_linux/legion.py
@@ -1497,9 +1497,7 @@ class SystemNotificationSender(NotificationSender):
                 log.warning("Cannot send notification: SUDO_USER not set")
                 return
             user_id = (
-                subprocess.run(
-                    ["id", "-u", sudo_user], stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True
-                )
+                subprocess.run(["id", "-u", sudo_user], stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True)
                 .stdout.decode("utf-8", errors="replace")
                 .replace("\n", "")
             )

--- a/python/legion_linux/legion_linux/legion.py
+++ b/python/legion_linux/legion_linux/legion.py
@@ -267,7 +267,7 @@ class EnumSettingFeature(Feature):
             log.error("Setting invalid value %s", value)
             raise ValueError(f"Invalid value {value}")
 
-    def get(self) -> bool:
+    def get(self) -> str:
         return self.value
 
 
@@ -1030,7 +1030,7 @@ class FanCurveIO(Feature):
             log.info("Trying to set minifancurve using fancurve profile to: %s", str(fan_curve.enable_minifancurve))
             self.set_minifancuve(fan_curve.enable_minifancurve)
         # pylint: disable=broad-except
-        except BaseException as error:
+        except Exception as error:
             log.error(str(error))
         for index, entry in enumerate(entries):
             point_id = index + 1
@@ -1096,7 +1096,7 @@ class FanCurveIO(Feature):
         try:
             fancurve.enable_minifancurve = self.get_minifancuve()
         # pylint: disable=broad-except
-        except BaseException as error:
+        except Exception as error:
             log.error(str(error))
         return fancurve
 
@@ -1488,9 +1488,13 @@ class SystemNotificationSender(NotifcationSender):
             # TODOs: find a better way
             # Code by user dvilela on stackoverflow
             # https://stackoverflow.com/a/54718205
+            sudo_user = os.environ.get("SUDO_USER")
+            if sudo_user is None:
+                log.warning("Cannot send notification: SUDO_USER not set")
+                return
             user_id = (
                 subprocess.run(
-                    ["id", "-u", os.environ["SUDO_USER"]], stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True
+                    ["id", "-u", sudo_user], stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True
                 )
                 .stdout.decode("utf-8", errors="replace")
                 .replace("\n", "")
@@ -1499,7 +1503,7 @@ class SystemNotificationSender(NotifcationSender):
                 [
                     "sudo",
                     "-u",
-                    os.environ["SUDO_USER"],
+                    sudo_user,
                     f"DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/{user_id}/bus",
                     "notify-send",
                     "-i",

--- a/python/legion_linux/legion_linux/legion.py
+++ b/python/legion_linux/legion_linux/legion.py
@@ -480,7 +480,7 @@ class BatteryConservation(BoolFileFeature):
         if value != self.get():
             self.set(value)
         else:
-            print(f"Already has value {value} - skip setting again.")
+            log.info("Already has value %s - skip setting again.", value)
 
 
 class RapidChargingFeature(BoolFileFeature):
@@ -557,7 +557,7 @@ class PlatformProfileFeature(FileFeature):
         try:
             available_choices_str = self.choices.get()
         except IOError as error:
-            print(error)
+            log.error("Failed to read platform profile choices: %s", error)
             available_choices_str = ""
         available_choices = available_choices_str.split(" ")
         return [p for p in self.all_values if p.value in available_choices]
@@ -761,7 +761,7 @@ class SystemDServiceFeature(BoolCommandFeature):
         return False
 
 
-class PowerProfilesDeamonService(SystemDServiceFeature):
+class PowerProfilesDaemonService(SystemDServiceFeature):
     def __init__(self):
         super().__init__("power-profiles-daemon")
 
@@ -1167,7 +1167,7 @@ class SettingsManager(Feature):
 
     def apply_settings(self, preset: Settings):
         for name, value in preset.setting_entries.items():
-            log.error("Try seting %s from preset to %s", name, value)
+            log.error("Try setting %s from preset to %s", name, value)
             has_set = Feature.set_feature_to_value(name, value)
             if not has_set:
                 log.error("Cannot set %s from preset to %s", name, value)
@@ -1256,22 +1256,26 @@ class CustomConservationController:
     def run(self):
         battery_cap = self.battery_capacity_perc.get()
         if battery_cap > self.upper_limit:
-            print(
-                "Enabling conservation mode because battery"
-                + f" {battery_cap} is greater than upper limit {self.upper_limit}"
+            log.info(
+                "Enabling conservation mode because battery %s is greater than upper limit %s",
+                battery_cap,
+                self.upper_limit,
             )
             self.battery_conservation.set_if_not_set(True)
             return self.battery_conservation.get()
         if battery_cap < self.lower_limit:
-            print(
-                "Disabling conservation mode because battery"
-                + f" {battery_cap} is lower than lower limit {self.lower_limit}"
+            log.info(
+                "Disabling conservation mode because battery %s is lower than lower limit %s",
+                battery_cap,
+                self.lower_limit,
             )
             self.battery_conservation.set_if_not_set(False)
             return self.battery_conservation.get()
-        print(
-            "Keeping conservation mode because battery"
-            + f" {battery_cap} is within bounds of {self.lower_limit} and {self.upper_limit}"
+        log.info(
+            "Keeping conservation mode because battery %s is within bounds of %s and %s",
+            battery_cap,
+            self.lower_limit,
+            self.upper_limit,
         )
         return self.battery_conservation.get()
 
@@ -1467,7 +1471,7 @@ class NVIDIAGPUOnQuietMode(Monitor):
 #                 monitors_to_notify = []
 
 
-class NotifcationSender:
+class NotificationSender:
     disable_notifications: bool
 
     def __init__(self):
@@ -1480,7 +1484,7 @@ class NotifcationSender:
         raise NotImplementedError()
 
 
-class SystemNotificationSender(NotifcationSender):
+class SystemNotificationSender(NotificationSender):
 
     def _send_notification(self, _, msg):
         if is_root_user():
@@ -1575,7 +1579,7 @@ class LegionModelFacade:
         self.ioport_light = IOPortLight()
 
         # services
-        self.power_profiles_deamon_service = PowerProfilesDeamonService()
+        self.power_profiles_deamon_service = PowerProfilesDaemonService()
         self.lenovo_legion_laptop_support_service = LenovoLegionLaptopSupportService()
         self.legion_gui_autostart = LegionGUIAutostart()
 
@@ -1752,11 +1756,16 @@ class LegionModelFacade:
         is_on_powersupply = self.on_power_supply.get()
         profile = self.platform_profile.get()
         preset_name = self.fancurve_repo.get_preset_name(profile, is_on_powersupply)
-        print(f"Loading preset={preset_name} for profile={profile} and is_powersupply={is_on_powersupply}")
+        log.info(
+            "Loading preset=%s for profile=%s and is_powersupply=%s",
+            preset_name,
+            profile,
+            is_on_powersupply,
+        )
         if preset_name in self.fancurve_repo.fancurve_presets:
             fancurve = self.fancurve_repo.load_by_name_or_default(preset_name)
             self.fancurve_io.write_fan_curve(fancurve, write_minifancurve)
-            print(fancurve)
+            log.info("Fancurve: %s", fancurve)
 
     def conservation_apply_mode_for_current_battery_capacity(self, lower_limit=None, upper_limit=None):
         if lower_limit is not None:

--- a/python/legion_linux/legion_linux/legion_gui.py
+++ b/python/legion_linux/legion_linux/legion_gui.py
@@ -151,7 +151,7 @@ def mark_error_combobox(combobox: QComboBox):
 
 
 def log_error(ex: Exception):
-    print("Error occured", ex)
+    print("Error occurred", ex)
     print(traceback.format_exc())
 
 
@@ -1150,7 +1150,7 @@ class FanCurveTab(QWidget):
         self.note_label2 = QLabel(
             "Greyed out features are not available. If most features are greyed out, "
             "the driver is not loaded properly or hwmon directory not found.\nIf features are marked "
-            "red, an unexpected error has occured while accessing the hardware and you should notify the maintainer."
+            "red, an unexpected error has occurred while accessing the hardware and you should notify the maintainer."
         )
         self.note_label2.setStyleSheet("color: red;")
         self.note_label2.setWordWrap(True)
@@ -1653,7 +1653,7 @@ class LegionTray:
         self.tray.show()
 
 
-def get_ressource_path(name):
+def get_resource_path(name):
     path = os.path.join(os.path.dirname(os.path.realpath(__file__)), name)
     return path
 
@@ -1691,13 +1691,13 @@ def get_icon_path(controller):
     log.info("Using icon_color %s", icon_color)
     if icon_color == "dark":
         log.info("Using icon legion_logo_dark")
-        icon_path = get_ressource_path("legion_logo_dark.png")
+        icon_path = get_resource_path("legion_logo_dark.png")
     elif icon_color == "light":
         log.info("Using icon legion_logo_light")
-        icon_path = get_ressource_path("legion_logo_light.png")
+        icon_path = get_resource_path("legion_logo_light.png")
     else:
         log.info("Using icon legion_logo")
-        icon_path = get_ressource_path("legion_logo.png")
+        icon_path = get_resource_path("legion_logo.png")
     return icon_path
 
 

--- a/python/legion_linux/legion_linux/legion_gui.py
+++ b/python/legion_linux/legion_linux/legion_gui.py
@@ -202,21 +202,22 @@ class EnumFeatureController:
                         value = val.value
 
                 if value is not None:
-                    print(f"Set to value: {value}")
+                    log.info("Set to value: %s", value)
                     self.feature.set(value)
                 else:
-                    print(f"Value for gui_value {gui_value} not found")
+                    log.info("Value for gui_value %s not found", gui_value)
             else:
                 self.widget.setDisabled(True)
         # pylint: disable=broad-except
         except Exception as ex:
             mark_error_combobox(self.widget)
             log_error(ex)
-        time.sleep(0.200)
+        QtCore.QTimer.singleShot(200, self._deferred_readback)
+
+    def _deferred_readback(self):
         self.update_view_from_feature()
 
         if self.dependent_controllers:
-            time.sleep(self.check_after_set_time)
             for contr in self.dependent_controllers:
                 contr.update_view_from_feature()
 
@@ -271,9 +272,6 @@ class BoolFeatureController:
             if self.feature.exists():
                 gui_value = self.checkbox.isChecked()
                 self.feature.set(gui_value)
-                time.sleep(0.100)
-                feature_value = self.feature.get()
-                self.checkbox.setChecked(feature_value)
                 self.checkbox.setDisabled(False)
             else:
                 self.checkbox.setDisabled(True)
@@ -282,8 +280,19 @@ class BoolFeatureController:
             mark_error(self.checkbox)
             log_error(ex)
 
+        QtCore.QTimer.singleShot(100, self._deferred_readback)
+
+    def _deferred_readback(self):
+        try:
+            if self.feature.exists():
+                feature_value = self.feature.get()
+                self.checkbox.setChecked(feature_value)
+        # pylint: disable=broad-except
+        except Exception as ex:
+            mark_error(self.checkbox)
+            log_error(ex)
+
         if self.dependent_controllers:
-            time.sleep(self.check_after_set_time)
             for contr in self.dependent_controllers:
                 contr.update_view_from_feature()
 
@@ -322,9 +331,6 @@ class BoolFeatureTrayController:
             if self.feature.exists():
                 gui_value = self.action.isChecked()
                 self.feature.set(gui_value)
-                time.sleep(0.100)
-                hw_value = self.feature.get()
-                self.action.setChecked(hw_value)
                 self.action.setDisabled(False)
                 self.action.setCheckable(True)
             else:
@@ -333,8 +339,18 @@ class BoolFeatureTrayController:
         # pylint: disable=broad-except
         except Exception as ex:
             log_error(ex)
+
+        QtCore.QTimer.singleShot(100, self._deferred_readback)
+
+    def _deferred_readback(self):
+        try:
+            if self.feature.exists():
+                hw_value = self.feature.get()
+                self.action.setChecked(hw_value)
+        # pylint: disable=broad-except
+        except Exception as ex:
+            log_error(ex)
         if self.dependent_controllers:
-            time.sleep(0.100)
             for contr in self.dependent_controllers:
                 contr.update_view_from_feature()
 
@@ -438,11 +454,12 @@ class EnumFeatureTrayController:
         # pylint: disable=broad-except
         except Exception as ex:
             log_error(ex)
-        time.sleep(0.200)
         log.info("Update view after setting inEnumFeatureTrayController ")
+        QtCore.QTimer.singleShot(200, self._deferred_readback)
+
+    def _deferred_readback(self):
         self.update_view_from_feature()
         if self.dependent_controllers:
-            time.sleep(0.100)
             for contr in self.dependent_controllers:
                 log.info("Update dependent view %s in EnumFeatureTrayController", str(contr))
                 contr.update_view_from_feature()
@@ -474,10 +491,10 @@ class IntFeatureController:
                 gui_value = self.widget.value()
                 low, upper, _ = self.feature.get_limits_and_step()
                 if low <= gui_value <= upper:
-                    print(f"Set to value: {gui_value}")
+                    log.info("Set to value: %s", gui_value)
                     self.feature.set(gui_value)
                 else:
-                    print(f"Value for gui_value {gui_value} not ignored with limits {low} and {upper}")
+                    log.info("Value for gui_value %s not ignored with limits %s and %s", gui_value, low, upper)
             else:
                 self.widget.setDisabled(True)
         # pylint: disable=broad-except
@@ -485,11 +502,15 @@ class IntFeatureController:
             mark_error_combobox(self.widget)
             log_error(ex)
         if wait:
-            time.sleep(0.200)
+            QtCore.QTimer.singleShot(200, self._deferred_readback)
+        else:
+            self.update_view_from_feature()
+
+    def _deferred_readback(self):
         self.update_view_from_feature()
 
     def update_view_from_feature(self, k=0, update_bounds=False):
-        print("update_view_from_feature", k)
+        log.info("update_view_from_feature: %s", k)
         try:
             if self.feature.exists():
                 # possible values

--- a/setmyfancurve.sh
+++ b/setmyfancurve.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -e
+set -u
 
 echo "MODEL"
 dmidecode -s system-version
@@ -12,97 +13,97 @@ if [ -z "${hwmondir}" ]; then
     echo "Error: Could not find legion hwmon directory. Is the legion_laptop module loaded?"
     exit 1
 fi
-echo "Using hwmon directory: ${hwmondir}" 
+echo "Using hwmon directory: ${hwmondir}"
 
 # Disable (0) or Enable (1) switching to minifancurve when everything seems very cool
-# echo 1    > ${hwmondir}/minifancurve
+# echo 1    > "${hwmondir}/minifancurve"
 
 # 1. Fan: Set the fan speed (rmp) of the first fan for the first 6 points (first must be 0)
-# If you want more, just continue 
-echo 0    > ${hwmondir}/pwm1_auto_point1_pwm
-echo 1500 > ${hwmondir}/pwm1_auto_point2_pwm
-echo 1900 > ${hwmondir}/pwm1_auto_point3_pwm
-echo 2100 > ${hwmondir}/pwm1_auto_point4_pwm
-echo 2200 > ${hwmondir}/pwm1_auto_point5_pwm
-echo 2500 > ${hwmondir}/pwm1_auto_point6_pwm
+# If you want more, just continue
+echo 0    > "${hwmondir}/pwm1_auto_point1_pwm"
+echo 1500 > "${hwmondir}/pwm1_auto_point2_pwm"
+echo 1900 > "${hwmondir}/pwm1_auto_point3_pwm"
+echo 2100 > "${hwmondir}/pwm1_auto_point4_pwm"
+echo 2200 > "${hwmondir}/pwm1_auto_point5_pwm"
+echo 2500 > "${hwmondir}/pwm1_auto_point6_pwm"
 
 # 2. Fan: Set the fan speed (rmp) of the first fan for the first 6 points; first must be 0)
-# If you want more, just continue 
-echo 0    > ${hwmondir}/pwm2_auto_point1_pwm
-echo 1600 > ${hwmondir}/pwm2_auto_point2_pwm
-echo 2000 > ${hwmondir}/pwm2_auto_point3_pwm
-echo 2200 > ${hwmondir}/pwm2_auto_point4_pwm
-echo 2300 > ${hwmondir}/pwm2_auto_point5_pwm
-echo 2500 > ${hwmondir}/pwm2_auto_point6_pwm
+# If you want more, just continue
+echo 0    > "${hwmondir}/pwm2_auto_point1_pwm"
+echo 1600 > "${hwmondir}/pwm2_auto_point2_pwm"
+echo 2000 > "${hwmondir}/pwm2_auto_point3_pwm"
+echo 2200 > "${hwmondir}/pwm2_auto_point4_pwm"
+echo 2300 > "${hwmondir}/pwm2_auto_point5_pwm"
+echo 2500 > "${hwmondir}/pwm2_auto_point6_pwm"
 
 
 # CPU lower temperature for each level for the first 6 points; first must be 0
-echo 0  > ${hwmondir}/pwm1_auto_point1_temp_hyst
-echo 46 > ${hwmondir}/pwm1_auto_point2_temp_hyst
-echo 52 > ${hwmondir}/pwm1_auto_point3_temp_hyst
-echo 56 > ${hwmondir}/pwm1_auto_point4_temp_hyst
-echo 58 > ${hwmondir}/pwm1_auto_point5_temp_hyst
-echo 67 > ${hwmondir}/pwm1_auto_point6_temp_hyst
+echo 0  > "${hwmondir}/pwm1_auto_point1_temp_hyst"
+echo 46 > "${hwmondir}/pwm1_auto_point2_temp_hyst"
+echo 52 > "${hwmondir}/pwm1_auto_point3_temp_hyst"
+echo 56 > "${hwmondir}/pwm1_auto_point4_temp_hyst"
+echo 58 > "${hwmondir}/pwm1_auto_point5_temp_hyst"
+echo 67 > "${hwmondir}/pwm1_auto_point6_temp_hyst"
 
-# CPU upper temperature for each level for the first 6 points; 
-echo 49 > ${hwmondir}/pwm1_auto_point1_temp
-echo 55 > ${hwmondir}/pwm1_auto_point2_temp
-echo 59 > ${hwmondir}/pwm1_auto_point3_temp
-echo 63 > ${hwmondir}/pwm1_auto_point4_temp
-echo 72 > ${hwmondir}/pwm1_auto_point5_temp
-echo 77 > ${hwmondir}/pwm1_auto_point6_temp
+# CPU upper temperature for each level for the first 6 points;
+echo 49 > "${hwmondir}/pwm1_auto_point1_temp"
+echo 55 > "${hwmondir}/pwm1_auto_point2_temp"
+echo 59 > "${hwmondir}/pwm1_auto_point3_temp"
+echo 63 > "${hwmondir}/pwm1_auto_point4_temp"
+echo 72 > "${hwmondir}/pwm1_auto_point5_temp"
+echo 77 > "${hwmondir}/pwm1_auto_point6_temp"
 
 # GPU lower temperature for each level for the first 6 points; first must be 0
-echo 0  > ${hwmondir}/pwm2_auto_point1_temp_hyst
-echo 56 > ${hwmondir}/pwm2_auto_point2_temp_hyst
-echo 57 > ${hwmondir}/pwm2_auto_point3_temp_hyst
-echo 58 > ${hwmondir}/pwm2_auto_point4_temp_hyst
-echo 59 > ${hwmondir}/pwm2_auto_point5_temp_hyst
-echo 60 > ${hwmondir}/pwm2_auto_point6_temp_hyst
+echo 0  > "${hwmondir}/pwm2_auto_point1_temp_hyst"
+echo 56 > "${hwmondir}/pwm2_auto_point2_temp_hyst"
+echo 57 > "${hwmondir}/pwm2_auto_point3_temp_hyst"
+echo 58 > "${hwmondir}/pwm2_auto_point4_temp_hyst"
+echo 59 > "${hwmondir}/pwm2_auto_point5_temp_hyst"
+echo 60 > "${hwmondir}/pwm2_auto_point6_temp_hyst"
 
-# GPU upper temperature for each level for the first 6 points; 
-echo 59 > ${hwmondir}/pwm2_auto_point1_temp
-echo 60 > ${hwmondir}/pwm2_auto_point2_temp
-echo 61 > ${hwmondir}/pwm2_auto_point3_temp
-echo 62 > ${hwmondir}/pwm2_auto_point4_temp
-echo 63 > ${hwmondir}/pwm2_auto_point5_temp
-echo 64 > ${hwmondir}/pwm2_auto_point6_temp
+# GPU upper temperature for each level for the first 6 points;
+echo 59 > "${hwmondir}/pwm2_auto_point1_temp"
+echo 60 > "${hwmondir}/pwm2_auto_point2_temp"
+echo 61 > "${hwmondir}/pwm2_auto_point3_temp"
+echo 62 > "${hwmondir}/pwm2_auto_point4_temp"
+echo 63 > "${hwmondir}/pwm2_auto_point5_temp"
+echo 64 > "${hwmondir}/pwm2_auto_point6_temp"
 
 # IC lower temperature for each level for the first 6 points; first must be 0
-echo 0  > ${hwmondir}/pwm3_auto_point1_temp_hyst
-echo 56 > ${hwmondir}/pwm3_auto_point2_temp_hyst
-echo 57 > ${hwmondir}/pwm3_auto_point3_temp_hyst
-echo 58 > ${hwmondir}/pwm3_auto_point4_temp_hyst
-echo 59 > ${hwmondir}/pwm3_auto_point5_temp_hyst
-echo 60 > ${hwmondir}/pwm3_auto_point6_temp_hyst
+echo 0  > "${hwmondir}/pwm3_auto_point1_temp_hyst"
+echo 56 > "${hwmondir}/pwm3_auto_point2_temp_hyst"
+echo 57 > "${hwmondir}/pwm3_auto_point3_temp_hyst"
+echo 58 > "${hwmondir}/pwm3_auto_point4_temp_hyst"
+echo 59 > "${hwmondir}/pwm3_auto_point5_temp_hyst"
+echo 60 > "${hwmondir}/pwm3_auto_point6_temp_hyst"
 
-# IC upper temperature for each level for the first 6 points; 
-echo 59 > ${hwmondir}/pwm3_auto_point1_temp
-echo 60 > ${hwmondir}/pwm3_auto_point2_temp
-echo 61 > ${hwmondir}/pwm3_auto_point3_temp
-echo 62 > ${hwmondir}/pwm3_auto_point4_temp
-echo 63 > ${hwmondir}/pwm3_auto_point5_temp
-echo 64 > ${hwmondir}/pwm3_auto_point6_temp
+# IC upper temperature for each level for the first 6 points;
+echo 59 > "${hwmondir}/pwm3_auto_point1_temp"
+echo 60 > "${hwmondir}/pwm3_auto_point2_temp"
+echo 61 > "${hwmondir}/pwm3_auto_point3_temp"
+echo 62 > "${hwmondir}/pwm3_auto_point4_temp"
+echo 63 > "${hwmondir}/pwm3_auto_point5_temp"
+echo 64 > "${hwmondir}/pwm3_auto_point6_temp"
 
-# Acceleration time (larger = slower acceleartion) for each level for the first 6 points; 
-echo 5 > ${hwmondir}/pwm1_auto_point1_accel
-echo 5 > ${hwmondir}/pwm1_auto_point2_accel
-echo 5 > ${hwmondir}/pwm1_auto_point3_accel
-echo 4 > ${hwmondir}/pwm1_auto_point4_accel
-echo 2 > ${hwmondir}/pwm1_auto_point5_accel
-echo 2 > ${hwmondir}/pwm1_auto_point6_accel
+# Acceleration time (larger = slower acceleartion) for each level for the first 6 points;
+echo 5 > "${hwmondir}/pwm1_auto_point1_accel"
+echo 5 > "${hwmondir}/pwm1_auto_point2_accel"
+echo 5 > "${hwmondir}/pwm1_auto_point3_accel"
+echo 4 > "${hwmondir}/pwm1_auto_point4_accel"
+echo 2 > "${hwmondir}/pwm1_auto_point5_accel"
+echo 2 > "${hwmondir}/pwm1_auto_point6_accel"
 
-# Decleration time (larger = slower acceleartion) for each level for the first 6 points; 
-echo 4 > ${hwmondir}/pwm1_auto_point1_decel
-echo 4 > ${hwmondir}/pwm1_auto_point2_decel
-echo 4 > ${hwmondir}/pwm1_auto_point3_decel
-echo 3 > ${hwmondir}/pwm1_auto_point4_decel
-echo 2 > ${hwmondir}/pwm1_auto_point5_decel
-echo 2 > ${hwmondir}/pwm1_auto_point6_decel
+# Decleration time (larger = slower acceleartion) for each level for the first 6 points;
+echo 4 > "${hwmondir}/pwm1_auto_point1_decel"
+echo 4 > "${hwmondir}/pwm1_auto_point2_decel"
+echo 4 > "${hwmondir}/pwm1_auto_point3_decel"
+echo 3 > "${hwmondir}/pwm1_auto_point4_decel"
+echo 2 > "${hwmondir}/pwm1_auto_point5_decel"
+echo 2 > "${hwmondir}/pwm1_auto_point6_decel"
 
-echo "Writing fancurve succesful!"
+echo "Writing fancurve successful!"
 cat /sys/kernel/debug/legion/fancurve
-echo "Writing fancurve succesful!"
+echo "Writing fancurve successful!"
 echo "MODEL"
 dmidecode -s system-version
 echo "BIOS"


### PR DESCRIPTION
## Summary

Fixes 6 confirmed bugs across the kernel module, Python package, CI workflows and deploy scripts, plus a set of code-quality improvements.

## Bug fixes

- **kernel-module**: fix null deref in feature lookup (`(!priv) && (priv->loaded)` → `||`); return `-EIO` instead of `-1` from sysfs store callbacks (`-1` surfaced as errno 255).
- **python**: `except BaseException` → `except Exception` (don't swallow `KeyboardInterrupt`/`SystemExit`); avoid `KeyError` when running as root without `SUDO_USER` set; correct `EnumSettingFeature.get()` return annotation (`bool` → `str`).
- **python/gui**: replace blocking `time.sleep` in controller readback with a deferred `QtCore.QTimer` readback so the UI thread is not frozen while reading hardware state.
- **ci**: fix `test_kenel_dkms_install.sh` → `test_kernel_dkms_install.sh` in all three workflow files (the Build step was silently failing).
- **deploy**: fix `build_containers.sh` working-dir bug; drop `curl --insecure` (disables TLS verification) from the deb download script.

## Code quality

- Replace remaining `print()` diagnostics with the configured logger.
- Fix internal identifier typos (`PowerProfilesDeamonService`→`Daemon`, `NotifcationSender`→`NotificationSender`, `get_ressource_path`→`get_resource_path`, `occured`→`occurred`, `seting`→`setting`) — no ABI impact.
- **legiond**: make GPU tool paths configurable via `nvidia_smi_path`/`rocm_smi_path` in `legiond.ini` (added `MAX_CMD_LEN`); replace `strcpy` with bounds-checked `snprintf` for the socket path.
- **smartfan**: quote hwmon paths and enable `set -u` in `setmyfancurve.sh`.

## Verification

- `checkpatch.pl`: 0 errors, 0 warnings on `legion-laptop.c`.
- `legiond` builds with `-std=gnu2x -Wall -Wextra`: zero warnings.
- `tests/test_python_cli.sh` passes; all Python compiles; bash scripts pass `bash -n`.