### PR TITLE
fix(kernel-module): avoid uninitialized value in WMI bool read and debug dump

### DIFF
--- a/kernel_module/legion-laptop.c
+++ b/kernel_module/legion-laptop.c
@@ -3641,10 +3641,11 @@ static int get_simple_wmi_attribute_bool(struct legion_private *priv,
 					 u32 method_id, bool invert,
 					 unsigned long scale, bool *value)
 {
-	unsigned long int_val = *value;
+	unsigned long int_val = 0;
 	int err = get_simple_wmi_attribute(priv, guid, instance, method_id,
 					   invert, scale, &int_val);
-	*value = int_val;
+	if (!err)
+		*value = int_val;
 	return err;
 }
 
@@ -5289,7 +5290,8 @@ static void seq_file_print_with_error(struct seq_file *s, const char *name,
 				      ssize_t err, int value)
 {
 	seq_printf(s, "%s error: %ld\n", name, err);
-	seq_printf(s, "%s: %d\n", name, value);
+	if (!err)
+		seq_printf(s, "%s: %d\n", name, value);
 }
 
 static int debugfs_fancurve_show(struct seq_file *s, void *unused)


### PR DESCRIPTION
## Summary

Two more clang static-analyzer findings from the continuing audit, both error-path only — success outputs are byte-identical.

## Changes

### 1. `get_simple_wmi_attribute_bool()` — no garbage write-through on failure

```c
unsigned long int_val = *value;      // read uninitialized caller var
int err = get_simple_wmi_attribute(...);
*value = int_val;                    // write it back even on failure
```

`int_val` was initialized from `*value` (uninitialized at the call site) and then written back into `*value` regardless of the WMI read result. On failure the caller's output variable was clobbered with that garbage.

```c
unsigned long int_val = 0;
int err = get_simple_wmi_attribute(...);
if (!err)
    *value = int_val;
return err;
```

### 2. `seq_file_print_with_error()` — no uninitialized value in debug dump

`debugfs_fancurve_show()` prints many sensor/fan/powermode lines via this helper. When a read failed, it still printed the value line — emitting an uninitialized stack word into `/sys/kernel/debug/legion/fancurve`.

```c
seq_printf(s, "%s error: %ld\n", name, err);   // always
if (!err)
    seq_printf(s, "%s: %d\n", name, value);    // only on success
```

Provided by the same `mutex_lock(&priv->fancurve_mutex)` dump, this is debug output only; lockfancontroller/minifancurve lines already used this "error or value" pattern.

## Verification

- Build: `make CC=clang LD=ld.lld LLVM=1` — clean, 0 warnings.
- Lint gate: `tests/test_kernel_checkpath.sh` — **0 errors, 0 warnings**.