### PR TITLE
fix(kernel-module): skip powermode toggle on read failure

### DIFF
--- a/kernel_module/legion-laptop.c
+++ b/kernel_module/legion-laptop.c
@@ -5041,8 +5041,13 @@ static void toggle_powermode(struct legion_private *priv)
 {
 	int old_powermode;
 	int next_powermode;
+	int err;
 
-	read_powermode(priv, &old_powermode);
+	err = read_powermode(priv, &old_powermode);
+	if (err) {
+		pr_info("Failed to read powermode, skipping toggle: %d\n", err);
+		return;
+	}
 	next_powermode = old_powermode == 0 ? 1 : 0;
 
 	write_powermode(priv, next_powermode);


### PR DESCRIPTION
## Summary

`toggle_powermode()` is called from the module removal path to force the EC to reload its default fan settings. It ignored the return value of `read_powermode()`; when the read failed, `old_powermode` held an uninitialized value and the computed `next_powermode` was then written to the EC/WMI.

## Change

If `read_powermode()` fails, the toggle is skipped with a log message instead of writing a bogus mode to the embedded controller. On the normal path (read succeeds) the behavior is unchanged.

```c
err = read_powermode(priv, &old_powermode);
if (err) {
    pr_info("Failed to read powermode, skipping toggle: %d\n", err);
    return;
}
```
## Verification

- Build: `make CC=clang LD=ld.lld LLVM=1` — clean, 0 warnings.
- Lint gate: `tests/test_kernel_checkpath.sh` — **0 errors, 0 warnings**.
- Hardware testing (toggle-on-unload on real Legion hardware) is encouraged; the change is limited to the read-failure path so normal unloads are unaffected.