### PR TITLE
fix(fancurve): expose extreme-mode presets and repair profile metadata

### DIFF
--- a/extra/service/profiles/balanced-battery.yaml
+++ b/extra/service/profiles/balanced-battery.yaml
@@ -1,4 +1,4 @@
-name: balanced-bat
+name: balanced-battery
 entries:
 - fan1_speed: 0
   fan2_speed: 0
@@ -90,4 +90,14 @@ entries:
   ic_upper_temp: 127
   acceleration: 1
   deceleration: 1
+- fan1_speed: 0
+  fan2_speed: 0
+  cpu_lower_temp: 0
+  cpu_upper_temp: 0
+  gpu_lower_temp: 0
+  gpu_upper_temp: 0
+  ic_lower_temp: 0
+  ic_upper_temp: 0
+  acceleration: 0
+  deceleration: 0
 enable_minifancurve: false

--- a/extra/service/profiles/balanced-performance-ac.yaml
+++ b/extra/service/profiles/balanced-performance-ac.yaml
@@ -1,4 +1,4 @@
-name: unknown
+name: balanced-performance-ac
 entries:
 - fan1_speed: 0
   fan2_speed: 0

--- a/extra/service/profiles/balanced-performance-battery.yaml
+++ b/extra/service/profiles/balanced-performance-battery.yaml
@@ -1,4 +1,4 @@
-name: unknown
+name: balanced-performance-battery
 entries:
 - fan1_speed: 0
   fan2_speed: 0

--- a/extra/service/profiles/extreme-ac.yaml
+++ b/extra/service/profiles/extreme-ac.yaml
@@ -1,4 +1,4 @@
-name: unknown
+name: extreme-ac
 entries:
 - fan1_speed: 0
   fan2_speed: 0

--- a/extra/service/profiles/performance-battery.yaml
+++ b/extra/service/profiles/performance-battery.yaml
@@ -1,4 +1,4 @@
-name: performance-ac
+name: performance-battery
 entries:
 - fan1_speed: 0
   fan2_speed: 0

--- a/extra/service/profiles/quiet-battery.yaml
+++ b/extra/service/profiles/quiet-battery.yaml
@@ -1,4 +1,4 @@
-name: quiet-bat
+name: quiet-battery
 entries:
 - fan1_speed: 0
   fan2_speed: 0

--- a/python/legion_linux/legion_linux/legion.py
+++ b/python/legion_linux/legion_linux/legion.py
@@ -1257,10 +1257,12 @@ class FanCurveRepository(Feature):
             "balanced-battery": None,
             "performance-battery": None,
             "balanced-performance-battery": None,
+            "extreme-battery": None,
             "quiet-ac": None,
             "balanced-ac": None,
             "performance-ac": None,
             "balanced-performance-ac": None,
+            "extreme-ac": None,
         }
 
         self.preset_dir = preset_dir
@@ -1820,7 +1822,13 @@ class LegionModelFacade:
             is_on_powersupply,
         )
         if preset_name in self.fancurve_repo.fancurve_presets:
-            fancurve = self.fancurve_repo.load_by_name_or_default(preset_name)
+            if not self.fancurve_repo.does_exists_by_name(preset_name):
+                # no battery preset shipped (e.g. extreme-battery): fall back
+                # to the AC twin, mirroring the legiond behavior
+                fallback = preset_name.replace("-battery", "-ac")
+                log.info("Preset %s not found, falling back to %s", preset_name, fallback)
+                preset_name = fallback
+            fancurve = self.fancurve_repo.load_by_name(preset_name)
             self.fancurve_io.write_fan_curve(fancurve, write_minifancurve)
             log.info("Fancurve: %s", fancurve)
 


### PR DESCRIPTION
Maintenance audit follow-up. What changed:
- `FanCurveRepository.fancurve_presets` now registers `extreme-ac` and `extreme-battery`; previously `fancurve-write-preset-for-current-profile` silently did nothing for the extreme power mode and the GUI never offered the extreme preset
- when a battery preset is not shipped (extreme-battery), fall back to the AC twin, mirroring the legiond behavior in `setapply.c`
- profile `name:` fields now match their filenames (several were `unknown` or a copy/paste from performance-ac)
- `balanced-battery.yaml` was missing the 10th fan curve point (every other preset has 10); on a 10-point EC the leftover point stayed at whatever the EC had cached