### PR TITLE
fix(shell): fix shellcheck warnings across deploy/, tests/, smartfan

### DIFF
--- a/deploy/build_kernelpatch.sh
+++ b/deploy/build_kernelpatch.sh
@@ -20,7 +20,7 @@ mkdir -p "${BUILD_DIR}"
 # Clone
 cd "${BUILD_DIR}"
 git clone --depth 1 --branch "v${KERNEL_VERSION}" https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-cd ${BUILD_DIR}/linux
+cd "${BUILD_DIR}/linux"
 
 DRIVER_DIR="${BUILD_DIR}/linux/drivers/platform/x86"
 if [ -d "${DRIVER_DIR}/lenovo" ]; then
@@ -44,9 +44,10 @@ config LEGION_LAPTOP
 	  This is a driver for Lenovo Legion laptops and contains drivers for
 	  hotkey, fan control, and power mode.
 EOF
+# shellcheck disable=SC2016
 printf '\nobj-$(CONFIG_LEGION_LAPTOP) += legion-laptop.o\n' >> "${DRIVER_DIR}/Makefile"
 
-cd ${BUILD_DIR}/linux
+cd "${BUILD_DIR}/linux"
 git config user.name "John Martens"
 git config user.email "john.martens4@proton.me"
 git add --all

--- a/deploy/dependencies/install_dependencies_suse.sh
+++ b/deploy/dependencies/install_dependencies_suse.sh
@@ -5,7 +5,7 @@ sudo zypper refresh
 set +e
 sudo zypper --non-interactive install make gcc kernel-devel kernel-default-devel git libopenssl-devel sensors dmidecode python3-qt6 python3-pip python3-wheel python3-PyYAML python3-Pillow pkexec
 ecode=$?
-if [ "$ecode" != 0 -a "$ecode" != 107 -a "$ecode" != 130 ]; then
+if [ "$ecode" != 0 ] && [ "$ecode" != 107 ] && [ "$ecode" != 130 ]; then
 	exit 1
 fi
 set -e

--- a/deploy/dependencies/install_dependencies_ubuntu_22_04.sh
+++ b/deploy/dependencies/install_dependencies_ubuntu_22_04.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -ex
 sudo apt-get update
-sudo apt-get install -y make gcc clang linux-headers-$(uname -r) build-essential git lm-sensors wget python3-yaml python3-venv python3-pip python3-wheel python3-argcomplete python3-pillow policykit-1
+sudo apt-get install -y make gcc clang "linux-headers-$(uname -r)" build-essential git lm-sensors wget python3-yaml python3-venv python3-pip python3-wheel python3-argcomplete python3-pillow policykit-1
 sudo apt-get install -y dkms openssl mokutil
 sudo pip install PyQt6

--- a/deploy/dependencies/install_dependencies_ubuntu_24_04.sh
+++ b/deploy/dependencies/install_dependencies_ubuntu_24_04.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 set -ex
 sudo apt-get update
-sudo apt-get install -y make gcc clang linux-headers-$(uname -r) linux-modules-extra-$(uname -r) build-essential git lm-sensors wget python3-pyqt6 python3-yaml python3-venv python3-pip python3-wheel python3-argcomplete policykit-1
+sudo apt-get install -y make gcc clang "linux-headers-$(uname -r)" "linux-modules-extra-$(uname -r)" build-essential git lm-sensors wget python3-pyqt6 python3-yaml python3-venv python3-pip python3-wheel python3-argcomplete policykit-1
 sudo apt-get install -y dkms openssl mokutil python3-pillow

--- a/deploy/dependencies/install_development_dependencies_arch.sh
+++ b/deploy/dependencies/install_development_dependencies_arch.sh
@@ -8,5 +8,5 @@ sudo pacman -S --noconfirm --disable-download-timeout wget \
     python-pylint python-installer python-build \
     xorg-server-xvfb libxcb
 
-${DIR}/linux_kernel/install_checkpath.sh
+"${DIR}/linux_kernel/install_checkpath.sh"
 

--- a/deploy/dependencies/install_development_dependencies_fedora.sh
+++ b/deploy/dependencies/install_development_dependencies_fedora.sh
@@ -10,5 +10,5 @@ sudo dnf -y install wget \
 # Linter/Tests (not as package in all rhel variants available!)
 python3 -m pip install pytest pylint
 
-${DIR}/linux_kernel/install_checkpath.sh
+"${DIR}/linux_kernel/install_checkpath.sh"
 

