### PR TITLE
fix(python): harden boot logo backup against /tmp symlink attack

### DIFF
--- a/python/legion_linux/legion_linux/legion.py
+++ b/python/legion_linux/legion_linux/legion.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import logging
 import subprocess
 import struct
+import tempfile
 import zlib
 from datetime import datetime
 import yaml
@@ -1660,10 +1661,13 @@ class LegionModelFacade:
 
     def _backup_file(self, file_path, timestamp):
         base_name = os.path.basename(file_path)
-        tmp_path = os.path.join("/tmp", base_name)
+
+        tmp_fd, tmp_path = tempfile.mkstemp(prefix=f"{base_name}_", suffix=".tmp")
+        os.close(tmp_fd)
         shutil.copy(file_path, tmp_path)
 
-        backup_path = os.path.join("/tmp", f"{base_name}_{timestamp}.bak")
+        backup_fd, backup_path = tempfile.mkstemp(prefix=f"{base_name}_{timestamp}_", suffix=".bak")
+        os.close(backup_fd)
         shutil.copy(file_path, backup_path)
         log.info("Backup of %s created: %s", base_name, backup_path)
         return tmp_path, backup_path


### PR DESCRIPTION
## Summary

`LegionModelFacade._backup_file()` copied EFI boot-logo variables to the **predictable** paths `/tmp/<basename>` and `/tmp/<basename>_<timestamp>.bak`. The boot-logo flow runs as root (it needs `chattr`/`cp` on `/sys/firmware/efi/efivars/`), so a local attacker could pre-create a symlink at one of those paths pointing at any root-writable file. `shutil.copy()` follows symlinks, so the EFI variable content would be written over the attacker's target — an arbitrary root file overwrite primitive.

## Change

Create the two temp files with `tempfile.mkstemp()` instead:
- random, unpredictable filename
- created with `O_EXCL` (no symlink can pre-exist at the chosen name)
- mode `0600`, owned by the caller

```python
tmp_fd, tmp_path = tempfile.mkstemp(prefix=f"{base_name}_", suffix=".tmp")
os.close(tmp_fd)
shutil.copy(file_path, tmp_path)

backup_fd, backup_path = tempfile.mkstemp(prefix=f"{base_name}_{timestamp}_", suffix=".bak")
os.close(backup_fd)
shutil.copy(file_path, backup_path)
```

The returned paths are still used identically by `enable_boot_logo()` / `restore_boot_logo()`; the filenames are just no longer attacker-guessable.

## Verification

Regression test simulating the attack (attacker pre-plants symlinks at the old predictable `/tmp/<basename>` paths → victim file):

| Code | Victim file result |
|---|---|
| old `_backup_file` | **overwritten** (vulnerable confirmed) |
| new `_backup_file` | untouched, temp files are regular files |

- `python3 -m py_compile`: OK
- lines within 120-col pylintrc limit
- `tests/test_python_cli.sh`: PASS (pylint/black not installed in this environment — CI gate should still be run on the PR)