### PR TITLE
Fix static analysis findings in Python package and legiond daemon

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,6 +530,7 @@ sudo python/legion_linux/legion_linux/legion_gui.py
 </p>
 
 - with `Read from HW` you can read the current fan curve that is saved in the hardware and display it.
+- the current fan curve is loaded automatically at start-up when the kernel module is present; otherwise the fan curve starts empty and `Read from HW` is greyed out
 - you can edit the values of the fancurve. They will not applied to hardware until your press `Apply to HW`
 - press `Apply to HW` to write the currently displayed fancurve to hardware and activate it
 - you can load and save a fancurve to a preset. Select the preset with the drop-down menu and press `Load from Preset` or `Save to preset`.

--- a/README_zh-hans.md
+++ b/README_zh-hans.md
@@ -542,6 +542,7 @@ sudo python/legion_linux/legion_linux/legion_gui.py
 </p>
 
 - 点击 `Read from HW` 可以读取并显示保存在硬件中的当前风扇曲线。
+- 如果内核模块已加载，启动时会自动读取当前风扇曲线；否则曲线初始为空，`Read from HW` 按钮不可用。
 - 你可以编辑风扇曲线的各项数值。只有点击 `Apply to HW` 后，修改才会写入硬件并生效。
 - 点击 `Apply to HW` 可将当前显示的风扇曲线写入硬件并激活。
 - 你可以将风扇曲线保存为预设或从预设加载。通过下拉菜单选择预设，然后点击 `Load from Preset` 或 `Save to preset`。

--- a/extra/service/legiond/legiond-ctl.c
+++ b/extra/service/legiond/legiond-ctl.c
@@ -49,6 +49,10 @@ int main(int argc, char *argv[])
 			// for example "legiond-ctl fanset 3" means 3 seconds delay
 			if (sscanf(argv[2], "%d", &request.delay_s) != 1)
 				request.delay_s = 0;
+			if (request.delay_s < 0) {
+				printf("invalid delay: must be >= 0\n");
+				return 1;
+			}
 		}
 	}
 

--- a/extra/service/legiond/legiond.c
+++ b/extra/service/legiond/legiond.c
@@ -4,6 +4,11 @@
 #include "modules/powerstate.h"
 #include "modules/setapply.h"
 
+#include <errno.h>
+#include <fcntl.h>
+#include <poll.h>
+#include <pthread.h>
+
 #define events_max 10
 #define BUF_LEN (events_max * (sizeof(struct inotify_event) + NAME_MAX + 1))
 
@@ -23,6 +28,16 @@ static timer_t timerid;
 static long delay_s_default;
 static long delay_ns_default;
 
+/*
+ * Serializes access to config/delayed/triggered between the SIGEV_THREAD
+ * timer thread and the main loop (socket commands).  It also serializes
+ * hardware writes (set_all/set_cpu), which must never run concurrently.
+ */
+static pthread_mutex_t state_lock = PTHREAD_MUTEX_INITIALIZER;
+
+static volatile sig_atomic_t terminate_requested;
+static int signal_pipe[2] = { -1, -1 };
+
 static void clear_socket(void)
 {
 	if (access(socket_path, F_OK) != -1)
@@ -38,18 +53,22 @@ static void cleanup_socket(void)
 }
 
 /*
- * GCC 12's C frontend parses plain [[noreturn]] but warns that it is
- * ignored, so use the GNU-namespaced spelling which both compilers honor.
+ * Async-signal-safe.  Only writes to the self-pipe and sets a flag; real
+ * cleanup happens when the main loop observes the pipe and returns.
  */
-[[gnu::noreturn]] static void term_handler([[maybe_unused]] int signum)
+static void term_handler([[maybe_unused]] int signum)
 {
-	/* cleanup_socket() runs through atexit() */
-	exit(0);
+	int saved_errno = errno;
+	ssize_t ignored = write(signal_pipe[1], "", 1);
+	(void)ignored;
+	errno = saved_errno;
+	terminate_requested = 1;
 }
 
 static void timer_handler([[maybe_unused]] union sigval sigev_value)
 {
 	pretty("config reload start");
+	pthread_mutex_lock(&state_lock);
 	parseconf(&config);
 	pretty("config reload end");
 	pretty("set_all start");
@@ -60,6 +79,7 @@ static void timer_handler([[maybe_unused]] union sigval sigev_value)
 
 	triggered = true;
 	pretty("set_all end");
+	pthread_mutex_unlock(&state_lock);
 }
 
 static void set_timer(long delay_s, long delay_ns)
