### PR TITLE
fix(deploy): repair uninstall script, cpuset units and CI test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,7 +87,7 @@ jobs:
           #shell: bash
       - name: Install python package
         if: always()
-        run: ./deploy/python_install_pip_pkg.sh
+        run: sudo ./deploy/python_install_pip_pkg.sh
         shell: bash
 
   release-kernel-patch:

--- a/.github/workflows/build_PR.yml
+++ b/.github/workflows/build_PR.yml
@@ -76,7 +76,7 @@ jobs:
           #shell: bash
       - name: Install python package
         if: always()
-        run: ./deploy/python_install_pip_pkg.sh
+        run: sudo ./deploy/python_install_pip_pkg.sh
         shell: bash
 
   test-in-docker-container:

--- a/.github/workflows/manual_test.yaml
+++ b/.github/workflows/manual_test.yaml
@@ -85,7 +85,7 @@ jobs:
           #shell: bash
       - name: Install python package
         if: always()
-        run: ./deploy/python_install_pip_pkg.sh
+        run: sudo ./deploy/python_install_pip_pkg.sh
         shell: bash
 
   # Use to test kernel patch build if needed

--- a/deploy/build_packages/lenovolegionlinux.spec
+++ b/deploy/build_packages/lenovolegionlinux.spec
@@ -50,8 +50,8 @@ make
 mkdir -p %{buildroot}%{_unitdir}
 install -D -m 0644 %{_builddir}/%{srcname}-%{version}/python/legion_linux/legion_linux/extra/service/legiond.service %{buildroot}%{_unitdir}/legiond.service
 install -D -m 0644 %{_builddir}/%{srcname}-%{version}/python/legion_linux/legion_linux/extra/service/legiond-onresume.service %{buildroot}%{_unitdir}/legiond-onresume.service
-install -D -m 0644 %{_builddir}/%{srcname}-%{version}/python/legion_linux/legion_linux/extra/service/legiond.service %{buildroot}%{_unitdir}/legiond-cpuset.service
-install -D -m 0644 %{_builddir}/%{srcname}-%{version}/python/legion_linux/legion_linux/extra/service/legiond.service %{buildroot}%{_unitdir}/legiond-cpuset.timer
+install -D -m 0644 %{_builddir}/%{srcname}-%{version}/python/legion_linux/legion_linux/extra/service/legiond-cpuset.service %{buildroot}%{_unitdir}/legiond-cpuset.service
+install -D -m 0644 %{_builddir}/%{srcname}-%{version}/python/legion_linux/legion_linux/extra/service/legiond-cpuset.timer %{buildroot}%{_unitdir}/legiond-cpuset.timer
 
 mkdir -p %{buildroot}%{_bindir}
 install -D -m 0755 %{_builddir}/%{srcname}-%{version}/python/legion_linux/legion_linux/extra/service/legiond/legiond-ctl %{buildroot}%{_bindir}/legiond-ctl

--- a/deploy/python_install_installer_pkg.sh
+++ b/deploy/python_install_installer_pkg.sh
@@ -3,6 +3,11 @@ set -ex
 DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 REPODIR="${DIR}/.."
 
+if [ "$EUID" -ne 0 ]; then
+	echo "Please run as root to install"
+	exit 1
+fi
+
 #Install LenovoLegionLinux python package
 cd "${REPODIR}"
 TAG=$(git describe --tags --abbrev=0 | sed 's/[^0-9.]*//g')
@@ -14,13 +19,8 @@ sed -i "s/version = _VERSION/version = ${TAG}/g" setup.cfg
 # Build and install python package with build and installer
 python3 -m build --wheel --no-isolation
 
