### PR TITLE
fix(cli): make argcomplete optional instead of a hard dependency

### DIFF
--- a/python/legion_linux/legion_linux/legion_cli.py
+++ b/python/legion_linux/legion_linux/legion_cli.py
@@ -1,7 +1,10 @@
 #!/usr/bin/env python3
 # PYTHON_ARGCOMPLETE_OK
 # pylint: disable=wrong-import-order
-import argcomplete
+try:
+    import argcomplete
+except ImportError:
+    argcomplete = None
 import argparse
 import logging
 import sys
@@ -501,7 +504,8 @@ def main():
     HybridMode(subcommands, None, cmd_group)
 
     # only add autocompletion if package is installed
-    argcomplete.autocomplete(parser)
+    if argcomplete is not None:
+        argcomplete.autocomplete(parser)
 
     args = parser.parse_args()
     log.setLevel(args.loglevel)


### PR DESCRIPTION
**Problem**: `legion_cli.py` imports `argcomplete` at module load, but the code comment says autocompletion should be added "only if package is installed" (#???). If `argcomplete` is missing, the *entire CLI* fails to start (every subcommand dies with ImportError), even though completion is only a convenience feature.

**Fix**:
- Wrap the `argcomplete` import in `try/except ImportError` and set the module to `None` when unavailable.
- Only call `argcomplete.autocomplete(parser)` when it actually imported, preserving current behavior everywhere else.

**Testing**: pylint 10/10, black clean, py_compile passes; smoke-tested both the present path (CLI help renders fully) and the fallback path (argcomplete blocked -> `legion_cli.argcomplete is None`, CLI still imports and runs).