### PR TITLE
fix(kernel-module): mark model_lpcn fancurve as WMI speed-only (16ARX8/LPCN family)

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ It allows you to control features like the fan curve, power mode, power limits, 
 - Lenovo Legion 5 17ACH6 (BIOS HHCN31WW): sensors, fan curve, power profile
 - Lenovo Legion 7i 16ITHG6 (BIOS H1CN35WW): sensors, fan curve, power profile
 - Lenovo Legion 7 Pro 16ARX8H (BIOS LPCN47WW): sensors, fan curve, power profile
-- Lenovo Legion Pro 5 16ARX8 (82WM) (BIOS LPCN65WW): sensors, fan curve (speed points only, see LPCN note below), power profile
+- Lenovo Legion 5 Pro 16ARX8 (82WM) (BIOS LPCN65WW): sensors, fan curve (speed points only, see LPCN note below), power profile
 - Lenovo Legion 7 16IAX7 (82TD) (BIOS K1CN48WW): sensors, fan curve (write works; WMI readback returns empty buffer), power profile
 - Lenovo Legion Pro 7 16IRX8H (BIOS KWCN54WW): sensors, fan curve, power profile, fan unlock (lifts the fan ceiling from ~4400 to ~7100 RPM)
 - Lenovo Legion 7 16IRX9, Gen 9: sensors, fan curve, power profile; also supported by [SmartFan](extra/smartfan/) without the kernel module
@@ -791,8 +791,8 @@ With the GUI, the touch pad is enabled/disabled by checking/unchecking the box `
 Some bugs cannot be fixed due to the firmware in the hardware:
 
 - size of fan curve cannot be changed (size is 10 on performance mode, 9 otherwise) but you can practically disable points by setting the temperature limits to 127, as already done when writing to `auto_points_size`
-- on models using the WMI3 fan table (LPCN family, e.g. Legion Pro 5 16ARX8 / Legion 7 Pro 16ARX8H), the WMI method only transmits the fan **speed** of each curve point: temperature thresholds, the second fan's speed and accel/decel values are not readable or writable through WMI (they read back as 0). The kernel module therefore exposes only the speed attributes on these models; the EC keeps using its own firmware temperature thresholds. [#140](https://github.com/johnfanv2/LenovoLegionLinux/issues/140)
-- on the Legion Pro 5 16ARX8 (BIOS LPCN65WW), switching to the `max-power` platform profile **cuts power instantly** (hard power-off with no shutdown sequence). The safe profiles are quiet/balanced/performance/custom. A hard power cut can also reset the EC battery charge mode from conservation back to rapid charge.
+- on models using the WMI3 fan table (LPCN family, e.g. Legion 5 Pro 16ARX8 / Legion 7 Pro 16ARX8H), the WMI method only transmits the fan **speed** of each curve point: temperature thresholds, the second fan's speed and accel/decel values are not readable or writable through WMI (they read back as 0). The kernel module therefore exposes only the speed attributes on these models; the EC keeps using its own firmware temperature thresholds. [#140](https://github.com/johnfanv2/LenovoLegionLinux/issues/140)
+- on the Legion 5 Pro 16ARX8 (BIOS LPCN65WW), switching to the `max-power` platform profile **cuts power instantly** (hard power-off with no shutdown sequence). The safe profiles are quiet/balanced/performance/custom. A hard power cut can also reset the EC battery charge mode from conservation back to rapid charge.
 
 ## :clap: Credits
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ It allows you to control features like the fan curve, power mode, power limits, 
 - Lenovo Legion 5 17ACH6 (BIOS HHCN31WW): sensors, fan curve, power profile
 - Lenovo Legion 7i 16ITHG6 (BIOS H1CN35WW): sensors, fan curve, power profile
 - Lenovo Legion 7 Pro 16ARX8H (BIOS LPCN47WW): sensors, fan curve, power profile
-- Lenovo Legion 5 Pro 16ARX8 (82WM) (BIOS LPCN65WW): sensors, fan curve (speed points only, see LPCN note below), power profile
+- Lenovo Legion Pro 5 16ARX8 (82WM) (BIOS LPCN65WW): sensors, fan curve (speed points only, see LPCN note below), power profile
 - Lenovo Legion 7 16IAX7 (82TD) (BIOS K1CN48WW): sensors, fan curve (write works; WMI readback returns empty buffer), power profile
 - Lenovo Legion Pro 7 16IRX8H (BIOS KWCN54WW): sensors, fan curve, power profile, fan unlock (lifts the fan ceiling from ~4400 to ~7100 RPM)
 - Lenovo Legion 7 16IRX9, Gen 9: sensors, fan curve, power profile; also supported by [SmartFan](extra/smartfan/) without the kernel module
@@ -791,8 +791,8 @@ With the GUI, the touch pad is enabled/disabled by checking/unchecking the box `
 Some bugs cannot be fixed due to the firmware in the hardware:
 
 - size of fan curve cannot be changed (size is 10 on performance mode, 9 otherwise) but you can practically disable points by setting the temperature limits to 127, as already done when writing to `auto_points_size`
