### PR TITLE
feat(python): support native Lenovo CPU power interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -518,6 +518,12 @@ psensor
 
 ### Changing and Setting your own Fan Curve with the Python GUI
 
+When the Legion platform profile provider is disabled, the GUI uses
+`/sys/firmware/acpi/platform_profile` if available. CPU sustained and short-term
+power limits use the native Lenovo firmware-attributes interface when present,
+with the firmware-provided bounds. Changes require Custom Mode. The existing
+Legion interfaces remain the fallback when the native CPU attributes are absent.
+
 Start the GUI as root
 
 ```bash

--- a/README_zh-hans.md
+++ b/README_zh-hans.md
@@ -530,6 +530,11 @@ psensor
 
 ### 使用 Python GUI 更改和设置自定义风扇曲线
 
+禁用 Legion 平台配置提供程序时，GUI 会使用系统的
+`/sys/firmware/acpi/platform_profile` 接口（如果存在）。CPU 持续和短期功耗限制
+优先使用 Lenovo 原生固件属性接口及其允许范围。修改这些原生功耗限制需要
+先选择“Custom Mode”。原生 CPU 属性不存在时，仍使用现有 Legion 接口。
+
 以 root 身份启动 GUI
 
 ```bash

--- a/doc/FEATURES_AND_TESTING.md
+++ b/doc/FEATURES_AND_TESTING.md
@@ -1,5 +1,19 @@
 ## Features and Testing
 
+## Native Lenovo power interfaces
+
+With `legion_laptop enable_platformprofile=0` and a registered native profile
+provider, verify that the GUI lists the choices from
+`/sys/firmware/acpi/platform_profile_choices`. Verify that CPU long/short-term
+readings match `ppt_pl1_spl/current_value` and `ppt_pl2_sppt/current_value` under
+`/sys/class/firmware-attributes/lenovo-wmi-other-*/attributes/`.
+
+Changes to native CPU limits require Custom Mode and must respect `min_value`,
+`max_value` and `scalar_increment`. Applying an unchanged value must skip the
+write. The CLI `set-feature` path must enforce the same checks. Test those paths
+without hardware writes using `QT_QPA_PLATFORM=offscreen python -m unittest
+discover -s tests -p test_native_power.py`.
+
 ## External HDMI
 Usually attached to dGPU. So easiest way to make it work is enabling dGPU only in BIOS/UEFI. More advanced would
 be switching in hybrid mode to dGPU only as long as HDMI is attached or outputting via dGPU.

--- a/python/legion_linux/legion_linux/legion.py
+++ b/python/legion_linux/legion_linux/legion.py
@@ -547,8 +547,18 @@ class MaximumFanSpeedFeature(BoolFileFeature):
 
 class PlatformProfileFeature(FileFeature):
     def __init__(self):
