### PR TITLE
fix(legiond): watch ACAD fallback path and repair cpuset OpenRC unit

### DIFF
--- a/extra/service/legiond-cpuset.initd
+++ b/extra/service/legiond-cpuset.initd
@@ -2,6 +2,8 @@
 # Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-command="/usr/sbin/legion-cpuset"
-command_background=true
-pidfile="/run/legiond-cpuset.pid"
+start() {
+    ebegin "setting legion cpu governor"
+    /usr/bin/legiond-ctl cpuset
+    eend $?
+}

--- a/extra/service/legiond/legiond.c
+++ b/extra/service/legiond/legiond.c
@@ -294,6 +294,14 @@ int main(void)
 		perror("inotify_add_watch profile_path");
 	if (inotify_add_watch(inotify_fd, ac_path, IN_MODIFY) == -1)
 		perror("inotify_add_watch ac_path");
+	/*
+	 * Not all systems expose ADP0; get_powerstate() falls back to the
+	 * ACAD path (ac_path_alt), so watch it too. ENOENT is expected on
+	 * systems where the primary path exists.
+	 */
+	if (inotify_add_watch(inotify_fd, ac_path_alt, IN_MODIFY) == -1 &&
+	    errno != ENOENT)
+		perror("inotify_add_watch ac_path_alt");
 
 	auto_free char *buffer = malloc(BUF_LEN);
 	if (buffer == NULL) {


### PR DESCRIPTION
Maintenance audit follow-up. What changed:
- `legiond.c`: inotify only watched `ADP0/online` (`ac_path`); on systems without it `get_powerstate()` falls back to `ACAD/online` (`ac_path_alt`), so AC plug/unplug never triggered a fan curve reload. Watch both paths, tolerating `ENOENT` on systems where the alternate path does not exist.
- `legiond-cpuset.initd`: referenced a nonexistent `/usr/sbin/legion-cpuset` binary; it now runs `/usr/bin/legiond-ctl cpuset` as a one-shot, matching the systemd `legiond-cpuset.service`.

Built with `-Wall -Wextra`, zero warnings.