### PR TITLE
fix(kernel): probe on kernel 7.x - evaluate EC ACPI names relative to the PNP0C09 device; do not fail on a missing _CFG

### DIFF
--- a/kernel_module/legion-laptop.c
+++ b/kernel_module/legion-laptop.c
@@ -8314,17 +8314,24 @@ static int acpi_init(struct legion_private *priv, struct acpi_device *adev)
 		acpi_path = get_model_acpi_path(_model, ACPI_PATH_STA);
 		err = eval_int(priv->adev, acpi_path, &cfg);
 		if (err) {
-			dev_info(dev, "Could not evaluate ACPI _STA\n");
+			dev_info(dev, "Could not evaluate ACPI %s: %d\n",
+				 acpi_path, err);
 			goto err_acpi_init;
 		}
 
+		/*
+		 * _CFG is only reported (here and in debugfs), never used to
+		 * gate a feature, and not every Lenovo DSDT defines it on the
+		 * embedded controller device, so its absence must not stop
+		 * the probe; _STA above is the presence check.
+		 */
 		acpi_path = get_model_acpi_path(_model, ACPI_PATH_CFG);
 		err = eval_int(priv->adev, acpi_path, &cfg);
-		if (err) {
-			dev_info(dev, "Could not evaluate ACPI _CFG\n");
-			goto err_acpi_init;
-		}
-		dev_info(dev, "ACPI CFG: %lu\n", cfg);
+		if (err)
+			dev_info(dev, "Could not evaluate ACPI %s: %d\n",
+				 acpi_path, err);
+		else
+			dev_info(dev, "ACPI CFG: %lu\n", cfg);
 	} else {
 		dev_info(dev, "Skipping ACPI _STA check");
 	}

--- a/kernel_module/legion-laptop.c
+++ b/kernel_module/legion-laptop.c
@@ -2243,14 +2243,10 @@ static int eval_int(struct acpi_device *adev, const char *name,
 	unsigned long long result;
 	acpi_status status;
 	acpi_handle handle;
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0)
-	status = acpi_get_handle(NULL, (char *)name, &handle);
-	if (ACPI_FAILURE(status))
-		return -EIO;
-#else
+
 	if (!adev) {
-		/* No ACPI companion device: resolve the full-qualified name
-		 * from the ACPI root, same as on kernel 7.0+.
+		/* No ACPI device to evaluate relative to: resolve the
+		 * fully-qualified name from the ACPI root.
 		 */
 		status = acpi_get_handle(NULL, (char *)name, &handle);
 		if (ACPI_FAILURE(status))
@@ -2258,7 +2254,6 @@ static int eval_int(struct acpi_device *adev, const char *name,
 	} else {
 		handle = adev->handle;
 	}
-#endif
 	status = acpi_evaluate_integer(handle, (char *)name, NULL, &result);
 	if (ACPI_FAILURE(status))
 		return -EIO;
@@ -2274,14 +2269,10 @@ static int exec_simple_method(struct acpi_device *adev, const char *name,
 {
 	acpi_handle handle;
 	acpi_status status;
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0)
-	status = acpi_get_handle(NULL, (char *)name, &handle);
-	if (ACPI_FAILURE(status))
-		return -EIO;
-#else
+
 	if (!adev) {
-		/* No ACPI companion device: resolve the full-qualified name
-		 * from the ACPI root, same as on kernel 7.0+.
+		/* No ACPI device to evaluate relative to: resolve the
+		 * fully-qualified name from the ACPI root.
 		 */
 		status = acpi_get_handle(NULL, (char *)name, &handle);
 		if (ACPI_FAILURE(status))
@@ -2289,7 +2280,6 @@ static int exec_simple_method(struct acpi_device *adev, const char *name,
 	} else {
 		handle = adev->handle;
 	}
-#endif
 	status = acpi_execute_simple_method(handle, (char *)name, arg);
 
 	return ACPI_FAILURE(status) ? -EIO : 0;
@@ -8301,6 +8291,22 @@ static int acpi_init(struct legion_private *priv, struct acpi_device *adev)
 	const char *acpi_path;
 
 	priv->adev = adev;
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0)
+	/*
+	 * The virtual platform device has no ACPI companion. The default
+	 * ACPI paths are names relative to the embedded controller device
+	 * (_STA, _CFG, VPC0.GBMD, ...), which is where the driver bound
+	 * before kernel 7.0, so look that device up by its HID and keep
+	 * evaluating relative to it. The reference is dropped in
+	 * acpi_exit().
+	 */
+	if (!priv->adev) {
+		priv->adev = acpi_dev_get_first_match_dev("PNP0C09", NULL, -1);
+		if (priv->adev)
+			dev_info(dev, "Using ACPI device %s for EC methods\n",
+				 dev_name(&priv->adev->dev));
+	}
+#endif
 	if (!priv->adev)
 		dev_info(dev, "No ACPI handle, will use FQN paths\n");
 	skip_acpi_sta_check = force || (!priv->conf->acpi_check_dev);
@@ -8327,6 +8333,15 @@ static int acpi_init(struct legion_private *priv, struct acpi_device *adev)
 
 err_acpi_init:
 	return err;
+}
+
+static void acpi_exit(struct legion_private *priv)
+{
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0)
+	/* Reference taken in acpi_init(); acpi_dev_put() accepts NULL. */
+	acpi_dev_put(priv->adev);
+#endif
+	priv->adev = NULL;
 }
 
 /* =============================  */