-        super().__init__(LEGION_SYS_BASEPATH + "/platform-profile/platform-profile-[0-9]/profile")
-        self.choices = StrFileFeature(LEGION_SYS_BASEPATH + "/platform-profile/platform-profile-[0-9]/choices")
+        super().__init__(
+            [
+                LEGION_SYS_BASEPATH + "/platform-profile/platform-profile-[0-9]*/profile",
+                "/sys/firmware/acpi/platform_profile",
+            ]
+        )
+        self.choices = StrFileFeature(
+            [
+                LEGION_SYS_BASEPATH + "/platform-profile/platform-profile-[0-9]*/choices",
+                "/sys/firmware/acpi/platform_profile_choices",
+            ]
+        )
         self.all_values = [
             NamedValue("low-power", "Low Power"),
             NamedValue("balanced", "Balanced Mode"),
@@ -642,14 +652,55 @@ class GPUOverclock(BoolFileFeature):
         super().__init__(os.path.join(LEGION_SYS_BASEPATH, "gpu_oc"))
 
 
-class CPUShorttermPowerLimit(IntFileFeature):
-    def __init__(self):
-        super().__init__(os.path.join(LEGION_SYS_BASEPATH, "cpu_shortterm_powerlimit"), 5, 200, 1)
+class LenovoPowerLimit(IntFileFeature):
+    """Prefer the native Lenovo power interface and its firmware-provided bounds."""
+
+    def __init__(self, attribute, legacy_filename):
+        super().__init__(
+            [
+                f"/sys/class/firmware-attributes/lenovo-wmi-other-[0-9]*/attributes/{attribute}/current_value",
+                os.path.join(LEGION_SYS_BASEPATH, legacy_filename),
+            ],
+            5,
+            200,
+            1,
+        )
+
+    def set_str_value(self, value: str):
+        self.set(int(value))
+
+    def uses_native_interface(self):
+        return self.filename is not None and Path(self.filename).name == "current_value"
+
+    def get_limits_and_step(self):
+        if not self.uses_native_interface():
+            return super().get_limits_and_step()
+        attribute_dir = Path(self.filename).parent
+        return tuple(
+            self._read_file_int(attribute_dir / name) for name in ("min_value", "max_value", "scalar_increment")
+        )
+
+    def set(self, value):
+        value = int(value)
+        if self.uses_native_interface():
+            if value == self.get():
+                return
+            if Path("/sys/firmware/acpi/platform_profile").read_text(encoding=DEFAULT_ENCODING).strip() != "custom":
+                raise ValueError("Select Custom Mode before changing CPU power limits.")
+            lower, upper, step = self.get_limits_and_step()
+            if not lower <= value <= upper or (step > 0 and (value - lower) % step):
+                raise ValueError(f"CPU power limit must be between {lower} and {upper} W in steps of {step} W.")
+        super().set(value)
 
 
-class CPULongtermPowerLimit(IntFileFeature):
+class CPUShorttermPowerLimit(LenovoPowerLimit):
     def __init__(self):
-        super().__init__(os.path.join(LEGION_SYS_BASEPATH, "cpu_longterm_powerlimit"), 5, 200, 1)
+        super().__init__("ppt_pl2_sppt", "cpu_shortterm_powerlimit")
+
+
+class CPULongtermPowerLimit(LenovoPowerLimit):
+    def __init__(self):
+        super().__init__("ppt_pl1_spl", "cpu_longterm_powerlimit")
 
 
 class CPUPeakPowerLimit(IntFileFeature):

--- a/python/legion_linux/legion_linux/legion_gui.py
+++ b/python/legion_linux/legion_linux/legion_gui.py
@@ -524,15 +524,16 @@ class IntFeatureController:
         try:
             if self.feature.exists():
                 # possible values
-                low, upper, _ = self.feature.get_limits_and_step()
-                if update_bounds:
+                low, upper, step = self.feature.get_limits_and_step()
+                value = self.feature.get()
+                if update_bounds or not self.widget.minimum() <= value <= self.widget.maximum():
                     self.widget.blockSignals(True)
-                    self.widget.setMinimum(low)
-                    self.widget.setMaximum(upper)
+                    self.widget.setMinimum(min(low, value))
+                    self.widget.setMaximum(max(upper, value))
+                    self.widget.setSingleStep(max(1, step))
                     self.widget.blockSignals(False)
 
                 # value -> index
-                value = self.feature.get()
                 self.widget.blockSignals(True)
                 self.widget.setValue(value)
                 self.widget.blockSignals(False)
@@ -854,6 +855,12 @@ class LegionController:
         self.hybrid_gsync_controller.update_view_from_feature()
 
     def update_power_gui(self, update_bounds=False):
+        if self.model.cpu_longterm_power_limit.uses_native_interface():
+            self.view_otheroptions.power_note_label.setText(
+                "CPU power limits can be changed in Custom Mode. "
+                "Greyed-out controls are not available on this laptop."
+            )
+            self.view_otheroptions.power_note_label.setStyleSheet("")
         self.power_mode_controller.update_view_from_feature(0, update_items=update_bounds)
         self.cpu_longterm_power_limit_controller.update_view_from_feature(update_bounds=update_bounds)
         self.cpu_shortterm_power_limit_controller.update_view_from_feature(update_bounds=update_bounds)

--- a/tests/test_native_power.py
+++ b/tests/test_native_power.py
@@ -1,0 +1,134 @@
+"""Exercise native power controls using temporary files, without hardware writes."""
+
+import glob
+import logging
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "python/legion_linux"))
+
+from PyQt6.QtWidgets import QApplication, QSpinBox
+from legion_linux.legion import (
+    LEGION_SYS_BASEPATH,
+    CPULongtermPowerLimit,
+    CPUShorttermPowerLimit,
+    FileFeature,
+    PlatformProfileFeature,
+)
+from legion_linux.legion_gui import IntFeatureController
+
+
+class NativePowerTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.app = QApplication.instance() or QApplication([])
+        logging.disable(logging.CRITICAL)
+
+    def setUp(self):
+        self.directory = tempfile.TemporaryDirectory()
+        self.addCleanup(self.directory.cleanup)
+        self.root = Path(self.directory.name)
+        self.lookup = patch.object(FileFeature, "_find_by_file_pattern", side_effect=self.find_files)
+        self.lookup.start()
+        self.addCleanup(self.lookup.stop)
+
+    def find_files(self, patterns):
+        for pattern in patterns if isinstance(patterns, list) else [patterns]:
+            matches = glob.glob(str(self.root) + pattern)
+            if matches:
+                return matches[0]
+        return None
+
+    def write(self, name, value):
+        path = self.root / name.lstrip("/")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(str(value))
+        return path
+
+    def native(self, attribute="ppt_pl1_spl", value=70):
+        base = "/sys/class/firmware-attributes/lenovo-wmi-other-0/attributes/" + attribute
+        for name, content in (("current_value", value), ("min_value", 50), ("max_value", 95), ("scalar_increment", 5)):
+            self.write(base + "/" + name, content)
+        return base
+
+    def test_native_preferred_and_both_cpu_mappings(self):
+        self.native()
+        self.native("ppt_pl2_sppt", 125)
+        self.write(LEGION_SYS_BASEPATH + "/cpu_longterm_powerlimit", 0)
+        self.assertEqual(CPULongtermPowerLimit().get(), 70)
+        self.assertEqual(CPUShorttermPowerLimit().get(), 125)
+        self.assertEqual(CPULongtermPowerLimit().get_limits_and_step(), (50, 95, 5))
+
+    def test_legacy_fallback(self):
+        path = self.write(LEGION_SYS_BASEPATH + "/cpu_longterm_powerlimit", 60)
+        feature = CPULongtermPowerLimit()
+        self.assertFalse(feature.uses_native_interface())
+        feature.set_str_value("65")
+        self.assertEqual(path.read_text(), "65")
+
+    def test_unchanged_value_does_not_write_or_require_profile(self):
+        self.native()
+        feature = CPULongtermPowerLimit()
+        with patch.object(feature, "_write_file") as write:
+            feature.set(70)
+            feature.set_str_value("70")
+            write.assert_not_called()
+
+    def test_gui_and_cli_reject_wrong_mode_range_and_step(self):
+        self.native()
+        feature = CPULongtermPowerLimit()
+        for setter in (feature.set, feature.set_str_value):
+            for mode, value in (("performance", 75), ("custom", 100), ("custom", 73)):
+                with self.subTest(mode=mode, value=value, setter=setter.__name__):
+                    with patch.object(Path, "read_text", return_value=mode), patch.object(
+                        feature, "_write_file"
+                    ) as write:
+                        with self.assertRaises(ValueError):
+                            setter(str(value))
+                        write.assert_not_called()
+
+    def test_valid_custom_mode_write(self):
+        base = self.native()
+        feature = CPULongtermPowerLimit()
+        with patch.object(Path, "read_text", return_value="custom"):
+            feature.set(75)
+            feature.set_str_value("80")
+        self.assertEqual((self.root / (base + "/current_value").lstrip("/")).read_text(), "80")
+
+    def test_missing_profile_blocks_write(self):
+        self.native()
+        feature = CPULongtermPowerLimit()
+        with patch.object(Path, "read_text", side_effect=FileNotFoundError), patch.object(
+            feature, "_write_file"
+        ) as write:
+            with self.assertRaises(FileNotFoundError):
+                feature.set_str_value("75")
+            write.assert_not_called()
+
+    def test_profile_fallback_and_legion_precedence(self):
+        self.write("/sys/firmware/acpi/platform_profile", "performance")
+        self.write("/sys/firmware/acpi/platform_profile_choices", "balanced performance custom")
+        native = PlatformProfileFeature()
+        self.assertEqual(native.get(), "performance")
+        self.assertEqual({item.value for item in native.get_values()}, {"balanced", "performance", "custom"})
+        base = LEGION_SYS_BASEPATH + "/platform-profile/platform-profile-12/"
+        self.write(base + "profile", "balanced")
+        self.write(base + "choices", "balanced performance")
+        legion = PlatformProfileFeature()
+        self.assertEqual(legion.get(), "balanced")
+        self.assertEqual({item.value for item in legion.get_values()}, {"balanced", "performance"})
+
+    def test_reading_outside_custom_bounds_is_not_clamped_or_written(self):
+        self.native(value=125)
+        feature = CPULongtermPowerLimit()
+        widget = QSpinBox()
+        with patch.object(feature, "_write_file") as write:
+            controller = IntFeatureController(widget, feature)
+            controller.update_view_from_feature(update_bounds=True)
+            self.assertEqual(widget.value(), 125)
+            self.assertEqual(widget.singleStep(), 5)
+            controller.update_feature_from_view(wait=False)
+            write.assert_not_called()


