### PR TITLE
fix(kernel-module): initialize uninitialized locals in debugfs_fancurve_show

### DIFF
--- a/kernel_module/legion-laptop.c
+++ b/kernel_module/legion-laptop.c
@@ -5316,13 +5316,13 @@ static void seq_file_print_with_error(struct seq_file *s, const char *name,
 static int debugfs_fancurve_show(struct seq_file *s, void *unused)
 {
 	struct legion_private *priv = s->private;
-	bool is_minifancurve;
-	bool is_lockfancontroller;
-	bool is_maximumfanspeed;
+	bool is_minifancurve = false;
+	bool is_lockfancontroller = false;
+	bool is_maximumfanspeed = false;
 	bool is_rapidcharge = false;
-	int powermode;
-	int temperature;
-	int fanspeed;
+	int powermode = 0;
+	int temperature = 0;
+	int fanspeed = 0;
 	int err;
 	unsigned long cfg;
 	struct fancurve wmi_fancurve;


### PR DESCRIPTION
Clang static analyzer run (make CC=clang LD=ld.lld LLVM=1 + clang --analyze) surfaced 3 core.CallAndMessage findings, all in debugfs_fancurve_show:

- 'temperature', 'fanspeed' and 'is_maximumfanspeed' are declared without initializers and passed to seq_file_print_with_error() after read functions (read_temperature, read_fanspeed, read_fanfullspeed) that return an error without writing the out-param on some access-method paths.

The value print is already guarded by !err since #545, so this is strictly error-path-only and success outputs are unchanged. Initializing the locals makes the debug dump self-contained and silences the analyzer.

Verification:
- clang --analyze: 0 findings (was 3)
- checkpatch.pl: 0 errors, 0 warnings
- make CC=clang LD=ld.lld LLVM=1 clean: builds with 0 warnings