### PR TITLE
fix(kernel-module): fix 5 static-analysis findings in legion-laptop.c

### DIFF
--- a/kernel_module/legion-laptop.c
+++ b/kernel_module/legion-laptop.c
@@ -5438,7 +5438,10 @@ static int debugfs_fancurve_show(struct seq_file *s, void *unused)
 	seq_puts(s, "Current fan curve in hardware (WMI; might be empty)\n");
 	wmi_fancurve.size = 0;
 	err = wmi_read_fancurve_custom(priv->conf, &wmi_fancurve);
-	fancurve_print_seqfile(&wmi_fancurve, s);
+	if (err)
+		seq_printf(s, "WMI fancurve error: %d\n", err);
+	else
+		fancurve_print_seqfile(&wmi_fancurve, s);
 	seq_puts(s, "=====================\n");
 	return 0;
 }
@@ -7391,11 +7394,13 @@ static ssize_t sensor_show(struct device *dev, struct device_attribute *devattr,
 	switch (sensor_id) {
 	case SENSOR_CPU_TEMP_ID:
 		err = read_temperature(priv, 0, &outval);
-		outval *= 1000;
+		if (!err)
+			outval *= 1000;
 		break;
 	case SENSOR_GPU_TEMP_ID:
 		err = read_temperature(priv, 1, &outval);
-		outval *= 1000;
+		if (!err)
+			outval *= 1000;
 		break;
 	case SENSOR_IC_TEMP_ID:
 		ec_read_sensor_values(&priv->ecram, priv->conf, &values);
@@ -7474,7 +7479,7 @@ static struct attribute *sensor_hwmon_attributes[] = {
 static ssize_t fan_max_show(struct device *dev,
 			    struct device_attribute *devattr, char *buf)
 {
-	return sprintf(buf, "%d\n", MAX_RPM);
+	return sysfs_emit(buf, "%d\n", MAX_RPM);
 }
 
 static ssize_t autopoint_show(struct device *dev,
@@ -7943,12 +7948,11 @@ static ssize_t minifancurve_show(struct device *dev,
 	mutex_lock(&priv->fancurve_mutex);
 	err = ec_read_minifancurve(&priv->ecram, priv->conf, &value);
 	if (err) {
-		err = -EIO;
 		pr_info("Failed to read minifancurve\n");
 		goto error_unlock;
 	}
 	mutex_unlock(&priv->fancurve_mutex);
-	return sprintf(buf, "%d\n", value);
+	return sysfs_emit(buf, "%d\n", value);
 
 error_unlock:
 	mutex_unlock(&priv->fancurve_mutex);
@@ -8240,7 +8244,6 @@ static int acpi_init(struct legion_private *priv, struct acpi_device *adev)
 	struct device *dev = &priv->platform_device->dev;
 	const char *acpi_path;
 
-	acpi_path = get_model_acpi_path(_model, ACPI_PATH_WRITE_RAPIDCHARGE);
 	priv->adev = adev;
 	if (!priv->adev)
 		dev_info(dev, "No ACPI handle, will use FQN paths\n");


### PR DESCRIPTION
## Summary

Fixes 5 findings in `kernel_module/legion-laptop.c` found with the clang static analyzer and a review of the sysfs/debugfs show paths. All are non-behavioral cleanups or error-path fixes — identical output on success paths. The hardware-affecting findings (e.g. `toggle_powermode` ignoring the read error) are intentionally left out and will be reported separately for maintainer input.

## Changes

- **`sensor_show`: avoid multiplying an uninitialized value on the error path** (`legion-laptop.c:7396-7401`)
  `outval *= 1000` ran even when `read_temperature()` failed, multiplying stack garbage (UB). Now it only scales when the read succeeded. The subsequent `if (err) return err;` already discarded the bad value, so user-visible behavior is unchanged — this just removes the UB.

- **`debugfs_fancurve_show`: check `wmi_read_fancurve_custom()` error** (`legion-laptop.c:5440`)
  The previous code stored `err` but never checked it; on failure it printed a possibly-partial fan curve as if valid. On error it now prints the error line instead. Debug output only.

- **`fan_max_show` / `minifancurve_show`: use `sysfs_emit()` instead of `sprintf()`** (`7477`, `7951`)
  Same class as the previous `sprintf()` → `sysfs_emit()` fixes; these two were missed. Success-path output identical.

- **`minifancurve_show`: drop dead store** (`7946`)
  `err = -EIO;` was immediately superseded by `return -EIO;` and never read.

- **`acpi_init`: drop dead store** (`8243`)
  `acpi_path = get_model_acpi_path(_model, ACPI_PATH_WRITE_RAPIDCHARGE);` was always overwritten (when the `_STA` check runs) or never used (when skipped) before the first read.

## Verification

- Build: `make CC=clang LD=ld.lld LLVM=1` — clean, 0 warnings.
- Lint: `tests/test_kernel_checkpath.sh` (the CI gate) — **0 errors, 0 warnings**.