-- on models using the WMI3 fan table (LPCN family, e.g. Legion 5 Pro 16ARX8 / Legion 7 Pro 16ARX8H), the WMI method only transmits the fan **speed** of each curve point: temperature thresholds, the second fan's speed and accel/decel values are not readable or writable through WMI (they read back as 0). The kernel module therefore exposes only the speed attributes on these models; the EC keeps using its own firmware temperature thresholds. [#140](https://github.com/johnfanv2/LenovoLegionLinux/issues/140)
-- on the Legion 5 Pro 16ARX8 (BIOS LPCN65WW), switching to the `max-power` platform profile **cuts power instantly** (hard power-off with no shutdown sequence). The safe profiles are quiet/balanced/performance/custom. A hard power cut can also reset the EC battery charge mode from conservation back to rapid charge.
+- on models using the WMI3 fan table (LPCN family, e.g. Legion Pro 5 16ARX8 / Legion 7 Pro 16ARX8H), the WMI method only transmits the fan **speed** of each curve point: temperature thresholds, the second fan's speed and accel/decel values are not readable or writable through WMI (they read back as 0). The kernel module therefore exposes only the speed attributes on these models; the EC keeps using its own firmware temperature thresholds. Confirmed on the Legion Pro 5 16ARX8 (BIOS LPCN65WW); assumed to apply to the rest of the LPCN family (e.g. LPCN47WW) pending confirmation from those users. [#140](https://github.com/johnfanv2/LenovoLegionLinux/issues/140)
+- on the Legion Pro 5 16ARX8 (BIOS LPCN65WW), the firmware's `max-power` mode **cuts power instantly** (hard power-off with no shutdown sequence) instead of raising limits, and can also reset the EC battery charge mode from conservation back to rapid charge. The kernel module therefore does not expose `max-power` as a platform profile choice on this model; the safe profiles are quiet/balanced/performance/custom.
 
 ## :clap: Credits
 

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ It allows you to control features like the fan curve, power mode, power limits, 
 - Lenovo Legion 5 17ACH6 (BIOS HHCN31WW): sensors, fan curve, power profile
 - Lenovo Legion 7i 16ITHG6 (BIOS H1CN35WW): sensors, fan curve, power profile
 - Lenovo Legion 7 Pro 16ARX8H (BIOS LPCN47WW): sensors, fan curve, power profile
+- Lenovo Legion Pro 5 16ARX8 (82WM) (BIOS LPCN65WW): sensors, fan curve (speed points only, see LPCN note below), power profile
 - Lenovo Legion 7 16IAX7 (82TD) (BIOS K1CN48WW): sensors, fan curve (write works; WMI readback returns empty buffer), power profile
 - Lenovo Legion Pro 7 16IRX8H (BIOS KWCN54WW): sensors, fan curve, power profile, fan unlock (lifts the fan ceiling from ~4400 to ~7100 RPM)
 - Lenovo Legion 7 16IRX9, Gen 9: sensors, fan curve, power profile; also supported by [SmartFan](extra/smartfan/) without the kernel module