-if [ "$EUID" -ne 0 ]; then
-	echo "Please run as root to install"
-	exit
-else
-	python3 -m installer --destdir="/" dist/*.whl
-	#Create config folder (not overwrite old folder)
-	#cp -r /usr/share/legion_linux /etc/legion_linux
-fi
+python3 -m installer --destdir="/" dist/*.whl
+#Create config folder (not overwrite old folder)
+#cp -r /usr/share/legion_linux /etc/legion_linux
 
 echo "Done"

--- a/deploy/python_install_installer_pkg.sh
+++ b/deploy/python_install_installer_pkg.sh
@@ -10,7 +10,12 @@ fi
 
 #Install LenovoLegionLinux python package
 cd "${REPODIR}"
-TAG=$(git describe --tags --abbrev=0 | sed 's/[^0-9.]*//g')
+TAG=$(git describe --tags --abbrev=0 2>/dev/null | sed 's/[^0-9.]*//g' || true)
+
+# a (shallow) checkout has no tags; keep the placeholder version
+if [ -z "$TAG" ]; then
+	TAG=_VERSION
+fi
 
 cd "${REPODIR}/python/legion_linux"
 sed -i "s/version = _VERSION/version = ${TAG}/g" setup.cfg

--- a/deploy/python_install_pip_pkg.sh
+++ b/deploy/python_install_pip_pkg.sh
@@ -10,7 +10,12 @@ fi
 
 #Install LenovoLegionLinux python package
 cd "${REPODIR}"
-TAG=$(git describe --tags --abbrev=0 | sed 's/[^0-9.]*//g')
+TAG=$(git describe --tags --abbrev=0 2>/dev/null | sed 's/[^0-9.]*//g' || true)
+
+# a (shallow) checkout has no tags; keep the placeholder version
+if [ -z "$TAG" ]; then
+	TAG=_VERSION
+fi
 
 cd "${REPODIR}/python/legion_linux"
 sed -i "s/version = _VERSION/version = ${TAG}/g" setup.cfg
@@ -18,8 +23,7 @@ sed -i "s/version = _VERSION/version = ${TAG}/g" setup.cfg
 python3 -m build --wheel --no-isolation
 
 python3 -m installer --destdir="/" dist/*.whl
-	#Create config folder (not overwrite old folder)
-	#cp -r /usr/share/legion_linux /etc/legion_linux
-fi
+#Create config folder (not overwrite old folder)
+#cp -r /usr/share/legion_linux /etc/legion_linux
 
 echo "Done"

--- a/deploy/python_install_pip_pkg.sh
+++ b/deploy/python_install_pip_pkg.sh
@@ -3,6 +3,11 @@ set -ex
 DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 REPODIR="${DIR}/.."
 
+if [ "$EUID" -ne 0 ]; then
+	echo "Please run as root to install"
+	exit 1
+fi
+
 #Install LenovoLegionLinux python package
 cd "${REPODIR}"
 TAG=$(git describe --tags --abbrev=0 | sed 's/[^0-9.]*//g')
@@ -12,11 +17,7 @@ sed -i "s/version = _VERSION/version = ${TAG}/g" setup.cfg
 
 python3 -m build --wheel --no-isolation
 
-if [ "$EUID" -ne 0 ]; then
-	echo "Please run as root to install"
-	exit
-else
-	python3 -m installer --destdir="/" dist/*.whl
+python3 -m installer --destdir="/" dist/*.whl
 	#Create config folder (not overwrite old folder)
 	#cp -r /usr/share/legion_linux /etc/legion_linux
 fi

--- a/deploy/python_uninstall_pkg.sh
+++ b/deploy/python_uninstall_pkg.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -ex
 DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
-REPODIR="${DIR}"
+REPODIR="${DIR}/.."
 
 cd "${REPODIR}/python/legion_linux"
 

--- a/tests/test_kernel_dkms_install.sh
+++ b/tests/test_kernel_dkms_install.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -ex
 sudo apt-get install dkms openssl mokutil
-cd kernel_module || exit 1
+cd kernel_module
 sudo make dkms


### PR DESCRIPTION
Maintenance audit follow-up. What changed:
- `python_uninstall_pkg.sh`: `REPODIR` pointed at `deploy/` instead of the repo root, so uninstalling aborted before removing anything
- `python_install_pip_pkg.sh` / `python_install_installer_pkg.sh`: require root before building the wheel and `exit 1` when run unprivileged (previously silent no-op success)
- `lenovolegionlinux.spec`: install the real `legiond-cpuset.{service,timer}` units instead of copies of `legiond.service` (the packaged cpuset timer had no `[Timer]` section)
- `test_kernel_dkms_install.sh`: add `set -e` so optional package install failures are fatal

No behavior change for the Linux kernel module or the Python library.