### PR TITLE
fix(python): create autostart dir when enabling GUI autostart

### DIFF
--- a/python/legion_linux/legion_linux/legion.py
+++ b/python/legion_linux/legion_linux/legion.py
@@ -380,11 +380,12 @@ class LegionGUIAutostart(BoolFileFeature):
         super().__init__(str(Path.home() / ".config"))
 
     def exists(self):
-        return self.desktop_file_path.exists() and self.autostart_dekstop_folder_path.exists()
+        return self.desktop_file_path.exists()
 
     def set(self, value: bool):
         log.info("Feature %s setting to %d", self.name(), value)
         if value:
+            self.autostart_dekstop_folder_path.mkdir(parents=True, exist_ok=True)
             src = self.desktop_file_path
             dest = self.autostart_desktop_file_path
             log.info("Feature %s: Copy %s to %s", self.name(), src, dest)


### PR DESCRIPTION
On systems where `~/.config/autostart` does not exist, the Autostart checkbox was permanently disabled and `set(True)` raised FileNotFoundError. Fix: mkdir -p on enable, and exists() now only checks the packaged desktop file.