--- a/deploy/dependencies/install_development_dependencies_suse.sh
+++ b/deploy/dependencies/install_development_dependencies_suse.sh
@@ -16,4 +16,4 @@ sudo zypper --non-interactive install \
     xorg-x11-server-extra libxcb-xinerama0 xauth
 
 
-${DIR}/linux_kernel/install_checkpath.sh
+"${DIR}/linux_kernel/install_checkpath.sh"

--- a/deploy/dependencies/install_development_dependencies_ubuntu_22_04.sh
+++ b/deploy/dependencies/install_development_dependencies_ubuntu_22_04.sh
@@ -14,5 +14,5 @@ sudo apt-get -y -qq install \
 
 sudo pip install pyqt6-tools PyQt6
 
-${DIR}/install_dependencies_ubuntu_22_04.sh
-${DIR}/linux_kernel/install_checkpath.sh
+"${DIR}/install_dependencies_ubuntu_22_04.sh"
+"${DIR}/linux_kernel/install_checkpath.sh"

--- a/deploy/dependencies/install_development_dependencies_ubuntu_24_04.sh
+++ b/deploy/dependencies/install_development_dependencies_ubuntu_24_04.sh
@@ -12,5 +12,5 @@ sudo apt-get -y -qq install \
     pylint python3-venv python3-pip python3-build \
     python3-installer xvfb libxcb-xinerama0 pyqt6-dev-tools
 
-${DIR}/install_dependencies_ubuntu_24_04.sh
-${DIR}/linux_kernel/install_checkpath.sh
+"${DIR}/install_dependencies_ubuntu_24_04.sh"
+"${DIR}/linux_kernel/install_checkpath.sh"

--- a/deploy/dependencies/linux_kernel/install_checkpath.sh
+++ b/deploy/dependencies/linux_kernel/install_checkpath.sh
@@ -2,7 +2,7 @@
 set -ex
 DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
-cd ${DIR}/../install_dir
+cd "${DIR}/../install_dir"
 
 wget "https://raw.githubusercontent.com/torvalds/linux/master/scripts/checkpatch.pl"
 wget "https://raw.githubusercontent.com/torvalds/linux/master/scripts/spelling.txt"

--- a/deploy/package_testing/build_containers.sh
+++ b/deploy/package_testing/build_containers.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 set -ex
 DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-cd ${DIR}
+cd "${DIR}"
 sudo docker compose build --no-cache

--- a/deploy/package_testing/download_install_debian.sh
+++ b/deploy/package_testing/download_install_debian.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+set -ex
 sudo apt install -y curl
 
 # deb.debian.org has a valid TLS certificate; ftp.de.debian.org serves a

--- a/deploy/python_install_installer_pkg.sh
+++ b/deploy/python_install_installer_pkg.sh
@@ -4,10 +4,10 @@ DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 REPODIR="${DIR}/.."
 
 #Install LenovoLegionLinux python package
-cd ${REPODIR}
+cd "${REPODIR}"
 TAG=$(git describe --tags --abbrev=0 | sed 's/[^0-9.]*//g')
 
-cd ${REPODIR}/python/legion_linux
+cd "${REPODIR}/python/legion_linux"
 sed -i "s/version = _VERSION/version = ${TAG}/g" setup.cfg
 #mkdir $HOME/.config/lenovo_linux
 

--- a/deploy/python_install_pip_pkg.sh
+++ b/deploy/python_install_pip_pkg.sh
@@ -4,10 +4,10 @@ DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 REPODIR="${DIR}/.."
 
 #Install LenovoLegionLinux python package
-cd ${REPODIR}
+cd "${REPODIR}"
 TAG=$(git describe --tags --abbrev=0 | sed 's/[^0-9.]*//g')
 
-cd ${REPODIR}/python/legion_linux
+cd "${REPODIR}/python/legion_linux"
 sed -i "s/version = _VERSION/version = ${TAG}/g" setup.cfg
 
 python3 -m build --wheel --no-isolation

--- a/deploy/python_uninstall_pkg.sh
+++ b/deploy/python_uninstall_pkg.sh
@@ -1,9 +1,9 @@
-!/bin/bash
+#!/bin/bash
 set -ex
 DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 REPODIR="${DIR}"
 
-cd ${REPODIR}/python/legion_linux
+cd "${REPODIR}/python/legion_linux"
 
 if [ "$EUID" -ne 0 ]; then
 	echo "Please run as root to install"