@@ -71,8 +91,43 @@ static void set_timer(long delay_s, long delay_ns)
 	timer_settime(timerid, 0, &its, NULL);
 }
 
+/*
+ * Reads one fixed-size request without blocking forever when a client
+ * connects but stalls mid-transfer.  Caps the wait at a total of 5 s.
+ */
+static int recv_request(int fd, LEGIOND_REQUEST *request)
+{
+	size_t received = 0;
+	struct timespec deadline;
+	if (clock_gettime(CLOCK_MONOTONIC, &deadline) != -1)
+		deadline.tv_sec += 5;
+
+	while (received < sizeof(*request)) {
+		struct timespec now;
+		if (clock_gettime(CLOCK_MONOTONIC, &now) != -1 &&
+		    (now.tv_sec > deadline.tv_sec ||
+		     (now.tv_sec == deadline.tv_sec && now.tv_nsec > deadline.tv_nsec)))
+			return -1;
+
+		struct pollfd pfd = { .fd = fd, .events = POLLIN };
+		int ready = poll(&pfd, 1, 2000);
+		if (ready == -1 && errno == EINTR)
+			continue;
+		if (ready <= 0)
+			return -1;
+
+		ssize_t n = recv(fd, (char *)request + received,
+				 sizeof(*request) - received, 0);
+		if (n <= 0)
+			return -1;
+		received += (size_t)n;
+	}
+	return 0;
+}
+
 static void handle_command(const LEGIOND_REQUEST *request)
 {
+	pthread_mutex_lock(&state_lock);
 	switch (request->cmd) {
 	case CMD_FANSET:
 		// delayed means user use legiond-ctl fanset with a parameter
@@ -111,6 +166,7 @@ static void handle_command(const LEGIOND_REQUEST *request)
 		printf("do nothing\n");
 		break;
 	}
+	pthread_mutex_unlock(&state_lock);
 }
 
 int main(void)
@@ -174,6 +230,19 @@ int main(void)
 	// run fancurve-set on startup
 	set_timer(delay_s_default, delay_ns_default);
 
+	// self-pipe to wake the select loop from the signal handler
+	if (pipe(signal_pipe) == -1) {
+		perror("pipe");
+		return 1;
+	}
+	for (int i = 0; i < 2; i++) {
+		int flags = fcntl(signal_pipe[i], F_GETFL, 0);
+		if (flags == -1 || fcntl(signal_pipe[i], F_SETFL, flags | O_NONBLOCK) == -1) {
+			perror("fcntl");
+			return 1;
+		}
+	}
+
 	// setup SIGTERM handler
 	struct sigaction action = {
 		.sa_handler = term_handler,
@@ -196,16 +265,29 @@ int main(void)
 	}
 
 	// listen