### PR DESCRIPTION
On a Legion 5 15IRX10, model 83LY, BIOS QNCN38WW, the GUI missed the native Linux platform profile provider and showed zero for CPU power limits through the legacy Legion interface. In the working session on September 8, the native Lenovo attributes reported 70 W sustained and 125 W short-term in Performance Mode.

This adds the system ACPI platform profile as a fallback and prefers the native Lenovo `ppt_pl1_spl` and `ppt_pl2_sppt` attributes when present. Legacy CPU interfaces remain the fallback when those attributes are absent. Native writes require Custom Mode and respect the firmware's range and step. Unchanged values skip the write. The checks also run through CLI `set-feature`, which the privileged GUI write path uses.

The spin box preserves an observed value outside the Custom Mode bounds instead of silently clamping it. Proposed changes still use the firmware bounds.

This is a draft because hardware validation is incomplete. On September 9, with the same kernel `7.1.9-arch1-2`, the native platform profile provider was absent after boot and reading `current_value` returned EINVAL. The Lenovo modules were loaded and the attribute bounds were still present. That needs investigation before treating this as a working configuration across boots. No CPU limit or power mode writes have been tested on real hardware.

Eight tests pass using temporary sysfs fixtures. They cover both CPU mappings, legacy fallback, GUI and CLI validation, valid Custom Mode writes, missing profile rejection, unchanged values, profile selection and out-of-range display. Pylint is 10/10; the CLI smoke test and `git diff --check` pass. Changed Python code was formatted with Black using the project configuration.

Run `QT_QPA_PLATFORM=offscreen python -m unittest discover -s tests -p test_native_power.py`.

Related to the QNCN support in #414. This branch is independent of the GUI startup fix in #546. It does not change fan control.

Developed with Codex. Hardware observations are from this laptop; successful writes in the tests are to temporary files only.
