### PR TITLE
fix(kernel-module): hide EC4-unsupported fancurve accel/decel attributes

### DIFF
--- a/kernel_module/legion-laptop.c
+++ b/kernel_module/legion-laptop.c
@@ -8112,6 +8112,36 @@ static bool legion_wmi_fancurve_speed_attribute(const struct attribute *attr)
 	       attr == &sensor_dev_attr_pwm1_auto_point10_pwm.dev_attr.attr;
 }
 
+// The EC4 fancurve interface (e.g. Legion 5 16IRX9, 83DG) stores per point
+// only the CPU/GPU max temperature thresholds and the fan speeds. The
+// acceleration/deceleration values have no EC registers: reads always return
+// 0 and writes are rejected, which breaks userspace that probes the
+// attributes to detect support. Hide them for those models.
+static bool
+legion_ec4_fancurve_unsupported_attribute(const struct attribute *attr)
+{
+	return attr == &sensor_dev_attr_pwm1_auto_point1_accel.dev_attr.attr ||
+	       attr == &sensor_dev_attr_pwm1_auto_point2_accel.dev_attr.attr ||
+	       attr == &sensor_dev_attr_pwm1_auto_point3_accel.dev_attr.attr ||
+	       attr == &sensor_dev_attr_pwm1_auto_point4_accel.dev_attr.attr ||
+	       attr == &sensor_dev_attr_pwm1_auto_point5_accel.dev_attr.attr ||
+	       attr == &sensor_dev_attr_pwm1_auto_point6_accel.dev_attr.attr ||
+	       attr == &sensor_dev_attr_pwm1_auto_point7_accel.dev_attr.attr ||
+	       attr == &sensor_dev_attr_pwm1_auto_point8_accel.dev_attr.attr ||
+	       attr == &sensor_dev_attr_pwm1_auto_point9_accel.dev_attr.attr ||
+	       attr == &sensor_dev_attr_pwm1_auto_point10_accel.dev_attr.attr ||
+	       attr == &sensor_dev_attr_pwm1_auto_point1_decel.dev_attr.attr ||
+	       attr == &sensor_dev_attr_pwm1_auto_point2_decel.dev_attr.attr ||
+	       attr == &sensor_dev_attr_pwm1_auto_point3_decel.dev_attr.attr ||
+	       attr == &sensor_dev_attr_pwm1_auto_point4_decel.dev_attr.attr ||
+	       attr == &sensor_dev_attr_pwm1_auto_point5_decel.dev_attr.attr ||
+	       attr == &sensor_dev_attr_pwm1_auto_point6_decel.dev_attr.attr ||
+	       attr == &sensor_dev_attr_pwm1_auto_point7_decel.dev_attr.attr ||
+	       attr == &sensor_dev_attr_pwm1_auto_point8_decel.dev_attr.attr ||
+	       attr == &sensor_dev_attr_pwm1_auto_point9_decel.dev_attr.attr ||
+	       attr == &sensor_dev_attr_pwm1_auto_point10_decel.dev_attr.attr;
+}
+
 static umode_t legion_hwmon_sensor_is_visible(struct kobject *kobj,
 					      struct attribute *attr, int idx)
 {
@@ -8141,6 +8171,9 @@ static umode_t legion_hwmon_fancurve_is_visible(struct kobject *kobj,
 
 	if (priv->conf->wmi_fancurve_speed_only &&
 	    !legion_wmi_fancurve_speed_attribute(attr))
+		return 0;
+	if (priv->conf->access_method_fancurve == ACCESS_METHOD_EC4 &&
+	    legion_ec4_fancurve_unsupported_attribute(attr))
 		return 0;
 	if (attr == &sensor_dev_attr_minifancurve.dev_attr.attr)
 		supported = priv->conf->has_minifancurve;


### PR DESCRIPTION
## Problem

   On models using the EC4 fan curve interface (e.g. Legion 5 16IRX9 / 83DG,
   BIOS NMCN*, added in #399), every fan curve write from userspace fails and
   crashes the GUI:

   1. The EC4 layout stores per point only `[CPU max temp, GPU max temp,
      speed1]` (registers `0xC50A` / `0xC531`, stride 3). There are **no EC
      registers for acceleration/deceleration**.
   2. The hwmon attributes `pwm1_auto_point{1-10}_{accel,decel}` were still
      advertised as writable, so `python/legion_linux` (which probes attribute
      existence via `_has_point_file` to detect support) always wrote back the
      accel/decel values of **0** it had just read from the EC.
   3. The kernel validates `2 <= accel/decel <= 5` and rejects the write with
      `-EOPNOTSUPP` (userspace sees `OSError: [Errno 95] Operation not
      supported`), aborting the whole fan curve write. In the GUI this surfaces
      as an unhandled RuntimeError → Qt abort (coredump).

   Related reports of the same errno on other models: #236, #265.

   ## Fix

   Hide the accel/decel hwmon attributes for models with
   `access_method_fancurve == ACCESS_METHOD_EC4`, mirroring the existing
   `wmi_fancurve_speed_only` / `legion_wmi_fancurve_speed_attribute()`
   filtering. The temperature-threshold and fan-speed attributes are kept —
   they are fully functional on EC4 models.

   ## Notes / open questions

   - **Scope**: per-point CPU/GPU *max* temps are stored by EC4 and kept
     writable. The *min* (hysteresis) and IC temp attributes write fine but are
     not persisted by the EC4 layout (no-ops). I left them exposed to keep this
     fix minimal — hiding them could be a follow-up if maintainers prefer.
   - **User-visible change**: 20 sysfs files are no longer created for EC4
     models. They never returned usable data (constant 0) and never accepted a
     write, so no working flow depends on them.
   - Userspace needs no changes: the python library skips accel/decel
     automatically once the attributes are absent.

   ## Testing

   On Legion 5 16IRX9 (83DG, BIOS NMCN34WW), CachyOS (clang-built kernel,
   built with `make LLVM=1`):

   - [x] `make LLVM=1` builds clean; module reloads (`make reloadmodule`)
   - [x] `ls /sys/class/hwmon/hwmon*/` no longer contains `*_accel` /
         `*_decel` fancurve files; temperature/speed attributes present
   - [x] `legion_cli fancurve-write-preset-to-hw extreme-ac` succeeds
         (previously failed at the first accel write)
   - [x] legion_gui "Apply to HW" writes the curve and no longer crashes
   - [x] checkpatch clean (CI)

   Closes the fan-curve part of the 83DG support follow-ups (#344, #413).