-	while (true) {
+	while (!terminate_requested) {
 		fd_set readfds;
 		FD_ZERO(&readfds);
 		FD_SET(server_fd, &readfds);
 		FD_SET(inotify_fd, &readfds);
+		FD_SET(signal_pipe[0], &readfds);
 
 		int maxfd = max_fd(server_fd, inotify_fd);
+		maxfd = max_fd(maxfd, signal_pipe[0]);
 
-		if (select(maxfd + 1, &readfds, NULL, NULL, NULL) == -1)
-			continue;
+		if (select(maxfd + 1, &readfds, NULL, NULL, NULL) == -1) {
+			if (terminate_requested || errno == EINTR)
+				continue;
+			perror("select");
+			break;
+		}
+
+		if (FD_ISSET(signal_pipe[0], &readfds)) {
+			char discard[64];
+			while (read(signal_pipe[0], discard, sizeof(discard)) > 0) {
+			}
+			break;
+		}
 
 		if (FD_ISSET(server_fd, &readfds)) {
 			auto_fd client_fd = accept(server_fd, NULL, NULL);
@@ -213,9 +295,7 @@ int main(void)
 				continue;
 
 			LEGIOND_REQUEST request = { 0 };
-			ssize_t received = recv(client_fd, &request,
-						sizeof(request), MSG_WAITALL);
-			if (received != (ssize_t)sizeof(request)) {
+			if (recv_request(client_fd, &request) != 0) {
 				printf("ignoring malformed request\n");
 				continue;
 			}

--- a/extra/service/legiond/legiond.c
+++ b/extra/service/legiond/legiond.c
@@ -38,6 +38,13 @@ static pthread_mutex_t state_lock = PTHREAD_MUTEX_INITIALIZER;
 static volatile sig_atomic_t terminate_requested;
 static int signal_pipe[2] = { -1, -1 };
 
+/* reload config, warning visibly when the file is missing or malformed */
+static void reload_config(void)
+{
+	if (parseconf(&config) != 0)
+		fprintf(stderr, "legiond: failed to parse config, using defaults\n");
+}
+
 static void clear_socket(void)
 {
 	if (access(socket_path, F_OK) != -1)
@@ -69,7 +76,7 @@ static void timer_handler([[maybe_unused]] union sigval sigev_value)
 {
 	pretty("config reload start");
 	pthread_mutex_lock(&state_lock);
-	parseconf(&config);
+	reload_config();
 	pretty("config reload end");
 	pretty("set_all start");
 	set_all(get_powerstate(), &config);
@@ -82,13 +89,17 @@ static void timer_handler([[maybe_unused]] union sigval sigev_value)
 	pthread_mutex_unlock(&state_lock);
 }
 
-static void set_timer(long delay_s, long delay_ns)
+static int set_timer(long delay_s, long delay_ns)
 {
 	struct itimerspec its = {
 		.it_value = { .tv_sec = delay_s, .tv_nsec = delay_ns },
 		.it_interval = { 0 },
 	};
-	timer_settime(timerid, 0, &its, NULL);
+	if (timer_settime(timerid, 0, &its, NULL) == -1) {
+		perror("timer_settime");
+		return -1;
+	}
+	return 0;
 }
 
 /*
@@ -132,16 +143,22 @@ static void handle_command(const LEGIOND_REQUEST *request)
 	case CMD_FANSET:
 		// delayed means user use legiond-ctl fanset with a parameter
 		triggered = false;
-		if (delayed) {
+		if (delayed > 0) {
 			printf("extend delay\n");
-			set_timer(delayed, 0);
-		} else if (request->delay_s == 0) {
+			if (set_timer(delayed, 0) == -1)
+				delayed = 0;
+		} else if (request->delay_s <= 0) {
+			// <= 0 is an authoritative reset to the default delay
 			printf("reset timer\n");
-			set_timer(delay_s_default, delay_ns_default);
+			if (set_timer(delay_s_default, delay_ns_default) == -1)
+				delayed = 0;
 		} else {
 			printf("reset timer with delay %d s\n",
 			       request->delay_s);
-			set_timer(request->delay_s, 0);
+			if (set_timer(request->delay_s, 0) == -1) {
+				delayed = 0;
+				break;
+			}
 			delayed = request->delay_s;
 		}
 		break;
@@ -158,7 +175,7 @@ static void handle_command(const LEGIOND_REQUEST *request)
 		break;
 	case CMD_RELOAD:
 		pretty("config reload start");
-		parseconf(&config);
+		reload_config();
 		set_all(get_powerstate(), &config);
 		pretty("config reload end");
 		break;
@@ -171,10 +188,27 @@ static void handle_command(const LEGIOND_REQUEST *request)
 
 int main(void)
 {
+	// refuse to run when another instance is already listening, so we
+	// never unlink a live daemon's socket
+	struct sockaddr_un probe_addr = {
+		.sun_family = AF_UNIX,
+	};
+	if (snprintf(probe_addr.sun_path, sizeof(probe_addr.sun_path), "%s", socket_path) >=
+	    (int)sizeof(probe_addr.sun_path)) {
+		fprintf(stderr, "socket path too long\n");
+		return 1;
+	}
+	auto_fd probe_fd = socket(AF_UNIX, SOCK_STREAM, 0);
+	if (probe_fd != -1 &&
+	    connect(probe_fd, (struct sockaddr *)&probe_addr, sizeof(probe_addr)) == 0) {
+		fprintf(stderr, "another legiond instance is already running\n");
+		return 1;
+	}
+
 	// remove socket before create it
 	clear_socket();
 
-	parseconf(&config);
+	reload_config();
 
 	// calculate delay
 	delay_s_default = (long)default_delay;
@@ -228,7 +262,8 @@ int main(void)
 	}
 
 	// run fancurve-set on startup
-	set_timer(delay_s_default, delay_ns_default);
+	if (set_timer(delay_s_default, delay_ns_default) == -1)
+		return 1;
 
 	// self-pipe to wake the select loop from the signal handler
 	if (pipe(signal_pipe) == -1) {
@@ -255,8 +290,10 @@ int main(void)
 		perror("inotify_init");
 		return 1;
 	}
-	inotify_add_watch(inotify_fd, profile_path, IN_MODIFY);
-	inotify_add_watch(inotify_fd, ac_path, IN_MODIFY);
+	if (inotify_add_watch(inotify_fd, profile_path, IN_MODIFY) == -1)
+		perror("inotify_add_watch profile_path");
+	if (inotify_add_watch(inotify_fd, ac_path, IN_MODIFY) == -1)
+		perror("inotify_add_watch ac_path");
 
 	auto_free char *buffer = malloc(BUF_LEN);
 	if (buffer == NULL) {

--- a/extra/service/legiond/modules/parseconf.c
+++ b/extra/service/legiond/modules/parseconf.c
@@ -62,12 +62,22 @@ static int handler(void *user, const char *section, const char *name,
 	} else if (MATCH("cpu_control", "bat_e")) {
 		ptr_cmd = &pconfig->cpu_bat_e;
 	} else {
-		// unknown section
-		return 0;
+		/*
+		 * Returning 0 aborts the whole parse, so a single typo
+		 * would silently drop every later key.  Warn and continue.
+		 */
+		fprintf(stderr, "unknown config key [%s] %s, ignoring\n", section, name);
+		return 1;
 	}
 
-	if (ptr_cmd)
-		snprintf(*ptr_cmd, sizeof(*ptr_cmd), "%s", value);
+	if (ptr_cmd) {
+		int written = snprintf(*ptr_cmd, sizeof(*ptr_cmd), "%s", value);
+		if (written < 0 || (size_t)written >= sizeof(*ptr_cmd)) {
+			fprintf(stderr, "config value for [%s] %s too long, ignoring\n",
+				section, name);
+			(*ptr_cmd)[0] = '\0';
+		}
+	}
 
 	return 1;
 }

--- a/python/legion_linux/legion_linux/legion.py
+++ b/python/legion_linux/legion_linux/legion.py
@@ -53,7 +53,7 @@ def get_dmesg(only_tail=False, filter_log=True):
             out, _ = process.communicate(timeout=1)
             out_str = out.decode(DEFAULT_ENCODING, errors="replace")
             return out_str
-    except OSError as ex:
+    except (OSError, subprocess.SubprocessError) as ex:
         log.error(ex)
         return str(ex)
 
@@ -573,32 +573,62 @@ class PlatformProfileFeature(FileFeature):
         return value
 
 
+def _find_power_supply_dir(supply_type):
+    """Return the first power_supply entry of the given type, or None.
+
+    Legacy names (ADP0/BAT0) are only used as a fallback since the Linux
+    power_supply class names the batteries/adapters by port location.
+    """
+    for supply_dir in glob.glob("/sys/class/power_supply/*"):
+        type_file = os.path.join(supply_dir, "type")
+        if os.path.exists(type_file):
+            with open(type_file, "r", encoding=DEFAULT_ENCODING) as filepointer:
+                if filepointer.read().strip() == supply_type:
+                    return supply_dir
+    return None
+
+
 class IsOnPowerSupplyFeature(BoolFileFeature):
     def __init__(self):
-        super().__init__("/sys/class/power_supply/ADP0/online")
+        supply_dir = _find_power_supply_dir("Mains") or "/sys/class/power_supply/ADP0"
+        super().__init__(os.path.join(supply_dir, "online"))
 
     def set(self, value: str):
         raise NotImplementedError()
 
+    def get(self):
+        if not self.exists():
+            return False
+        return super().get()
+
 
 class BatteryIsCharging(BoolFileFeature):
     def __init__(self):
-        super().__init__("/sys/class/power_supply/BAT0/status")
+        supply_dir = _find_power_supply_dir("Battery") or "/sys/class/power_supply/BAT0"
+        super().__init__(os.path.join(supply_dir, "status"))
 
     def set(self, _: str):
         raise NotImplementedError()
 
     def get(self):
+        if not self.exists():
+            return False
         value = self._read_file_str(self.filename)
         return value == "Charging"
 
 
 class BatteryCurrentCapacityPercentage(FloatFileFeature):
     def __init__(self):
-        super().__init__("/sys/class/power_supply/BAT0/capacity")
+        supply_dir = _find_power_supply_dir("Battery") or "/sys/class/power_supply/BAT0"
+        super().__init__(os.path.join(supply_dir, "capacity"))
 
     def set(self, _: str):
         raise NotImplementedError()
+
+    def get(self):
+        if not self.exists():
+            return 0
+        return super().get()
 
 
 class CPUOverclock(BoolFileFeature):
@@ -834,6 +864,10 @@ class FanCurveIO(Feature):
             return matches[0] + "/"
         return None
 
+    def _require_hwmon(self):
+        if self.hwmon_path is None:
+            raise RuntimeError("hwmon dir not found: is the legion-laptop kernel module loaded?")
+
     @staticmethod
     def _validate_point_id(point_id):
         if point_id < 1 or point_id > 10:
@@ -870,8 +904,10 @@ class FanCurveIO(Feature):
         return int(self._read_file(file_path))
 
     def get_auto_points_size(self):
+        if self.hwmon_path is None:
+            return None
         file_path = self.hwmon_path + self.auto_points_size
-        if self.hwmon_path is None or not os.path.exists(file_path):
+        if not os.path.exists(file_path):
             return None
         return self._read_file(file_path)
 
@@ -886,10 +922,18 @@ class FanCurveIO(Feature):
         self._write_file(file_path, value)
 
     def set_fan_1_speed_rpm(self, point_id, value):
-        return self.set_fan_1_speed_pwm(point_id, int(value // 100 * (100 * 255) / self.get_fan_1_max_rpm()))
+        max_rpm = self.get_fan_1_max_rpm()
+        if max_rpm == 0:
+            raise ValueError("fan1_max is 0, cannot convert rpm to pwm")
+        pwm = max(0, min(255, int(value // 100 * (100 * 255) / max_rpm)))
+        return self.set_fan_1_speed_pwm(point_id, pwm)
 
     def set_fan_2_speed_rpm(self, point_id, value):
-        return self.set_fan_2_speed_pwm(point_id, int(value // 100 * (100 * 255) / self.get_fan_2_max_rpm()))
+        max_rpm = self.get_fan_2_max_rpm()
+        if max_rpm == 0:
+            raise ValueError("fan2_max is 0, cannot convert rpm to pwm")
+        pwm = max(0, min(255, int(value // 100 * (100 * 255) / max_rpm)))
+        return self.set_fan_2_speed_pwm(point_id, pwm)
 
     def set_lower_cpu_temperature(self, point_id, value):
         point_id = self._validate_point_id(point_id)
@@ -993,12 +1037,14 @@ class FanCurveIO(Feature):
         return self.exists() and self.hwmon_path is not None and os.path.exists(self.hwmon_path + self.minifancurve)
 
     def set_minifancuve(self, value):
+        self._require_hwmon()
         log.info("Setting minifancurve to: %s", str(value))
         file_path = self.hwmon_path + self.minifancurve
         outvalue = 1 if value else 0
         return self._write_file_or(file_path, outvalue)
 
     def get_minifancuve(self):
+        self._require_hwmon()
         file_path = self.hwmon_path + self.minifancurve
         invalue = self._read_file_or(file_path, False)
         return invalue != 0
@@ -1009,6 +1055,7 @@ class FanCurveIO(Feature):
 
     def write_fan_curve(self, fan_curve: FanCurve, _=False):
         """Writes a fan curve object to the file system and sets minifancurve if enabled"""
+        self._require_hwmon()
         entries = list(fan_curve.entries)
         while entries and entries[-1].is_empty():
             entries.pop()
@@ -1053,6 +1100,7 @@ class FanCurveIO(Feature):
 
     def read_fan_curve(self) -> FanCurve:
         """Reads a fan curve object from the file system"""
+        self._require_hwmon()
         entries = []
         has_fan_2_speed = self.has_fan_2_speed()
         has_temperature_curve = self.has_temperature_curve()
@@ -1170,10 +1218,14 @@ class SettingsManager(Feature):
 
     def apply_settings(self, preset: Settings):
         for name, value in preset.setting_entries.items():
-            log.error("Try setting %s from preset to %s", name, value)
-            has_set = Feature.set_feature_to_value(name, value)
-            if not has_set:
-                log.error("Cannot set %s from preset to %s", name, value)
+            try:
+                log.info("Try setting %s from preset to %s", name, value)
+                has_set = Feature.set_feature_to_value(name, value)
+                if not has_set:
+                    log.error("Cannot set %s from preset to %s", name, value)
+            # pylint: disable=broad-except
+            except Exception as err:
+                log.error("Failed to set %s from preset to %s: %s", name, value, err)
 
     def _name_to_filename(self, name):
         return os.path.join(self.preset_dir, name + ".yaml")
@@ -1776,13 +1828,18 @@ class LegionModelFacade:
         return self.battery_custom_conservation_controller.run()
 
     def load_settings(self):
-        if self.settings_manager.does_exists_by_name("settings"):
-            log.info("Settings file exists and will be loaded.")
+        if not self.settings_manager.does_exists_by_name("settings"):
+            log.info("Settings file does not exist.")
+            return
+        log.info("Settings file exists and will be loaded.")
+        try:
             settings = self.settings_manager.load_by_name("settings")
             log.info("Loaded settings:\n %s", settings.to_yaml())
-            self.settings_manager.apply_settings(settings)
-        else:
-            log.info("Settings file does not exist.")
+        # pylint: disable=broad-except
+        except Exception as err:
+            log.error("Failed to load settings file: %s", err)
+            return
+        self.settings_manager.apply_settings(settings)
 
     def save_settings(self):
         log.info("Saving settings...")

--- a/python/legion_linux/legion_linux/legion.py
+++ b/python/legion_linux/legion_linux/legion.py
@@ -163,6 +163,9 @@ def write_file_with_legion_cli(name, values):
             err_str = stderr.decode(DEFAULT_ENCODING, errors="replace")
             returncode = process.returncode
             log.info("FileFeature %s executed with code %d: %s; %s", name, returncode, out_str, err_str)
+        if returncode != 0:
+            log.error("FileFeature %s failed with code %d: %s; %s", name, returncode, out_str, err_str)
+            raise RuntimeError(f"legion_cli failed for {name} with code {returncode}: {err_str}")
     except IOError as err:
         log.error("FileFeature %s executed with error %s and out %s and err %s", name, str(err), out_str, err_str)
         log.error(get_dmesg(only_tail=True, filter_log=False))
@@ -371,8 +374,8 @@ class LegionGUIAutostart(BoolFileFeature):
 
     def __init__(self):
         self.autostart_dekstop_folder_path = Path.home() / ".config" / "autostart"
-        self.desktop_file_path = Path("/usr/share/applications") / "legion_gui_user.desktop"
-        self.autostart_desktop_file_path = self.autostart_dekstop_folder_path / "legion_gui_user.desktop"
+        self.desktop_file_path = Path("/usr/share/applications") / "legion_gui.desktop"
+        self.autostart_desktop_file_path = self.autostart_dekstop_folder_path / "legion_gui.desktop"
         super().__init__(str(Path.home() / ".config"))
 
     def exists(self):

--- a/python/legion_linux/legion_linux/legion_cli.py
+++ b/python/legion_linux/legion_linux/legion_cli.py
@@ -520,4 +520,16 @@ def main():
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    try:
+        sys.exit(main())
+    except FileNotFoundError as err:
+        log.error(str(err))
+        print(
+            "Error: The kernel module is not loaded or the hwmon directory was not found. "
+            "Are you sure 'legion-laptop' is loaded? Use '--donotexpecthwmon' to proceed without hwmon access.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    except RuntimeError as err:
+        log.error(str(err))
+        sys.exit(err.args[0] if err.args else 1)

--- a/python/legion_linux/legion_linux/legion_cli.py
+++ b/python/legion_linux/legion_linux/legion_cli.py
@@ -7,8 +7,8 @@ import logging
 import sys
 import os
 
-# Make it possible to run without installationimport
-# pylint: disable=# pylint: disable=wrong-import-position
+# Make it possible to run without installation
+# pylint: disable=wrong-import-position
 sys.path.insert(0, os.path.dirname(__file__) + "/..")
 import legion_linux.legion
 from legion_linux.legion import LegionModelFacade
@@ -532,4 +532,8 @@ if __name__ == "__main__":
         sys.exit(1)
     except RuntimeError as err:
         log.error(str(err))
-        sys.exit(err.args[0] if err.args else 1)
+        sys.exit(1)
+    except (OSError, KeyError, TypeError, ValueError) as err:
+        log.error(str(err))
+        print(f"Error: {err}", file=sys.stderr)
+        sys.exit(1)

--- a/python/legion_linux/legion_linux/legion_gui.py
+++ b/python/legion_linux/legion_linux/legion_gui.py
@@ -4,6 +4,7 @@
 import sys
 import os
 import os.path
+import glob
 import traceback
 import logging
 import random
@@ -121,14 +122,18 @@ class MonitorWorker(QRunnable):
                 # pylint: disable=broad-except
                 except Exception as err:
                     log.error(str(err))
-            for msg in diag_msgs:
-                if msg.has_value and msg.filter_do_output:
-                    log.info(str(msg.msg))
-                    self.notification_sender.notify("Legion", msg.msg)
-                elif msg.has_value:
-                    log.info("FILTERED: %s", msg.msg)
-                else:
-                    log.info("FILTERED2: %s", msg.msg)
+            try:
+                for msg in diag_msgs:
+                    if msg.has_value and msg.filter_do_output:
+                        log.info(str(msg.msg))
+                        self.notification_sender.notify("Legion", msg.msg)
+                    elif msg.has_value:
+                        log.info("FILTERED: %s", msg.msg)
+                    else:
+                        log.info("FILTERED2: %s", msg.msg)
+            # pylint: disable=broad-except
+            except Exception as err:
+                log.error("Error while sending notification: %s", str(err))
             time.sleep(10.0)
 
         log.info("Finishing monitoring thread")
@@ -392,6 +397,11 @@ class PresetTrayController:
             def callback(_, pname=name):
                 self.on_action_click(pname)
 
+            try:
+                action.triggered.disconnect()
+            # pylint: disable=broad-except
+            except Exception:
+                pass
             action.triggered.connect(callback)
 
     def on_action_click(self, name):
@@ -1052,11 +1062,14 @@ class FanCurveTab(QWidget):
         has_acceleration_curve: bool,
     ):
         self.minfancurve_check.setDisabled(not has_minifancurve)
+        empty_entry = FanCurveEntry(0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+        for entry_view in self.entry_edits:
+            entry_view.set(empty_entry)
+            entry_view.set_disabled(not enabled, has_fan_2_speed, has_temperature_curve, has_acceleration_curve)
         for i, entry in enumerate(fancurve.entries):
+            if i >= len(self.entry_edits):
+                break
             self.entry_edits[i].set(entry)
-            self.entry_edits[i].set_disabled(
-                not enabled, has_fan_2_speed, has_temperature_curve, has_acceleration_curve
-            )
         self.load_button.setDisabled(not enabled)
         self.write_button.setDisabled(not enabled)
 
@@ -1709,10 +1722,8 @@ def main():
     app = QApplication(sys.argv)
 
     use_legion_cli_to_write = "--use_legion_cli_to_write" in sys.argv
-    do_not_excpect_hwmon = True
-    controller = LegionController(
-        app, expect_hwmon=not do_not_excpect_hwmon, use_legion_cli_to_write=use_legion_cli_to_write
-    )
+    expect_hwmon = bool(glob.glob(legion_linux.legion.FanCurveIO.hwmon_dir_pattern))
+    controller = LegionController(app, expect_hwmon=expect_hwmon, use_legion_cli_to_write=use_legion_cli_to_write)
 
     # Load savable settings from file if exists
     controller.model.load_settings()
@@ -1748,7 +1759,7 @@ def main():
 
     # Main Windows
     main_window = MainWindow(controller, icon)
-    controller.init(read_from_hw=not do_not_excpect_hwmon)
+    controller.init(read_from_hw=expect_hwmon)
 
     # Tray
     tray = LegionTray(icon, main_window, controller)

--- a/python/legion_linux/legion_linux/legion_gui.py
+++ b/python/legion_linux/legion_linux/legion_gui.py
@@ -37,7 +37,7 @@ from PyQt6.QtWidgets import (
 )
 
 # Make it possible to run without installation
-# pylint: disable=# pylint: disable=wrong-import-position
+# pylint: disable=wrong-import-position
 sys.path.insert(0, os.path.dirname(__file__) + "/..")
 import legion_linux.legion
 from legion_linux.legion import (
@@ -1760,6 +1760,11 @@ def main():
     # Main Windows
     main_window = MainWindow(controller, icon)
     controller.init(read_from_hw=expect_hwmon)
+
+    # Monitoring callback is registered in init(), which runs after
+    # load_settings(), so start the worker now if the setting is enabled
+    if controller.model.app_model.enable_gui_monitoring.get():
+        controller.start_monitoring()
 
     # Tray
     tray = LegionTray(icon, main_window, controller)


### PR DESCRIPTION
## Summary

Fixes found by static analysis of the Python package (`legion.py`, `legion_cli.py`, `legion_gui.py`) and the `legiond` C daemon. Zero-warning build for both compilers (gcc, clang), pylint stays at 10.00/10.

## legiond (`extra/service/legiond/`)

High-severity:
- **Data race on shared state (UB)**: `config`, `delayed`, `triggered` were read/written from both the `SIGEV_THREAD` timer thread (`timer_handler`) and the main loop (`handle_command`). Added a `pthread_mutex_t` around all access. The same lock also serializes the hardware writes from `set_all` (timer thread) and `set_cpu` (socket command), which previously could run concurrently on the EC.
- **Blocking `recv(MSG_WAITALL)`**: a client that connects and stalls mid-transfer froze the whole daemon. Replaced with `recv_request()` using `poll()` with a 2 s per-iteration timeout and a 5 s total cap.
- **`exit()` from a signal handler** is not async-signal-safe. `term_handler` now only writes to a self-pipe and sets `volatile sig_atomic_t`; the main `select()` loop observes the pipe and returns, so the `atexit()` socket cleanup still runs.

Medium/low:
- **`fanset -5` wedged the daemon**: negative delay made `delayed` truthy so every later `fanset` took the "extend delay" branch. `legiond-ctl` now rejects `delay < 0`; `handle_command` treats `delay_s <= 0` as an authoritative reset and no longer trusts a stale/negative `delayed`; `timer_settime()` errors are checked everywhere.
- **One typo in `legiond.ini` silently dropped the rest of the config**: the libinih handler returned `0` (aborts the parse) on unknown keys. Now it warns and continues; `parseconf()` failures are reported at all three call sites via `reload_config()`; over-long config values are rejected instead of being truncated and then executed via `system()`.
- **`inotify_add_watch()` failures were silent**: missing `platform_profile`/AC files now produce a `perror`, and `get_powerstate()` doesn't wait on a dead watcher.
- **Second daemon instance**: a live socket is probed with `connect()` before unlinking, so a second `legiond` no longer removes the first instance's socket.

## Python package

High-severity:
- **`write_file_with_legion_cli` silently "succeeded" on failure** (pkexec cancelled policy, missing hwmon): non-zero return code now logs and raises `RuntimeError` (`legion.py`).
- **CLI crashed with a traceback when the kernel module was not loaded**: `legion_cli.py` now exits gracefully with a helpful message (`--donotexpecthwmon` hint).
- **GUI never read the live fan curve** (`do_not_expect_hwmon` was hardcoded `True`): now detected at runtime via the hwmon glob (`legion_gui.py`).
- **FanCurveTab stale cell values**: when a curve has fewer than 10 entries, the unused cells were left with stale values that got written back to the EC; now reset to empty first (`legion_gui.py`).
- **MonitorWorker thread died silently**: notification errors now caught and logged instead of killing the thread.
- **PresetTrayController duplicate signal connections**: disconnect before reconnecting.
- **Autostart feature permanently disabled**: referenced `legion_gui_user.desktop`, but the packaged file is `legion_gui.desktop` (see `setup.cfg`) — fixed (`legion.py`).

Medium/low:
- **Hardcoded `ADP0`/`BAT0`**: power-supply detection now scans `/sys/class/power_supply/*/type` ("Mains"/"Battery") with the legacy names as fallback; `get()` on the AC/battery features returns a sane default instead of raising when the file is absent.
- **CLI still tracebacked** on sysfs `IOError`/`KeyError`/`TypeError`: `__main__` now catches them and exits non-zero with a one-line message.
- **`FanCurveIO` `TypeError` when hwmon is missing**: `_require_hwmon()` guard on read/write fancurve and minifancurve; `get_auto_points_size()` no longer builds the path before the `None` check.
- **RPM→PWM conversion exceeded 255** when the requested RPM is above the fan max, failing the sysfs write: now clamped to [0, 255].
- **Corrupt/empty `settings.yaml` crashed the GUI at startup**: `load_settings()` wraps the load and each applied entry in try/except, skipping bad entries.
- **Successful settings writes were logged at `error` level**: now `info`.
- **`get_dmesg()` `TimeoutExpired`** (a `SubprocessError`, not `OSError`) escaped the error handlers: caught now.
- **Saved "enable monitoring" setting never started the worker** (callback registered after `load_settings()`): `main()` now starts it after `controller.init()`.
- Fixed corrupted `# pylint: disable=# pylint: disable=...` comments.

## Verification

- `make` (gcc) and `make CC=clang` in `extra/service/legiond` — zero warnings with `-Wall -Wextra`.
- `./tests/test_python.sh` — pylint 10.00/10.
- `./tests/test_python_cli.sh` — passes.
- `black python/legion_linux` — clean.