--- a/extra/smartfan/smartfan.sh
+++ b/extra/smartfan/smartfan.sh
@@ -85,10 +85,14 @@ set_fan_speed() {
     if [ "$pct" -gt 100 ]; then pct=100; fi
     
     local val=$((pct * 100))
-    local b0=$(printf '0x%02x' $((val & 0xFF)))
-    local b1=$(printf '0x%02x' $(((val >> 8) & 0xFF)))
-    local b2=$(printf '0x%02x' $(((val >> 16) & 0xFF)))
-    local b3=$(printf '0x%02x' $(((val >> 24) & 0xFF)))
+    local b0
+    b0=$(printf '0x%02x' $((val & 0xFF)))
+    local b1
+    b1=$(printf '0x%02x' $(((val >> 8) & 0xFF)))
+    local b2
+    b2=$(printf '0x%02x' $(((val >> 16) & 0xFF)))
+    local b3
+    b3=$(printf '0x%02x' $(((val >> 24) & 0xFF)))
     
     # Try both fan channels
     echo "\_SB_.GZFD.WMAE 0 0x12 {0x01, 0x00, 0x03, 0x04, $b0, $b1, $b2, $b3}" > "$ACPI_CALL" 2>/dev/null
@@ -127,8 +131,10 @@ get_max_temp() {
 
 get_target_pct() {
     local temp=$1
-    local temps=($TEMP_POINTS)
-    local fans=($FAN_POINTS)
+    local temps
+    read -ra temps <<< "$TEMP_POINTS"
+    local fans
+    read -ra fans <<< "$FAN_POINTS"
     local target=${fans[0]}
     
     # If below first point, use first fan speed
@@ -178,7 +184,8 @@ run_daemon() {
     find_hwmon
     get_profile "$mode"
     
-    local current_pct=$(echo $FAN_POINTS | awk '{print $1}')
+    local current_pct
+    current_pct=$(echo "$FAN_POINTS" | awk '{print $1}')
     local down_count=0
     local ramp_up_count=0
     local temp_history=""
@@ -201,11 +208,12 @@ run_daemon() {
         fi
         
         # Check mode changes
-        local new_mode=$(cat "$MODEFILE" 2>/dev/null)
+        local new_mode
+        new_mode=$(cat "$MODEFILE" 2>/dev/null)
         if [ -n "$new_mode" ] && [ "$new_mode" != "$mode" ]; then
             mode="$new_mode"
             get_profile "$mode"
-            current_pct=$(echo $FAN_POINTS | awk '{print $1}')
+            current_pct=$(echo "$FAN_POINTS" | awk '{print $1}')
             down_count=0
             ramp_up_count=0
             temp_history=""
@@ -214,7 +222,8 @@ run_daemon() {
         fi
         
         # Get temperature
-        local temp=$(get_max_temp)
+        local temp
+        temp=$(get_max_temp)
         if [ -z "$temp" ] || [ "$temp" -eq 0 ]; then
             temp=$last_temp
             log "Warning: Could not read temperature, using last known: $temp"
@@ -223,7 +232,8 @@ run_daemon() {
         
         # Apply smoothing
         temp_history="$temp_history $temp"
-        local count=$(echo "$temp_history" | wc -w)
+        local count
+        count=$(echo "$temp_history" | wc -w)
         if [ "$count" -gt "$temp_samples" ]; then
             temp_history=$(echo "$temp_history" | cut -d' ' -f2-)
         fi
@@ -237,7 +247,8 @@ run_daemon() {
         temp=$((sum / count))
         
         # Get target speed
-        local target_pct=$(get_target_pct "$temp")
+        local target_pct
+        target_pct=$(get_target_pct "$temp")
         
         # Fan control logic with smooth transitions
         if [ "$target_pct" -gt "$current_pct" ]; then
@@ -303,7 +314,8 @@ stop_daemon() {
     
     # Kill by PID
     if [ -f "$PIDFILE" ]; then
-        local pid=$(cat "$PIDFILE" 2>/dev/null)
+        local pid
+        pid=$(cat "$PIDFILE" 2>/dev/null)
         if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
             kill -TERM "$pid" 2>/dev/null
             # Wait for graceful shutdown

--- a/extra/smartfan/workmode.sh
+++ b/extra/smartfan/workmode.sh
@@ -34,7 +34,7 @@ echo "║  5) turbo        (fans 100% NOW)     ║"
 echo "║  6) fans off     (stop smart fan)    ║"
 echo "╚══════════════════════════════════════╝"
 echo ""
-read -p "Select mode [1-6]: " choice
+read -r -p "Select mode [1-6]: " choice
 
 case $choice in
     1) wmi_arg="0x01"; fanmode="quiet"; label="quiet" ;;
@@ -69,8 +69,8 @@ fi
 echo ""
 echo "Temps:"
 if [ -n "$HWMON" ]; then
-    echo "  CPU: $(($(cat $HWMON/temp1_input) / 1000))°C"
-    echo "  GPU: $(($(cat $HWMON/temp2_input) / 1000))°C"
-    echo "  Fan1: $(cat $HWMON/fan1_input) RPM"
-    echo "  Fan2: $(cat $HWMON/fan2_input) RPM"
+    echo "  CPU: $(($(cat "$HWMON/temp1_input") / 1000))°C"
+    echo "  GPU: $(($(cat "$HWMON/temp2_input") / 1000))°C"
+    echo "  Fan1: $(cat "$HWMON/fan1_input") RPM"
+    echo "  Fan2: $(cat "$HWMON/fan2_input") RPM"
 fi

--- a/tests/test_kernel_checkpath.sh
+++ b/tests/test_kernel_checkpath.sh
@@ -2,5 +2,5 @@
 set -ex
 DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 
-${DIR}/../deploy/dependencies/install_dir/checkpatch.pl --ignore LINUX_VERSION_CODE --ignore CONSTANT_COMPARISON -f --no-tree ${DIR}/../kernel_module/legion-laptop.c
+"${DIR}/../deploy/dependencies/install_dir/checkpatch.pl" --ignore LINUX_VERSION_CODE --ignore CONSTANT_COMPARISON -f --no-tree "${DIR}/../kernel_module/legion-laptop.c"
 

--- a/tests/test_kernel_dkms_install.sh
+++ b/tests/test_kernel_dkms_install.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 sudo apt-get install dkms openssl mokutil
-cd kernel_module
+cd kernel_module || exit 1
 sudo make dkms

--- a/tests/test_python.sh
+++ b/tests/test_python.sh
@@ -2,4 +2,4 @@
 set -ex
 DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
-pylint --ignore-patterns=legion_gui_qt6.py,legion_version.py --rcfile ${DIR}/../python/legion_linux/pylintrc ${DIR}/../python/legion_linux/legion_linux
+pylint --ignore-patterns=legion_gui_qt6.py,legion_version.py --rcfile "${DIR}/../python/legion_linux/pylintrc" "${DIR}/../python/legion_linux/legion_linux"

--- a/tests/test_python_cli.sh
+++ b/tests/test_python_cli.sh
@@ -3,4 +3,4 @@ set -ex
 DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 # Smoketest CLI
-${DIR}/../python/legion_linux/legion_linux/legion_cli.py --donotexpecthwmon
+"${DIR}/../python/legion_linux/legion_linux/legion_cli.py" --donotexpecthwmon

--- a/tests/test_python_installed.sh
+++ b/tests/test_python_installed.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
-REPODIR="${DIR}/.."
 set -ex
-${DIR}/test_python_cli_installed.sh
-${DIR}/test_python_gui_installed.sh 
+"${DIR}/test_python_cli_installed.sh"
+"${DIR}/test_python_gui_installed.sh"


### PR DESCRIPTION
Fixes shellcheck warnings found across all shell scripts in the repo. Suggested by @st0nie in #528.

**3 real bugs:**
- `deploy/python_uninstall_pkg.sh`: broken shebang `!/bin/bash` → `#!/bin/bash`
- `deploy/package_testing/download_install_debian.sh`: missing shebang entirely
- `tests/test_kernel_dkms_install.sh`: `cd` without `|| exit` — script would silently continue in the wrong directory on failure

**Code quality fixes:**
- Quote unquoted variables to prevent word splitting (SC2086)
- Replace deprecated `[ -a ]` test operator with `&&` (SC2166)
- Quote `7.2.2-1-cachyos` in apt-get install (SC2046)
- Split local declare+assign to avoid masking return values (SC2155)
- Use `read -ra` instead of array word splitting (SC2206)
- Add `-r` flag to `read` to preserve backslashes (SC2162)
- Remove unused `REPODIR` variable (SC2034)
- Suppress false-positive SC2016 for Makefile syntax in printf

```
shellcheck deploy/*.sh deploy/dependencies/*.sh deploy/dependencies/linux_kernel/*.sh deploy/package_testing/*.sh tests/*.sh extra/smartfan/*.sh
# EXIT: 0 — clean
```