### PR TITLE
fix(build): build with the LLVM toolchain automatically on clang-built kernels

### DIFF
--- a/kernel_module/Makefile
+++ b/kernel_module/Makefile
@@ -2,6 +2,18 @@ SHELL := /bin/bash
 KERNELVERSION  ?= $(shell uname -r)
 KSRC := /lib/modules/$(KERNELVERSION)/build
 
+# Kernels built with clang (CONFIG_CC_IS_CLANG=y, e.g. CachyOS) need the LLVM
+# toolchain for out-of-tree modules: gcc rejects the kernel's clang-only flags.
+# Detect it so that plain `make`, `make install` and DKMS (dkms.conf runs this
+# Makefile) work; override with LLVM=1 / LLVM=0 on the command line. dkms >= 3.x
+# does the same detection for the build command it runs itself.
+ifeq ($(shell grep -qs '^CONFIG_CC_IS_CLANG=y' $(KSRC)/include/config/auto.conf $(KSRC)/.config && echo 1),1)
+LLVM ?= 1
+endif
+# LLVM is always passed explicitly: make exports the variable to the sub-make
+# through MAKEOVERRIDES, so an empty value is needed for LLVM=0 to take effect.
+KMAKEFLAGS := -C $(KSRC) M=$(CURDIR) $(if $(filter-out 0,$(LLVM)),LLVM=$(LLVM),LLVM=)
+
 #install dir for kernel drivers
 INSTALLDIR := /lib/modules/$(KERNELVERSION)/kernel/drivers/platform/x86
 MODDESTDIR := /lib/modules/$(KERNELVERSION)/kernel/drivers/platform/x86
@@ -10,27 +22,27 @@ DKMSDIR := /usr/src/LenovoLegionLinux-1.0.0
 obj-m += legion-laptop.o
 
 all:
-	$(MAKE) -C $(KSRC) M=$(shell pwd) modules
+	$(MAKE) $(KMAKEFLAGS) modules
 
 moduleInContainer:
 	docker run -it --rm -v "$(shell pwd)":/kernel_module -w /kernel_module  -v /usr/src/:/usr/src/  -v /lib/modules/:/lib/modules gcc:12.2.0 bash
 
 allWarn:
-	$(MAKE) -C $(KSRC) M=$(shell pwd) KCFLAGS=-W modules
+	$(MAKE) $(KMAKEFLAGS) KCFLAGS=-W modules
 
 clean:
-	make -C $(KSRC) M=$(shell pwd) clean
+	$(MAKE) $(KMAKEFLAGS) clean
 
 install: all
 	@rm -fv $(INSTALLDIR)/legion-laptop.ko
 	@mkdir -pv $(MODDESTDIR)
 	@install -p -D -m 644 *.ko $(INSTALLDIR)
-	@depmod -a $(KVER)
+	@depmod -a $(KERNELVERSION)
 	@printf "%s\n" "Installion finished."
 
 uninstall:
 	@rm -f $(INSTALLDIR)/legion-laptop.ko
-	@depmod -a
+	@depmod -a $(KERNELVERSION)
 	@printf "%s\n" "Uninstall finished."
 
 install_forcereload:

--- a/kernel_module/dkms.conf
+++ b/kernel_module/dkms.conf
@@ -1,6 +1,6 @@
 PACKAGE_NAME="LenovoLegionLinux"
 PACKAGE_VERSION="DKMS_VERSION"
-MAKE[0]="make KERNELVERSION=${kernelver}"
+MAKE[0]="make KERNELVERSION=${kernelver} KSRC=${kernel_source_dir}"
 BUILT_MODULE_NAME[0]="legion-laptop"
 AUTOINSTALL="yes"
 DEST_MODULE_LOCATION[0]="/kernel/drivers/platform/x86"


### PR DESCRIPTION
Model: **Lenovo Legion Pro 5 16IRX8 (82WK), BIOS KWCN54WW**, on CachyOS 7.2.4-3-cachyos. The fix is not
model-specific; it applies to any kernel built with clang.

Fixes #358. Part of #564.

Out-of-tree builds against a kernel compiled with clang (`CONFIG_CC_IS_CLANG=y`, e.g. CachyOS) fail with gcc,
because the kernel's own flags are clang-only:

```text
warning: the compiler differs from the one used to build the kernel
  The kernel was built by: clang version 22.1.8
  You are using:           gcc (GCC) 16.2.1
gcc: error: unrecognized command-line option '-mstack-alignment=8'
gcc: error: unrecognized command-line option '-mretpoline-external-thunk'
gcc: error: unrecognized command-line option '-mllvm'
```

Detect `CONFIG_CC_IS_CLANG` in the target kernel's configuration and pass `LLVM=1` to the kernel build unless
`LLVM` is given on the command line, so that plain `make`, `make install` and the DKMS build all work without a
manual flag. dkms 3.x does the same detection for the build command it runs itself, but `dkms.conf` here invokes
this Makefile, so the Makefile has to know too.

Three smaller fixes come with it, all in the same area:

- `LLVM` is always passed to the sub-make explicitly, with an empty value when it is 0. Without that, make carries
  the detected `LLVM=1` into the sub-make through `MAKEOVERRIDES` and a command-line `LLVM=0` has no effect.
- The detection reads `include/config/auto.conf` as well as `.config`, with `grep -qs` so a missing file is quiet.
- `dkms.conf` passes `KSRC=${kernel_source_dir}`, so `dkms --kernelsourcedir` and the detection cannot disagree,
  and `make install` / `make uninstall` run `depmod -a $(KERNELVERSION)` instead of the undefined `$(KVER)`, which
  had them updating the running kernel's module index when building for a different kernel.

## Verification

On CachyOS 7.2.4-3-cachyos (clang 22.1.8):

```text
$ make                     # was: gcc errors as above
make -C /lib/modules/7.2.4-3-cachyos/build M=.../kernel_module LLVM=1 modules
  CC [M]  legion-laptop.o
  LD [M]  legion-laptop.ko
$ make LLVM=0              # override honoured: gcc is selected again
  The kernel was built by: clang version 22.1.8
  You are using:           gcc
```

`sudo make install` then `modprobe legion_laptop` loads the module, and it has been running as the permanent
install on this machine since. On a gcc-built kernel nothing changes: the detection does not fire and the sub-make
is invoked exactly as before.

`tests/test_kernel_checkpath.sh` is unaffected and still clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
