### PR TITLE
fix(ci): bootstrap pacman keyring in arch containers

### DIFF
--- a/deploy/Dockerfile.arch
+++ b/deploy/Dockerfile.arch
@@ -1,6 +1,9 @@
 ARG BASE_IMAGE=archlinux:latest
 FROM $BASE_IMAGE
-RUN pacman -Syu --noconfirm
+# bootstrap the pacman keyring; a fresh archlinux base image has no usable
+# secret key, so a plain `pacman -Syu` periodically fails with "There is no
+# secret key available to sign with"
+RUN pacman-key --init && pacman-key --populate archlinux && pacman -Syu --noconfirm
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/deploy/package_testing/Dockerfile.arch
+++ b/deploy/package_testing/Dockerfile.arch
@@ -1,6 +1,9 @@
 ARG BASE_IMAGE=archlinux:latest
 FROM $BASE_IMAGE
-RUN pacman -Syu --noconfirm
+# bootstrap the pacman keyring; a fresh archlinux base image has no usable
+# secret key, so a plain `pacman -Syu` periodically fails with "There is no
+# secret key available to sign with"
+RUN pacman-key --init && pacman-key --populate archlinux && pacman -Syu --noconfirm
 
 ARG DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
`test-in-docker-container` fails intermittently on the `legion-arch` image: the `RUN pacman -Syu --noconfirm` step hits `ERROR: There is no secret key available to sign with` on a fresh base image whose keyring is not initialized yet. Hit on PRs #553 and #560 among others.

The fix initializes and populates the archlinux keyring before the system upgrade (the standard arch-container bootstrap):

```dockerfile
RUN pacman-key --init && pacman-key --populate archlinux && pacman -Syu --noconfirm
```

Applied to both `deploy/Dockerfile.arch` and `deploy/package_testing/Dockerfile.arch`.