### PR TITLE
feat(kernel-module): add T3CN (Legion 5 15AGP11, 83Q6) using model_t2cn

### DIFF
--- a/kernel_module/legion-laptop.c
+++ b/kernel_module/legion-laptop.c
@@ -2061,6 +2061,17 @@ static const struct dmi_system_id optimistic_allowlist[] = {
 		.driver_data = (void *)&model_t2cn
 	},
 	{
+		// e.g. Legion 5 15AGP11 (83Q6, AMD Ryzen AI 9 465 + RTX 5070) -
+		// same platform as the 83Q7 above; EC 0x5509, fancurve via
+		// WMI3 (#504)
+		.ident = "T3CN",
+		.matches = {
+			DMI_MATCH(DMI_SYS_VENDOR, "LENOVO"),
+			DMI_MATCH(DMI_BIOS_VERSION, "T3CN"),
+		},
+		.driver_data = (void *)&model_t2cn
+	},
+	{
 		// e.g. Legion 5 15IRX10 (83LY)
 		.ident = "QNCN",
 		.matches = {


### PR DESCRIPTION
Adds a DMI allowlist entry for the **Legion 5 15AGP11 (83Q6, AMD Ryzen AI 9 465 + RTX 5070)**, BIOS prefix `T3CN`, pointing at the existing `model_t2cn`.

This is the same platform generation as the 83Q7 added in the T2CN entry — EC chip `0x5509`, vendor EC RAM reads blocked by firmware, fans/temps/fancurve over WMI3 — so no new `model_config` is needed.

### The problem

The 83Q6 has no DMI entry, so the module either refuses to load, or with `force=1` falls back to `optimistic_allowlist[0]` (GKCN / `model_v0`, a 2021 Legion 7 config) and reads the wrong EC offsets. That fails silently: sensors return 0 rather than erroring.

```
Using configuration for system: GKCN
Skipped checking embedded controller id
Fan 1: 0 RPM   Fan 2: 0 RPM
CPU Temperature: +0.0°C   GPU Temperature: +0.0°C
Error WMI call for reading brightness: expected a value between 1 and 3, but got 0
```

### After

```
is_denied: 0; is_allowed: 1; do_load_by_list: 1; do_load: 1
Using configuration for system: T3CN
Read embedded controller ID 0x5509
Keyboard backlight handling disabled by this driver
```

Matched by the allowlist rather than forced, and the EC ID check now **passes on its own** instead of being skipped.

### Fan verification

Sampled against the independent `yogafan` hwmon under 20-thread CPU load:

| load | `legion_hwmon` | `yogafan` | CPU temp |
|---|---|---|---|
| idle | 0 RPM | 0 RPM | 38°C |
| 10s | 1200 RPM | 1250 RPM | 75°C |
| 20s | 2000 RPM | 1900 RPM | 79°C |
| 40s | 2500 RPM | 2800 RPM | 84°C |
| 60–90s | 3100 RPM | 3300 RPM | 85–86°C |
| cooling | 2600 RPM | 2700 RPM | 47°C |

CPU temperature tracked 38°C idle → 86°C loaded → 47°C on release. Both fans report (fan1 1950 / fan2 2050 RPM while cooling). Offsets between the two sources are sampling skew, not disagreement.

### Why `model_t2cn` verbatim

Every model-specific flag was checked against the hardware:

| Field | Evidence on 83Q6 |
|---|---|
| `embedded_controller_id = 0x5509` | `Read embedded controller ID 0x5509`, check passes unforced |
| `access_method_keyboard = NO_ACCESS` | brightness read fails identically to 83Q7 (the reason for ea15282) |
| `skip_ylogo_light = true` | no lid lighting on this chassis |
| `skip_ioport_light = true` | no illuminated rear I/O ports |
| `access_method_fanspeed/temperature = WMI3` | table above |

### Known limitations

Unchanged by this patch and shared with the 83Q7: IC temperature (`temp3`) still reads 0, and the EC-backed power-limit attributes still read 0, since vendor EC RAM access is blocked by firmware.

Also worth noting: the mainline `lenovo-wmi-other` driver logs `fan reporting/tuning is unsupported on this device` for `DC2A8805-…` on this machine, yet LLL's WMI3 path reads fans correctly — so that probe doesn't predict WMI3 usability here.

### Testing

- Machine: Lenovo Legion 5 15AGP11 (83Q6), BIOS T3CN37WW, board LNVNB161216
- Kernel 7.2.2, Artix Linux
- `make` clean; `checkpatch.pl --ignore LINUX_VERSION_CODE --ignore CONSTANT_COMPARISON`: **0 errors, 0 warnings**
- Loaded via `make reloadmodule` (plain `insmod`, no `force`) to confirm the DMI match binds on its own

Refs #504