@@ -790,6 +791,8 @@ With the GUI, the touch pad is enabled/disabled by checking/unchecking the box `
 Some bugs cannot be fixed due to the firmware in the hardware:
 
 - size of fan curve cannot be changed (size is 10 on performance mode, 9 otherwise) but you can practically disable points by setting the temperature limits to 127, as already done when writing to `auto_points_size`
+- on models using the WMI3 fan table (LPCN family, e.g. Legion Pro 5 16ARX8 / Legion 7 Pro 16ARX8H), the WMI method only transmits the fan **speed** of each curve point: temperature thresholds, the second fan's speed and accel/decel values are not readable or writable through WMI (they read back as 0). The kernel module therefore exposes only the speed attributes on these models; the EC keeps using its own firmware temperature thresholds. [#140](https://github.com/johnfanv2/LenovoLegionLinux/issues/140)
+- on the Legion Pro 5 16ARX8 (BIOS LPCN65WW), switching to the `max-power` platform profile **cuts power instantly** (hard power-off with no shutdown sequence). The safe profiles are quiet/balanced/performance/custom. A hard power cut can also reset the EC battery charge mode from conservation back to rapid charge.
 
 ## :clap: Credits
 

--- a/README_zh-hans.md
+++ b/README_zh-hans.md
@@ -131,7 +131,7 @@ Lenovo Legion Linux（LLL）为联想拯救者系列笔记本提供了额外的L
 - 联想拯救者 5 17ACH6（BIOS HHCN31WW）：传感器、风扇曲线、电源配置
 - 联想拯救者 7i 16ITHG6（BIOS H1CN35WW）：传感器、风扇曲线、电源配置
 - 联想拯救者 7 Pro 16ARX8H（BIOS LPCN47WW）：传感器、风扇曲线、电源配置
-- 联想拯救者 5 Pro 16ARX8 (82WM)（BIOS LPCN65WW）：传感器、风扇曲线（仅速度点，见下方 LPCN 说明）、电源配置
+- 联想拯救者 Pro 5 16ARX8 (82WM)（BIOS LPCN65WW）：传感器、风扇曲线（仅速度点，见下方 LPCN 说明）、电源配置
 - 联想拯救者 7 16IAX7 (82TD)（BIOS K1CN48WW）：传感器、风扇曲线（写入正常；WMI 回读返回空缓冲区）、电源配置
 - 联想拯救者 Pro 7 16IRX8H（BIOS KWCN54WW）：传感器、风扇曲线、电源配置、风扇解锁（可将风扇上限从约 4400 RPM 提升至约 7100 RPM）
 - 联想拯救者 7 16IRX9，第九代：传感器、风扇曲线、电源配置；也可通过 [SmartFan](extra/smartfan/) 在不加载内核模块的情况下使用
@@ -819,8 +819,8 @@ cat /sys/module/legion_laptop/drivers/platform:legion/PNP0C09:00/fan_unlock
 由于硬件固件的限制，部分问题无法修复：
 
 - 风扇曲线的点数无法更改（性能模式下为 10 点，其它模式为 9 点），但你可以通过将温度限制设置为 127 来实际禁用某些点，在写入 `auto_points_size` 时已经采用了这种方式。
-- 在使用 WMI3 风扇表的机型上（LPCN 系列，如拯救者 5 Pro 16ARX8 / 拯救者 7 Pro 16ARX8H），WMI 方法只传输每个曲线点的风扇**速度**：温度阈值、第二个风扇的速度以及加/减速值无法通过 WMI 读取或写入（回读始终为 0）。因此内核模块在这些机型上只暴露速度属性；EC 继续使用自己的固件温度阈值。[#140](https://github.com/johnfanv2/LenovoLegionLinux/issues/140)
-- 在拯救者 5 Pro 16ARX8（BIOS LPCN65WW）上，切换到 `max-power` 平台配置文件会**立即断电**（硬关机，无正常关机流程）。安全的配置文件为 quiet/balanced/performance/custom。硬断电还可能将 EC 的电池充电模式从养护模式重置为快充。
+- 在使用 WMI3 风扇表的机型上（LPCN 系列，如拯救者 Pro 5 16ARX8 / 拯救者 7 Pro 16ARX8H），WMI 方法只传输每个曲线点的风扇**速度**：温度阈值、第二个风扇的速度以及加/减速值无法通过 WMI 读取或写入（回读始终为 0）。因此内核模块在这些机型上只暴露速度属性；EC 继续使用自己的固件温度阈值。已在拯救者 Pro 5 16ARX8（BIOS LPCN65WW）上确认；LPCN 系列其余机型（如 LPCN47WW）暂按推测适用，待相关用户确认。[#140](https://github.com/johnfanv2/LenovoLegionLinux/issues/140)
+- 在拯救者 Pro 5 16ARX8（BIOS LPCN65WW）上，固件的 `max-power` 模式并非提升功耗限制，而是会**立即断电**（硬关机，无正常关机流程），还可能将 EC 的电池充电模式从养护模式重置为快充。因此内核模块在该机型上不将 `max-power` 作为平台配置文件选项暴露；安全的配置文件为 quiet/balanced/performance/custom。
 
 ## :clap: 鸣谢
 

--- a/README_zh-hans.md
+++ b/README_zh-hans.md
@@ -131,6 +131,7 @@ Lenovo Legion Linux（LLL）为联想拯救者系列笔记本提供了额外的L
 - 联想拯救者 5 17ACH6（BIOS HHCN31WW）：传感器、风扇曲线、电源配置
 - 联想拯救者 7i 16ITHG6（BIOS H1CN35WW）：传感器、风扇曲线、电源配置
 - 联想拯救者 7 Pro 16ARX8H（BIOS LPCN47WW）：传感器、风扇曲线、电源配置
+- 联想拯救者 5 Pro 16ARX8 (82WM)（BIOS LPCN65WW）：传感器、风扇曲线（仅速度点，见下方 LPCN 说明）、电源配置
 - 联想拯救者 7 16IAX7 (82TD)（BIOS K1CN48WW）：传感器、风扇曲线（写入正常；WMI 回读返回空缓冲区）、电源配置
 - 联想拯救者 Pro 7 16IRX8H（BIOS KWCN54WW）：传感器、风扇曲线、电源配置、风扇解锁（可将风扇上限从约 4400 RPM 提升至约 7100 RPM）
 - 联想拯救者 7 16IRX9，第九代：传感器、风扇曲线、电源配置；也可通过 [SmartFan](extra/smartfan/) 在不加载内核模块的情况下使用
@@ -818,6 +819,8 @@ cat /sys/module/legion_laptop/drivers/platform:legion/PNP0C09:00/fan_unlock
 由于硬件固件的限制，部分问题无法修复：
 
 - 风扇曲线的点数无法更改（性能模式下为 10 点，其它模式为 9 点），但你可以通过将温度限制设置为 127 来实际禁用某些点，在写入 `auto_points_size` 时已经采用了这种方式。
+- 在使用 WMI3 风扇表的机型上（LPCN 系列，如拯救者 5 Pro 16ARX8 / 拯救者 7 Pro 16ARX8H），WMI 方法只传输每个曲线点的风扇**速度**：温度阈值、第二个风扇的速度以及加/减速值无法通过 WMI 读取或写入（回读始终为 0）。因此内核模块在这些机型上只暴露速度属性；EC 继续使用自己的固件温度阈值。[#140](https://github.com/johnfanv2/LenovoLegionLinux/issues/140)
+- 在拯救者 5 Pro 16ARX8（BIOS LPCN65WW）上，切换到 `max-power` 平台配置文件会**立即断电**（硬关机，无正常关机流程）。安全的配置文件为 quiet/balanced/performance/custom。硬断电还可能将 EC 的电池充电模式从养护模式重置为快充。
 
 ## :clap: 鸣谢
 

--- a/kernel_module/legion-laptop.c
+++ b/kernel_module/legion-laptop.c
@@ -1002,7 +1002,14 @@ static const struct model_config model_lpcn = {
 		[ACPI_PATH_READ_RAPIDCHARGE] = "\\_SB.PCI0.LPC0.EC0.VPC0.GBMD",
 		[ACPI_PATH_WRITE_RAPIDCHARGE] = "\\_SB.PCI0.LPC0.EC0.VPC0.SBMC",
 	},
-	.has_extreme_powermode = true
+	.has_extreme_powermode = true,
+	/* WMI3 fancurve writes only transmit per-point speed1 (see
+	 * wmi_write_fancurve_custom): temperature thresholds, fan2 speed
+	 * and accel/decel have no WMI backing and never persist. Expose
+	 * only the speed attributes so userspace does not write (and the
+	 * GUI/CLI does not crash on) fields the firmware drops.
+	 */
+	.wmi_fancurve_speed_only = true
 };
 
 static const struct model_config model_kfcn = {

--- a/kernel_module/legion-laptop.c
+++ b/kernel_module/legion-laptop.c
@@ -1002,7 +1002,12 @@ static const struct model_config model_lpcn = {
 		[ACPI_PATH_READ_RAPIDCHARGE] = "\\_SB.PCI0.LPC0.EC0.VPC0.GBMD",
 		[ACPI_PATH_WRITE_RAPIDCHARGE] = "\\_SB.PCI0.LPC0.EC0.VPC0.SBMC",
 	},
-	.has_extreme_powermode = true,
+	/* max-power (the "extreme" platform_profile choice) cuts power
+	 * instantly on this EC (hard power-off, no shutdown sequence) instead
+	 * of raising limits like on other has_extreme_powermode models, so
+	 * keep it out of platform_profile's choices entirely.
+	 */
+	.has_extreme_powermode = false,
 	/* WMI3 fancurve writes only transmit per-point speed1 (see
 	 * wmi_write_fancurve_custom): temperature thresholds, fan2 speed
 	 * and accel/decel have no WMI backing and never persist. Expose


### PR DESCRIPTION
## Problem

On the LPCN family (e.g. **Legion Pro 5 16ARX8 / 82WM**, BIOS LPCN65WW, EC 0x5507), `access_method_fancurve = ACCESS_METHOD_WMI3`, but the WMI method only supports the per-point **speed**:

- `wmi_write_fancurve_custom()` builds a 0x40 buffer where only `buffer[0x06..0x18]` (points 0-9 `speed1`) are filled — temperature thresholds, fan2 speed and accel/decel are never transmitted.
- `wmi_read_fancurve_custom()` `memset`s the curve and only fills `speed1` — everything else reads back as 0.

Consequences on model_lpcn today:

1. Writes to `pwm*_auto_pointN_temp`/`_temp_hyst`/`pwm2_*` are **accepted and silently never persisted** (debugfs readback always 0).
2. Accel/decel writes fail kernel validation with `-EOPNOTSUPP`, so `legion_cli fancurve-write-file-to-hw` and the GUI "Apply to HW" crash with `OSError: [Errno 95] Operation not supported` **mid-write**, leaving a partially applied curve.
3. The all-zeros curve in debugfs confuses users into thinking fan control is broken (#140, same machine; same errno pattern on other WMI models: #534, #535, #236).

## Fix

Set `.wmi_fancurve_speed_only = true` on `model_lpcn`, mirroring `model_n2cn` and the EC4 attribute filtering from #537. The hwmon fancurve group then exposes only `fan1_max` and `pwm1_auto_point{1-10}_pwm`; userspace (python lib probes attribute existence) auto-skips the hidden fields, and full fancurve writes complete successfully. The EC keeps using its own firmware temperature thresholds — same behavior as before, minus the misleading no-op attributes and the crash.

Also set `.has_extreme_powermode = false` on `model_lpcn`: on this EC, the firmware's `max-power` mode doesn't raise limits like on other extreme-powermode models — it cuts power **instantly** (hard power-off, no shutdown sequence). Rather than just documenting the risk, the kernel module no longer exposes `max-power` as a `platform_profile` choice on this model, so it can't be reached manually or via legiond auto-switching.

## Testing

On a Legion Pro 5 16ARX8 (82WM, BIOS LPCN65WW), Arch Linux, kernel 7.2.4-arch1-2, built from main @ e3b2116 + this patch:

- [x] `make` builds clean
- [x] `sudo make reloadmodule` loads; hwmon exposes exactly `fan1_max` + 10 `pwm1_auto_pointN_pwm` files (was 101 fancurve files incl. the no-op ones)
- [x] `sudo legion_cli fancurve-write-file-to-hw custom-ac.yaml` → "Successfully wrote fan curve from file to hardware" (previously crashed at `set_acceleration` with Errno 95)
- [x] Speeds land in the EC and fans track them (verified via `/sys/kernel/debug/legion/fancurve` and live RPM); EC thermal control unaffected
- [x] Sensors/fan RPM telemetry unaffected
- [x] `platform_profile_choices` no longer lists `max-power` on this model

## README

- Adds the 16ARX8 (82WM) to the confirmed models list (speed-only fan curve) with the LPCN note, refs #140.
- Documents the LPCN65WW `max-power` hard power-off quirk (and that it can reset EC battery charge mode from conservation/Long_Life back to rapid charge), and notes it's now hidden from `platform_profile` on this model rather than just a warning.
- The WMI3 speed-only note is scoped as confirmed on the Legion Pro 5 16ARX8 (LPCN65WW) and assumed (not yet confirmed) for the rest of the LPCN family, e.g. LPCN47WW.

Would appreciate confirmation from other LPCN users (e.g. Legion 7 Pro 16ARX8H, LPCN47WW) that speed-only matches what they see — based on the shared `wmi_write_fancurve_custom()` path it should apply to the whole family.

---

**Follow-up:** per AGENTS.md — checkpatch clean (0 errors, 0 warnings), C hunk clang-format clean, and README_zh-hans.md carries the same model entry and Known Bugs bullets (docs parity). Model naming matches the official Lenovo name ("Legion Pro 5"), consistent with the existing "Legion Pro 7" / "Legion 7 Pro" entries.