@@ -8907,6 +8922,7 @@ err_ecram_init:
 	ecram_memoryio_exit(&priv->ec_memoryio);
 err_ecram_memoryio_init:
 err_acpi_init:
+	acpi_exit(priv);
 	legion_shared_exit(priv);
 err_legion_shared_init:
 err_model_mismtach:
@@ -8939,6 +8955,7 @@ static void legion_remove(struct platform_device *pdev)
 	legion_debugfs_exit(priv);
 	ecram_exit(&priv->ecram);
 	ecram_memoryio_exit(&priv->ec_memoryio);
+	acpi_exit(priv);
 	legion_shared_exit(priv);
 
 	pr_info("Legion platform unloaded\n");


### PR DESCRIPTION
Model: **Lenovo Legion Pro 5 16IRX8 (82WK), BIOS KWCN54WW.** The fix itself is not model-specific.

Part of #564.

On kernel 7.0+ the driver binds a virtual platform device (18953e1), so `priv->adev` is NULL, and c52b4f2 made
`eval_int()` / `exec_simple_method()` resolve every ACPI name from the root on those kernels. The default paths
(`_STA`, `_CFG`, `VPC0.GBMD`, `VPC0.SBMC`, `FANS`, `CPUT`, …) are names relative to the embedded controller device
the driver bound to before 7.0, so `\_STA` does not exist and the probe fails for **every model that sets
`acpi_check_dev`** (16 models rely on the relative defaults). The EC path also differs between platforms (here
`\_SB_.PC00.LPCB.EC0_`), so a single absolute default cannot fix it.

Release 0.0.26 unpatched, CachyOS 7.2.4-3-cachyos:

```text
legion legion: Using configuration for system: KWCN
legion legion: No ACPI handle, will use FQN paths
legion legion: Could not evaluate ACPI _STA
legion legion: Could not init ACPI access: -5
legion legion: probe with driver legion failed with error -5
```

**1. Evaluate the relative names against the embedded controller again.** On 7.x, look the EC up by HID
(`acpi_dev_get_first_match_dev("PNP0C09", NULL, -1)`, which only returns present devices) in `acpi_init()` and
evaluate against its handle, exactly as the ACPI companion provided before 7.0. Absolute per-model overrides keep
working because ACPICA ignores the handle for rooted names. The reference is dropped in a new `acpi_exit()` from
`legion_remove()` and from the probe error path; the root-resolution fallback stays for the case where no PNP0C09
device exists. `eval_int()` and `exec_simple_method()` lose their 7.x special case, because the existing `!adev`
branch already does the right thing.

**2. Do not fail the probe on a missing `_CFG`.** The value is only reported (probe log and debugfs) and never
gates a feature; on this DSDT the only `_CFG` is `VPC0._CFG` (ideapad layout) and the EC device has none. Log the
result either way and continue. `_STA` remains the presence check.

## Verification

`make` then `sudo make reloadmodule` on 7.2.4-3-cachyos, 0.0.26 plus these two commits:

```text
legion legion: Using ACPI device PNP0C09:00 for EC methods
legion legion: Could not evaluate ACPI _CFG: -5      (stock model_kwcn; the model paths in the 16IRX8 PR resolve it)
legion legion: Read embedded controller ID 0x5507
legion legion: legion_laptop loaded for this device
```

`sensors` then lists `legion_hwmon-isa-0000` with Fan 1 / Fan 2 / CPU / GPU / IC temperatures, and
`sudo cat /sys/kernel/debug/legion/fancurve` prints the ten-point table (README quick tests 1-3). Load and unload
cycles are clean, and the fan-curve write test in the 16IRX8 PR was run on top of this. Kernels older than 7.0 keep
the ACPI-companion path unchanged: the `acpi_dev_put()` is under the 7.0 guard.

`tests/test_kernel_checkpath.sh` reports 0 errors and 0 warnings, and the touched code is clang-format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
