### PR TITLE
Legion Pro 5 16IRX8 (KWCN): WMI3 fan table as level indices, Other Method paths, RPM-to-level presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ It allows you to control features like the fan curve, power mode, power limits, 
 - Lenovo Legion 7 Pro 16ARX8H (BIOS LPCN47WW): sensors, fan curve, power profile
 - Lenovo Legion 7 16IAX7 (82TD) (BIOS K1CN48WW): sensors, fan curve (write works; WMI readback returns empty buffer), power profile
 - Lenovo Legion Pro 7 16IRX8H (BIOS KWCN54WW): sensors, fan curve, power profile, fan unlock (lifts the fan ceiling from ~4400 to ~7100 RPM)
+- Lenovo Legion Pro 5 16IRX8 (82WK, BIOS KWCN54WW): sensors, fan curve (level indices 0-10, custom power mode), power profile, power limits and fan full speed through the Other Method WMI path; fan curve verified on Linux in custom power mode (level 9 → 4400/4600 RPM, level 10 → 5400/5400 RPM)
 - Lenovo Legion 7 16IRX9, Gen 9: sensors, fan curve, power profile; also supported by [SmartFan](extra/smartfan/) without the kernel module
 
 Many more models — including LOQ models and 2024/2025 Legions like the Legion 7 16IAX10 — are supported; see the DMI allowlist in [`kernel_module/legion-laptop.c`](kernel_module/legion-laptop.c) for the full list.

--- a/README.md
+++ b/README.md
@@ -203,6 +203,8 @@ sudo zypper install dkms openssl mokutil
 
 ```bash
 sudo pacman -S linux-headers base-devel lm_sensors git dmidecode python-pyqt6 python-yaml python-argcomplete python-darkdetect
+# Only for kernels built with clang (e.g. CachyOS); the Makefile then builds with LLVM=1 by itself
+sudo pacman -S clang llvm lld
 # Install the following for installation with DKMS
 sudo pacman -S dkms openssl mokutil
 ```
@@ -225,6 +227,8 @@ cd LenovoLegionLinux/kernel_module
 make
 sudo make reloadmodule
 ```
+
+*Note:* on kernels built with clang (`CONFIG_CC_IS_CLANG=y`, e.g. CachyOS) the Makefile detects this and passes `LLVM=1` to the kernel build by itself, for `make`, `make install` and DKMS alike; install `clang`, `llvm` and `lld` first.
 
 **For further instructions, problems, and tests see `Initial Usage Testing` below. Do them first before a permanent installation.**
 
@@ -465,7 +469,7 @@ Expected:
 
 - the controller might have loaded default values if you pressed Ctrl+Q(or FN+Q on certain devices) to change the power mode or waited too long; then try again
 - The entries in the fan curve are set to their values. The other values are not relevant (marked with XXXX)
-- On Legion Zone v3 firmware (e.g. Legion Pro 5 16IRX8, BIOS KWCN) the table holds fan levels 0-10 (`u` = 5): a written pwm is rounded to the nearest level (write 0, 26, 51, ... 255) and reads back as `level * 255 / 10` (0, 25, 51, 76, 102, 127, 153, 178, 204, 229, 255), points 9 and 10 need at least pwm 64 and 115, and a write below a point's minimum returns `Operation not supported`
+- On Legion Zone v3 firmware (e.g. Legion Pro 5 16IRX8, BIOS KWCN) the table holds fan levels 0-10 (`u` = 5): a written pwm is rounded to the nearest level (write 0, 26, 51, ... 255) and reads back as `level * 255 / 10` (0, 25, 51, 76, 102, 127, 153, 178, 204, 229, 255), points 9 and 10 need at least pwm 64 and 115, and a write below a point's minimum returns `Operation not supported`. The Python tools (`legion_cli`, `legion_gui` and the `legiond` presets) convert RPM values to the nearest firmware level on these models (for example 4400 rpm → level 9) and raise a 0 rpm point to the point's minimum level, so existing presets keep working
 
 ```
 u(speed_of_unit)|speed1[u]|speed2[u]|speed1[pwm]|speed2[pwm]|acceleration|deceleration|cpu_min_temp|cpu_max_temp|gpu_min_temp|gpu_max_temp|ic_min_temp|ic_max_temp
@@ -957,6 +961,15 @@ A graphical GNOME applet uses `power-profiles-daemon` to change the power mode u
 For KDE, there is the graphical tool `powerdevil`, which also uses `power-profiles-daemon` internally.
 
 If KDE only shows `balanced` and `performance` in `/sys/firmware/acpi/platform_profile_choices` but the Legion device (for example `/sys/devices/pci0000:00/0000:00:1f.0/PNP0C09:00/platform-profile/platform-profile-1/choices`) includes `quiet`, check whether `lenovo_wmi_gamezone` is also loaded. If both providers are active, the global profile choices are the intersection of both providers and quiet mode might disappear. In that case, unload or blacklist `lenovo_wmi_gamezone` and keep `legion_laptop` as the single provider for power mode.
+
+Alternatively keep both drivers and let each do what the other cannot: load `legion_laptop` with `enable_platformprofile=0`, so it registers no platform-profile provider and leaves the power mode (`platform_profile`) and the power limits (`/sys/class/firmware-attributes/lenovo-wmi-other-*`) to the mainline drivers. Its own `powermode` and power-limit attributes stay available under the platform device; what the mainline drivers do not offer at all, and what you keep `legion_laptop` for, is the fan curve, the fan speeds and fan full speed. Put
+
+```text
+options legion_laptop enable_platformprofile=0
+softdep legion_laptop pre: ideapad_laptop lenovo_wmi_gamezone lenovo_wmi_other lenovo_wmi_events lenovo_wmi_capdata
+```
+
+into `/etc/modprobe.d/legion_laptop.conf`; the `softdep` line loads the mainline drivers first so they bind the WMI devices both drivers list. The mainline `custom` profile is the same firmware mode as `powermode` 255; select it through `/sys/class/platform-profile/platform-profile-N/profile` of the device named `lenovo-wmi-gamezone`, because the legacy `/sys/firmware/acpi/platform_profile` file refuses `custom` by design. Verified on a Legion Pro 5 16IRX8 with kernel 7.2.
 
 ### It almost works, but (some) temperature sensor/changing point in fan control or (some) fan speed is not working. What should I do?
 

--- a/README.md
+++ b/README.md
@@ -821,6 +821,7 @@ Thank you for your contribution for the Linux support:
 * [normaneye](https://github.com/normaneye), fixing GPU temperature bug in GUI
 * [Petingoso](https://github.com/Petingoso), fix script to run withou sudo
 * [XenHat](https://github.com/XenHat), fix README
+* [Hishammm0](https://github.com/Hishammm0), Legion Pro 5 16IRX8 (KWCN) fan levels, kernel 7.x ACPI probe fix, clang build support
 
 Also please tell me if it works or does not work on your laptop.
 

--- a/README.md
+++ b/README.md
@@ -374,9 +374,9 @@ u(speed_of_unit)|speed1[u]|speed2[u]|speed1[pwm]|speed2[pwm]|acceleration|decele
 The fan curve is displayed as a table with the following columns:
 
 ```text
-u(speed_of_unit): unit for the speed (1- Percentage, 2-PWM, 3-RPM)
-speed1[u]: speed in rpm divided by 100 for fan1 at this point
-speed2[u]: speed in rpm divided by 100 for fan2 at this point
+u(speed_of_unit): unit for the speed (1-Percentage, 2-PWM, 3-RPM/100, 4-Percentage rounded to nearest, 5-Level index 0-10 into the firmware fan table)
+speed1[u]: speed of fan1 at this point, in the unit given by u
+speed2[u]: speed of fan2 at this point, in the unit given by u
 speed1[pwm]: speed in pwm (0-255) for fan1 at this point
 speed2[pwm]: speed in pwm (0-255) for fan2 at this point
 acceleration: acceleration time (higher = slower)
@@ -464,6 +464,7 @@ Expected:
 
 - the controller might have loaded default values if you pressed Ctrl+Q(or FN+Q on certain devices) to change the power mode or waited too long; then try again
 - The entries in the fan curve are set to their values. The other values are not relevant (marked with XXXX)
+- On Legion Zone v3 firmware (e.g. Legion Pro 5 16IRX8, BIOS KWCN) the table holds fan levels 0-10 (`u` = 5): a written pwm is rounded to the nearest level (write 0, 26, 51, ... 255) and reads back as `level * 255 / 10` (0, 25, 51, 76, 102, 127, 153, 178, 204, 229, 255), points 9 and 10 need at least pwm 64 and 115, and a write below a point's minimum returns `Operation not supported`
 
 ```
 u(speed_of_unit)|speed1[u]|speed2[u]|speed1[pwm]|speed2[pwm]|acceleration|deceleration|cpu_min_temp|cpu_max_temp|gpu_min_temp|gpu_max_temp|ic_min_temp|ic_max_temp

--- a/README_zh-hans.md
+++ b/README_zh-hans.md
@@ -384,9 +384,9 @@ u(speed_of_unit)|speed1[u]|speed2[u]|speed1[pwm]|speed2[pwm]|acceleration|decele
 风扇曲线以表格形式展示，列说明如下：
 
 ```text
-u(speed_of_unit): 风扇速度的单位（1-百分比, 2-PWM, 3-RPM）
-speed1[u]: fan1 在该点的速度（rpm 除以 100）
-speed2[u]: fan2 在该点的速度（rpm 除以 100）
+u(speed_of_unit): 风扇速度的单位（1-百分比, 2-PWM, 3-RPM/100, 4-百分比、四舍五入, 5-固件风扇表等级索引 0-10）
+speed1[u]: fan1 在该点的速度（单位由 u 决定）
+speed2[u]: fan2 在该点的速度（单位由 u 决定）
 speed1[pwm]: fan1 在该点的 pwm（0-255）
 speed2[pwm]: fan2 在该点的 pwm（0-255）
 acceleration: 加速时间（数值越大越慢）
@@ -476,6 +476,7 @@ cat /sys/kernel/debug/legion/fancurve
 
 - 如果你按下 Ctrl+Q（或某些设备的 FN+Q）更改电源模式，或等待时间过长，控制器可能会加载默认值；此时请重试
 - 风扇曲线中的对应条目值应被设置为你输入的数值，其它值不相关（用 XXXX 表示）
+- 在 Legion Zone v3 固件上（例如 Legion Pro 5 16IRX8，BIOS KWCN），风扇表保存的是 0-10 的风扇等级（`u` = 5）：写入的 pwm 会四舍五入到最近的等级（写入 0、26、51 … 255），读回时为 `level * 255 / 10`（0、25、51、76、102、127、153、178、204、229、255）；第 9、10 点至少需要 pwm 64 和 115，低于某点最小值的写入会返回 `Operation not supported`
 
 ```
 u(speed_of_unit)|speed1[u]|speed2[u]|speed1[pwm]|speed2[pwm]|acceleration|deceleration|cpu_min_temp|cpu_max_temp|gpu_min_temp|gpu_max_temp|ic_min_temp|ic_max_temp

--- a/README_zh-hans.md
+++ b/README_zh-hans.md
@@ -213,6 +213,8 @@ sudo zypper install dkms openssl mokutil
 
 ```bash
 sudo pacman -S linux-headers base-devel lm_sensors git dmidecode python-pyqt6 python-yaml python-argcomplete python-darkdetect
+# 仅用于 clang 编译的内核（例如 CachyOS）；Makefile 会自动以 LLVM=1 构建
+sudo pacman -S clang llvm lld
 # 如需通过 DKMS 安装，请安装以下包
 sudo pacman -S dkms openssl mokutil
 ```
@@ -235,6 +237,8 @@ cd LenovoLegionLinux/kernel_module
 make
 sudo make reloadmodule
 ```
+
+*注意：* 在使用 clang 编译的内核上（`CONFIG_CC_IS_CLANG=y`，例如 CachyOS），Makefile 会自动检测并在内核构建中传入 `LLVM=1`（`make`、`make install` 与 DKMS 均适用）；请先安装 `clang`、`llvm` 和 `lld`。
 
 **更多详细说明、问题和测试请见下方的 `首次使用测试` 部分，请务必先进行这些测试再进行永久安装。**
 
@@ -477,7 +481,7 @@ cat /sys/kernel/debug/legion/fancurve
 
 - 如果你按下 Ctrl+Q（或某些设备的 FN+Q）更改电源模式，或等待时间过长，控制器可能会加载默认值；此时请重试
 - 风扇曲线中的对应条目值应被设置为你输入的数值，其它值不相关（用 XXXX 表示）
-- 在 Legion Zone v3 固件上（例如 Legion Pro 5 16IRX8，BIOS KWCN），风扇表保存的是 0-10 的风扇等级（`u` = 5）：写入的 pwm 会四舍五入到最近的等级（写入 0、26、51 … 255），读回时为 `level * 255 / 10`（0、25、51、76、102、127、153、178、204、229、255）；第 9、10 点至少需要 pwm 64 和 115，低于某点最小值的写入会返回 `Operation not supported`
+- 在 Legion Zone v3 固件上（例如 Legion Pro 5 16IRX8，BIOS KWCN），风扇表保存的是 0-10 的风扇等级（`u` = 5）：写入的 pwm 会四舍五入到最近的等级（写入 0、26、51 … 255），读回时为 `level * 255 / 10`（0、25、51、76、102、127、153、178、204、229、255）；第 9、10 点至少需要 pwm 64 和 115，低于某点最小值的写入会返回 `Operation not supported`。在这些机型上，Python 工具（`legion_cli`、`legion_gui` 以及 `legiond` 预设）会把 RPM 值转换为最接近的固件等级（例如 4400 rpm → 9 级），并把 0 rpm 的点提升到该点的最低等级，因此现有预设仍可使用
 
 ```
 u(speed_of_unit)|speed1[u]|speed2[u]|speed1[pwm]|speed2[pwm]|acceleration|deceleration|cpu_min_temp|cpu_max_temp|gpu_min_temp|gpu_max_temp|ic_min_temp|ic_max_temp
@@ -984,6 +988,15 @@ GNOME 的图形小程序会用 `power-profiles-daemon` 以软件方式切换电�
 对于 KDE，有图形工具 `powerdevil`，其内部同样利用 `power-profiles-daemon`。
 
 如果 KDE 在 `/sys/firmware/acpi/platform_profile_choices` 中只显示 `balanced` 和 `performance`，但 Legion 设备（例如 `/sys/devices/pci0000:00/0000:00:1f.0/PNP0C09:00/platform-profile/platform-profile-1/choices`）包含 `quiet`，请检查是否同时加载了 `lenovo_wmi_gamezone`。如果两个驱动同时处于活动状态，全局可选模式会取两者的交集，quiet 模式可能会消失。此时可卸载或拉黑（blacklist）`lenovo_wmi_gamezone`，让 `legion_laptop` 成为唯一的电源模式提供者。
+
+另一种做法是同时保留两个驱动、各司其职：以 `enable_platformprofile=0` 加载 `legion_laptop`，它便不再注册电源模式提供者，把电源模式（`platform_profile`）和功耗限制（`/sys/class/firmware-attributes/lenovo-wmi-other-*`）交给主线驱动。它自身的 `powermode` 与功耗限制属性仍在平台设备下可用；主线驱动完全不提供、也正是保留 `legion_laptop` 的原因，是风扇曲线、风扇转速和风扇全速。将
+
+```text
+options legion_laptop enable_platformprofile=0
+softdep legion_laptop pre: ideapad_laptop lenovo_wmi_gamezone lenovo_wmi_other lenovo_wmi_events lenovo_wmi_capdata
+```
+
+写入 `/etc/modprobe.d/legion_laptop.conf`；`softdep` 行会先加载主线驱动，让它们先绑定两个驱动都声明的 WMI 设备。主线的 `custom` 配置与 `powermode` 255 是同一个固件模式；请通过名为 `lenovo-wmi-gamezone` 的设备的 `/sys/class/platform-profile/platform-profile-N/profile` 选择它，因为旧的 `/sys/firmware/acpi/platform_profile` 文件按设计拒绝 `custom`。已在 Legion Pro 5 16IRX8、内核 7.2 上验证。
 
 ### 几乎都能用，但某些温度传感器/风扇控制节点或风扇转速无效，怎么办？
 

--- a/README_zh-hans.md
+++ b/README_zh-hans.md
@@ -846,6 +846,7 @@ cat /sys/module/legion_laptop/drivers/platform:legion/PNP0C09:00/fan_unlock
 * [normaneye](https://github.com/normaneye)，修复了 GUI 中的 GPU 温度显示问题
 * [Petingoso](https://github.com/Petingoso)，修复了脚本无需 sudo 即可运行的问题
 * [XenHat](https://github.com/XenHat)，修正了 README 文档
+* [Hishammm0](https://github.com/Hishammm0)，Legion Pro 5 16IRX8（KWCN）风扇等级、内核 7.x ACPI 探测修复、clang 构建支持
 
 如果你的笔记本支持或者不支持本项目，请也告知我们。
 

--- a/README_zh-hans.md
+++ b/README_zh-hans.md
@@ -133,6 +133,7 @@ Lenovo Legion Linux（LLL）为联想拯救者系列笔记本提供了额外的L
 - 联想拯救者 7 Pro 16ARX8H（BIOS LPCN47WW）：传感器、风扇曲线、电源配置
 - 联想拯救者 7 16IAX7 (82TD)（BIOS K1CN48WW）：传感器、风扇曲线（写入正常；WMI 回读返回空缓冲区）、电源配置
 - 联想拯救者 Pro 7 16IRX8H（BIOS KWCN54WW）：传感器、风扇曲线、电源配置、风扇解锁（可将风扇上限从约 4400 RPM 提升至约 7100 RPM）
+- 联想拯救者 Pro 5 16IRX8（82WK，BIOS KWCN54WW）：传感器、风扇曲线（0-10 等级索引，自定义电源模式）、电源配置、通过 Other Method WMI 路径的功耗限制与风扇全速；风扇曲线已在 Linux 自定义电源模式下验证（9 级 → 4400/4600 RPM，10 级 → 5400/5400 RPM）
 - 联想拯救者 7 16IRX9，第九代：传感器、风扇曲线、电源配置；也可通过 [SmartFan](extra/smartfan/) 在不加载内核模块的情况下使用
 
 还支持更多机型 —— 包括 LOQ 系列以及 2024/2025 款拯救者（如 Legion 7 16IAX10）；完整列表见 [`kernel_module/legion-laptop.c`](kernel_module/legion-laptop.c) 中的 DMI 白名单。

--- a/doc/FEATURES_AND_TESTING.md
+++ b/doc/FEATURES_AND_TESTING.md
@@ -37,6 +37,8 @@ on Linux through this driver's hwmon interface: entering custom mode seeds an em
 2100 RPM (the EC ramps at roughly 100 RPM/s). The DSDT's Fan_Set_Table handler copies the ten bytes
 to EC RAM F9F0..F9F9 (`ecmemoryram` offset 0x1F0) and ignores the FSTM/FSID/FSTL header, so the
 `Fan_Get_Table` readback and that block are the same bytes.
+The Python tools (`legion_cli`, `legion_gui`, `legiond` presets) map RPM to the nearest level through
+`LEVEL_FAN_TABLES` in `legion.py` (keyed by BIOS prefix) and clamp to the per-point minimum.
 On the Legion Pro 7 16IRX8H with the same BIOS the EC resets the table to 1..10 when
 mode 0xE0 is entered and ignores later writes (issue #429); use mode 255 and check
 `/sys/kernel/debug/legion/ecmemory` offset 0x1F0..0x1F9 after a write.

--- a/doc/FEATURES_AND_TESTING.md
+++ b/doc/FEATURES_AND_TESTING.md
@@ -10,6 +10,37 @@ and the notice explains that custom fan curves are unsupported. Check that
 Run `QT_QPA_PLATFORM=offscreen python -m unittest discover -s tests -p
 'test_gui_startup.py'` for the startup regression tests.
 
+## Fan curve on Legion Zone v3 firmware (level indices)
+
+On `model_kwcn` (Legion Pro 5 16IRX8, BIOS KWCN54WW) `Fan_Set_Table` takes ten level
+indices 0-10, not percentages; `LENOVO_FAN_TABLE_DATA.FanTable_Data` maps level n to an
+RPM (fan 1 on the 16IRX8: 1700, 1900, 2100, 2300, 2500, 2900, 3400, 3700, 4400, 5400).
+The driver uses `FAN_SPEED_UNIT_LEVEL` (debugfs `u` = 5): hwmon pwm 0-255 maps to
+level `round(pwm * 10 / 255)`, a write below the per-point minimum 1,1,1,1,1,1,1,1,3,5
+returns `EOPNOTSUPP`, and an all-zero (never written) table is sent as 1..10.
+
+Test (custom power mode, `stress-ng` + `watch sensors` running):
+
+```bash
+H=$(grep -l legion_hwmon /sys/class/hwmon/hwmon*/name | xargs dirname)
+echo 255 | sudo tee $H/pwm1_auto_point10_pwm   # level 10
+sudo cat /sys/kernel/debug/legion/fancurve      # WMI block: u = 5, speed1 = 10
+sensors                                         # fan 1 should reach FanTable_Data[9]
+echo 204 | sudo tee $H/pwm1_auto_point10_pwm   # level 8 -> FanTable_Data[7]
+echo 25  | sudo tee $H/pwm1_auto_point10_pwm   # EOPNOTSUPP: point 10 minimum is 5
+```
+
+Measured on a Legion Pro 5 16IRX8 (KWCN54WW), first from Windows with the same WMI calls and then
+on Linux through this driver's hwmon interface: entering custom mode seeds an empty table with
+1,2,3,4,5,6,7,8,8,8; level 9 on every point gave 4400 / 4600 RPM (fan 1 / fan 2) and level 10 gave
+5400 / 5400 RPM, matching FanTable_Data, within 15 s from a warm fan and about 30 s from an idle
+2100 RPM (the EC ramps at roughly 100 RPM/s). The DSDT's Fan_Set_Table handler copies the ten bytes
+to EC RAM F9F0..F9F9 (`ecmemoryram` offset 0x1F0) and ignores the FSTM/FSID/FSTL header, so the
+`Fan_Get_Table` readback and that block are the same bytes.
+On the Legion Pro 7 16IRX8H with the same BIOS the EC resets the table to 1..10 when
+mode 0xE0 is entered and ignores later writes (issue #429); use mode 255 and check
+`/sys/kernel/debug/legion/ecmemory` offset 0x1F0..0x1F9 after a write.
+
 ## External HDMI
 Usually attached to dGPU. So easiest way to make it work is enabling dGPU only in BIOS/UEFI. More advanced would
 be switching in hybrid mode to dGPU only as long as HDMI is attached or outputting via dGPU.

--- a/kernel_module/legion-laptop.c
+++ b/kernel_module/legion-laptop.c
@@ -737,6 +737,13 @@ static const struct model_config model_kwcn = {
 	.acpi_check_dev = true,
 	.ramio_physical_start = 0xFE0B0400,
 	.ramio_size = 0x600,
+	/* 82WK DSDT: _CFG, GBMD and SBMC live under VPC0, not on the EC. */
+	.acpi_paths = { [ACPI_PATH_STA] = "\\_SB.PC00.LPCB.EC0.VPC0._STA",
+			[ACPI_PATH_CFG] = "\\_SB.PC00.LPCB.EC0.VPC0._CFG",
+			[ACPI_PATH_READ_RAPIDCHARGE] =
+				"\\_SB.PC00.LPCB.EC0.VPC0.GBMD",
+			[ACPI_PATH_WRITE_RAPIDCHARGE] =
+				"\\_SB.PC00.LPCB.EC0.VPC0.SBMC" },
 	/* WMAA(0, 0x0D, 0x01) raises the firmware fan ceiling from ~4400 RPM to
 	 * ~7000-7100 RPM on KWCN54WW (Legion Pro 7 16IRX8H, EC 0x5507).
 	 */

--- a/kernel_module/legion-laptop.c
+++ b/kernel_module/legion-laptop.c
@@ -714,7 +714,26 @@ static const struct model_config model_kwcn = {
 	.access_method_fanspeed = ACCESS_METHOD_WMI3,
 	.access_method_temperature = ACCESS_METHOD_WMI3,
 	.access_method_fancurve = ACCESS_METHOD_WMI3,
-	.access_method_fanfullspeed = ACCESS_METHOD_WMI,
+	/*
+	 * KWCN54WW (Legion Pro 5 16IRX8, 82WK) declares only Fan_Get_Table and
+	 * Fan_Set_Table on LENOVO_FAN_METHOD, only CPU_Set_OC_Data on
+	 * LENOVO_CPU_METHOD and nothing on LENOVO_GPU_METHOD, so the fan
+	 * full-speed methods (ids 1/2) and the legacy power-limit methods
+	 * cannot work. LENOVO_OTHER_METHOD answers for the plain feature IDs
+	 * and LENOVO_CAPABILITY_DATA_01 / LENOVO_DISCRETE_DATA publish the
+	 * per-mode ranges, so use the Other Method paths, clamped.
+	 */
+	.access_method_fanfullspeed = ACCESS_METHOD_WMI3,
+	.fanfullspeed_requires_custom_powermode = true,
+	.access_method_powerlimits = ACCESS_METHOD_WMI3_CLAMPED,
+	/*
+	 * Fan_Set_Table carries one level per point for both fans; the pwm2,
+	 * temperature and accel/decel curve attributes have no effect, so
+	 * hide them as model_n2cn does. Level 10 was measured at 5400 RPM
+	 * (= LENOVO_FAN_TABLE_DATA.CurrentFanMaxSpeed).
+	 */
+	.wmi_fancurve_speed_only = true,
+	.fan_max_rpm = 5400,
 	.acpi_check_dev = true,
 	.ramio_physical_start = 0xFE0B0400,
 	.ramio_size = 0x600,

--- a/kernel_module/legion-laptop.c
+++ b/kernel_module/legion-laptop.c
@@ -3213,13 +3213,33 @@ enum SENSOR_ATTR {
 /* ============================= */
 
 #define MAX_RPM 10000
+/* Highest level index Fan_Set_Table takes on Legion Zone v3 firmware. */
+#define MAX_FAN_LEVEL 10
 
 enum fan_speed_unit {
 	FAN_SPEED_UNIT_PERCENT = 1,
 	FAN_SPEED_UNIT_PWM = 2,
 	FAN_SPEED_UNIT_RPM_HUNDRED = 3,
 	FAN_SPEED_UNIT_PERCENT_NEAREST = 4,
+	/*
+	 * Index 0..MAX_FAN_LEVEL into the firmware's per-level RPM table
+	 * (WMI data block LENOVO_FAN_TABLE_DATA.FanTable_Data), the unit
+	 * Lenovo Legion Toolkit uses for Fan_Set_Table on Legion Zone v3
+	 * firmware (e.g. KWCN54WW). Level 0 means "fan off"; the driver
+	 * never sends it, see fancurve_level_min.
+	 */
+	FAN_SPEED_UNIT_LEVEL = 5,
 };
+
+/*
+ * Lowest level Lenovo Legion Toolkit sends per curve point on Legion Zone
+ * v3 firmware (GodModeControllerV2 GetMinimumFanTableAsync): level 0 is
+ * never sent and the last two points stay at or above 3 and 5. The EC
+ * does not range-check the table itself, so this is a safety policy,
+ * not a firmware limit.
+ */
+static const u8 fancurve_level_min[MAXFANCURVESIZE] = { 1, 1, 1, 1, 1,
+							1, 1, 1, 3, 5 };
 
 struct fancurve_point {
 	// rpm1 devided by 100
@@ -3328,6 +3348,18 @@ static bool fancurve_set_speed_pwm(struct fancurve *fancurve, int point_id,
 			0, 255);
 		return true;
 	}
+	case FAN_SPEED_UNIT_LEVEL: {
+		int level = DIV_ROUND_CLOSEST(value * MAX_FAN_LEVEL, 255);
+
+		if (level < fancurve_level_min[point_id]) {
+			pr_err("Level %d (pwm %d) is below the minimum %d for pwm1_auto_point%d_pwm\n",
+			       level, value, fancurve_level_min[point_id],
+			       point_id + 1);
+			return false;
+		}
+		*speed = level;
+		return true;
+	}
 	default:
 		pr_info("No method to set for fan_speed_unit %d.",
 			fancurve->fan_speed_unit);
@@ -3364,6 +3396,9 @@ static bool fancurve_get_speed_pwm(const struct fancurve *fancurve,
 		*value = speed * 255 * 100 / max_rpm;
 		return true;
 	}
+	case FAN_SPEED_UNIT_LEVEL:
+		*value = min_t(int, speed, MAX_FAN_LEVEL) * 255 / MAX_FAN_LEVEL;
+		return true;
 	default:
 		pr_info("No method to get for fan_speed_unit %d.",
 			fancurve->fan_speed_unit);
@@ -4072,6 +4107,7 @@ static ssize_t wmi_read_fancurve_custom(const struct model_config *model,
 	fancurve->fan_speed_unit =
 		model == &model_n2cn ? FAN_SPEED_UNIT_PERCENT_NEAREST :
 		model == &model_secn ? FAN_SPEED_UNIT_RPM_HUNDRED :
+		model == &model_kwcn ? FAN_SPEED_UNIT_LEVEL :
 				       FAN_SPEED_UNIT_PERCENT;
 
 	for (i = 0; i < size; i++) {
@@ -4079,16 +4115,51 @@ static ssize_t wmi_read_fancurve_custom(const struct model_config *model,
 
 		if (speed > U8_MAX)
 			return -ERANGE;
+		if (fancurve->fan_speed_unit == FAN_SPEED_UNIT_LEVEL &&
+		    speed > MAX_FAN_LEVEL)
+			pr_warn_once(
+				"fan table point %zu holds %u, above level %d (stale percent write?)\n",
+				i + 1, speed, MAX_FAN_LEVEL);
 		fancurve->points[i].speed1 = speed;
+		/* Fan_Set_Table carries one table for all fans (FSID = 0). */
+		fancurve->points[i].speed2 = speed;
 	}
 
 	return 0;
+}
+
+/*
+ * Make a level table safe to send. Fan_Get_Table returns ten zeros until
+ * something has written the table (EC RAM untouched since boot), and an
+ * older driver may have left percent-unit values above MAX_FAN_LEVEL
+ * behind. Unset points get Legion Toolkit's default curve (1..10), the
+ * rest is pulled inside [fancurve_level_min, MAX_FAN_LEVEL].
+ */
+static void fancurve_level_table_sanitize(u8 speeds[MAXFANCURVESIZE])
+{
+	size_t i;
+
+	for (i = 0; i < MAXFANCURVESIZE; i++) {
+		u8 fixed = speeds[i];
+
+		if (fixed == 0)
+			fixed = i + 1;
+		fixed = clamp_t(u8, fixed, fancurve_level_min[i],
+				MAX_FAN_LEVEL);
+		if (fixed != speeds[i]) {
+			pr_info("fan table point %zu: level %u sent as %u\n",
+				i + 1, speeds[i], fixed);
+			speeds[i] = fixed;
+		}
+	}
 }
 
 static ssize_t wmi_write_fancurve_custom(const struct model_config *model,
 					 const struct fancurve *fancurve)
 {
 	u8 buffer[0x40];
+	u8 speeds[MAXFANCURVESIZE];
+	size_t point;
 	int err;
 
 	// The buffer is read like this in ACPI firmware
@@ -4108,16 +4179,12 @@ static ssize_t wmi_write_fancurve_custom(const struct model_config *model,
 	// CreateByteField (Arg2, 0x18, FSS9)
 
 	memset(buffer, 0, sizeof(buffer));
-	buffer[0x06] = fancurve->points[0].speed1;
-	buffer[0x08] = fancurve->points[1].speed1;
-	buffer[0x0A] = fancurve->points[2].speed1;
-	buffer[0x0C] = fancurve->points[3].speed1;
-	buffer[0x0E] = fancurve->points[4].speed1;
-	buffer[0x10] = fancurve->points[5].speed1;
-	buffer[0x12] = fancurve->points[6].speed1;
-	buffer[0x14] = fancurve->points[7].speed1;
-	buffer[0x16] = fancurve->points[8].speed1;
-	buffer[0x18] = fancurve->points[9].speed1;
+	for (point = 0; point < MAXFANCURVESIZE; point++)
+		speeds[point] = fancurve->points[point].speed1;
+	if (fancurve->fan_speed_unit == FAN_SPEED_UNIT_LEVEL)
+		fancurve_level_table_sanitize(speeds);
+	for (point = 0; point < MAXFANCURVESIZE; point++)
+		buffer[0x06 + 2 * point] = speeds[point];
 
 	print_hex_dump(KERN_DEBUG, "legion_laptop fan table wmi write buffer",
 		       DUMP_PREFIX_ADDRESS, 16, 1, buffer, sizeof(buffer),

--- a/python/legion_linux/legion_linux/legion.py
+++ b/python/legion_linux/legion_linux/legion.py
@@ -806,6 +806,66 @@ class LenovoLegionLaptopSupportService(SystemDServiceFeature):
         super().__init__("legiond.service legiond-onresume.service legiond-cpuset.service legiond-cpuset.timer")
 
 
+# Models whose WMI3 fan curve takes level indices 0-10 instead of percentages
+# (FAN_SPEED_UNIT_LEVEL in the kernel module, debugfs unit 5), keyed by the BIOS
+# version prefix the kernel module uses for its DMI allowlist. The values are the
+# nominal RPM per level from the firmware's LENOVO_FAN_TABLE_DATA (fan 1, fan 2).
+# The firmware drives both fans from one table, so fan 1's table selects the
+# level and fan 2's is only used to display the resulting speed.
+# The KWCN numbers were read from a Legion Pro 5 16IRX8 (82WK, BIOS KWCN54WW);
+# other machines matched by the same prefix (e.g. the Legion Pro 7 16IRX8H) use
+# them as well, which only affects which level an RPM preset rounds to and the
+# RPM shown for a level, never the validity of the level written.
+LEVEL_FAN_TABLES = {
+    "KWCN": (
+        [1700, 1900, 2100, 2300, 2500, 2900, 3400, 3700, 4400, 5400],
+        [1700, 1900, 2100, 2200, 2700, 2900, 3500, 3700, 4600, 5400],
+    ),
+}
+# Lowest level the firmware accepts per curve point (the kernel module rejects
+# anything below with EOPNOTSUPP).
+LEVEL_POINT_MIN = [1, 1, 1, 1, 1, 1, 1, 1, 3, 5]
+MAX_FAN_LEVEL = 10
+
+
+def read_bios_version_prefix():
+    """Returns the first four characters of the BIOS version (e.g. KWCN), or an empty string."""
+    try:
+        with open("/sys/class/dmi/id/bios_version", "r", encoding=DEFAULT_ENCODING) as filepointer:
+            return filepointer.read().strip()[:4]
+    except OSError:
+        return ""
+
+
+def fan_level_to_pwm(level):
+    """Hwmon pwm value the kernel module maps back to exactly this level."""
+    return round(level * 255 / MAX_FAN_LEVEL)
+
+
+def fan_pwm_to_level(pwm):
+    """Level the kernel module derives from a pwm value (DIV_ROUND_CLOSEST(pwm * 10, 255))."""
+    return (pwm * MAX_FAN_LEVEL + 127) // 255
+
+
+def fan_rpm_to_level(rpm, point_id, table):
+    """Nearest level for an RPM value, clamped to the point's minimum and MAX_FAN_LEVEL.
+
+    An RPM exactly between two levels resolves to the lower (quieter) one.
+    """
+    if rpm <= 0:
+        level = 0
+    else:
+        level = 1 + min(range(len(table)), key=lambda i: abs(table[i] - rpm))
+    return max(LEVEL_POINT_MIN[point_id - 1], min(MAX_FAN_LEVEL, level))
+
+
+def fan_level_to_rpm(level, table):
+    """Nominal RPM of a level (0 for level 0)."""
+    if 1 <= level <= len(table):
+        return table[level - 1]
+    return 0
+
+
 class FanCurveIO(Feature):
     hwmon_dir_pattern = os.path.join(LEGION_SYS_BASEPATH, "hwmon/hwmon*")
     pwm1_fan_speed = "pwm1_auto_point{}_pwm"
@@ -828,8 +888,13 @@ class FanCurveIO(Feature):
     def __init__(self, expect_hwmon=True):
         super().__init__()
         self.hwmon_path = self._find_hwmon_dir()
+        self.level_tables = LEVEL_FAN_TABLES.get(read_bios_version_prefix())
         if (not self.hwmon_path) and expect_hwmon:
             raise FileNotFoundError("hwmon dir not found")
+
+    def uses_fan_levels(self):
+        """True when the fan curve speeds are firmware level indices, not percentages."""
+        return self.level_tables is not None
 
     def exists(self):
         if self.hwmon_path is not None:
@@ -923,7 +988,17 @@ class FanCurveIO(Feature):
         file_path = self.hwmon_path + self.pwm2_fan_speed.format(point_id)
         self._write_file(file_path, value)
 
+    def _rpm_to_pwm_by_level(self, point_id, value, table):
+        point_id = self._validate_point_id(point_id)
+        level = fan_rpm_to_level(value, point_id, table)
+        nominal = fan_level_to_rpm(level, table)
+        if abs(nominal - value) >= 50:
+            log.info("Fan curve point %d: %s rpm becomes level %d (%d rpm)", point_id, value, level, nominal)
+        return fan_level_to_pwm(level)
+
     def set_fan_1_speed_rpm(self, point_id, value):
+        if self.level_tables is not None:
+            return self.set_fan_1_speed_pwm(point_id, self._rpm_to_pwm_by_level(point_id, value, self.level_tables[0]))
         max_rpm = self.get_fan_1_max_rpm()
         if max_rpm == 0:
             raise ValueError("fan1_max is 0, cannot convert rpm to pwm")
@@ -931,6 +1006,8 @@ class FanCurveIO(Feature):
         return self.set_fan_1_speed_pwm(point_id, pwm)
 
     def set_fan_2_speed_rpm(self, point_id, value):
+        if self.level_tables is not None:
+            return self.set_fan_2_speed_pwm(point_id, self._rpm_to_pwm_by_level(point_id, value, self.level_tables[1]))
         max_rpm = self.get_fan_2_max_rpm()
         if max_rpm == 0:
             raise ValueError("fan2_max is 0, cannot convert rpm to pwm")
@@ -989,10 +1066,17 @@ class FanCurveIO(Feature):
 
     def get_fan_1_speed_rpm(self, point_id):
         pwm = self.get_fan_1_speed_pwm(point_id)
+        if self.level_tables is not None:
+            return fan_level_to_rpm(fan_pwm_to_level(pwm), self.level_tables[0])
         return round(((pwm * self.get_fan_1_max_rpm() + (100 * 255) - 1) // (100 * 255)) * 100, ndigits=2)
 
     def get_fan_2_speed_rpm(self, point_id):
+        if self.level_tables is not None and not self.has_fan_2_speed():
+            # one level drives both fans; report fan 2's nominal speed for that level
+            return fan_level_to_rpm(fan_pwm_to_level(self.get_fan_1_speed_pwm(point_id)), self.level_tables[1])
         pwm = self.get_fan_2_speed_pwm(point_id)
+        if self.level_tables is not None:
+            return fan_level_to_rpm(fan_pwm_to_level(pwm), self.level_tables[1])
         return round(((pwm * self.get_fan_2_max_rpm() + (100 * 255) - 1) // (100 * 255)) * 100, ndigits=2)
 
     def get_lower_cpu_temperature(self, point_id):
@@ -1109,7 +1193,9 @@ class FanCurveIO(Feature):
         has_acceleration_curve = self.has_acceleration_curve()
         for point_id in range(1, 11):
             fan1_speed = self.get_fan_1_speed_rpm(point_id)
-            fan2_speed = self.get_fan_2_speed_rpm(point_id) if has_fan_2_speed else fan1_speed
+            fan2_speed = (
+                self.get_fan_2_speed_rpm(point_id) if (has_fan_2_speed or self.level_tables is not None) else fan1_speed
+            )
             if has_temperature_curve:
                 cpu_lower_temp = self.get_lower_cpu_temperature(point_id)
                 cpu_upper_temp = self.get_upper_cpu_temperature(point_id)


### PR DESCRIPTION
Model: **Lenovo Legion Pro 5 16IRX8 (82WK), BIOS KWCN54WW, EC 0x5507**, i9-13900HX + RTX 4070 Laptop, on CachyOS
7.2.4-3-cachyos.

Fixes #564 (the fan-table and Other-Method parts). Applies cleanly on `main` on its own, but on kernel 7.x the
driver needs the probe fixes in the companion PR to load at all.

Everything below was measured, first on Windows with the same WMI calls Lenovo Legion Toolkit makes, then on Linux
through this driver's hwmon interface.

## `Fan_Set_Table` takes level indices 0..10, not percentages

The firmware publishes one nominal RPM per level and fan (`LENOVO_FAN_TABLE_DATA.FanTable_Data`, identical in every
power mode):

| level | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 |
|---|---|---|---|---|---|---|---|---|---|---|
| fan 1 | 1700 | 1900 | 2100 | 2300 | 2500 | 2900 | 3400 | 3700 | 4400 | 5400 |
| fan 2 | 1700 | 1900 | 2100 | 2200 | 2700 | 2900 | 3500 | 3700 | 4600 | 5400 |

In SmartFanMode 255, level 9 on every point gives **4400 / 4600 RPM** and level 10 gives **5400 / 5400 RPM**, the
table entries exactly. The fan 1 / fan 2 asymmetry at level 9 is the signature of a table lookup. The stock
`FAN_SPEED_UNIT_PERCENT` reads the firmware's default 1..10 back as pwm 2..25 and sends out-of-range levels on
write.

The 82WK DSDT confirms the mechanism. `\_SB_.GZFD.WMAB` method 6 creates FSTM@0, FSID@1, FSTL@2 and FSS0..FSS9,
never uses the first three, copies FSS0..FSS9 into `EC0.F9F0..F9F9` under the `LFCM` mutex, calls
`EC0.NCMD(0x8C, 0)` and returns 0 unconditionally. Method 5 ignores its argument, echoes the same ten bytes and
leaves the sensor half of the reply zero. So per-fan curves through FSID are unreachable here and the sensor table
is never populated.

`FAN_SPEED_UNIT_LEVEL` maps hwmon pwm 0..255 to level 0..10 and back, refuses a level below the per-point minimum
Legion Toolkit uses (1 for points 1-8, 3 and 5 for points 9-10) with `EOPNOTSUPP`, and sanitizes the whole table
before every transmit, because `Fan_Get_Table` returns ten zeros until the table has been written and an older
driver may have left percent values behind.

## The absent WMI methods do not fail, they return zeros

`LENOVO_FAN_METHOD` declares only `Fan_Get_Table` and `Fan_Set_Table` (no ids 1/2/3), `LENOVO_CPU_METHOD` only
`CPU_Set_OC_Data`, and `LENOVO_GPU_METHOD` nothing. On the stock driver `fan_fullspeed`, `fan_maxspeed` and six
power-limit attributes therefore read a silent **0** and three return EINVAL, because the WMI call's ACPI status is
never checked. `LENOVO_OTHER_METHOD.GetFeatureValue` answers the plain feature IDs and `LENOVO_CAPABILITY_DATA_01`
carries 70 per-mode rows with the ranges, which is exactly what `ACCESS_METHOD_WMI3_CLAMPED` consumes. So
`model_kwcn` moves to the Other Method paths, gains `wmi_fancurve_speed_only` (the temperature, pwm2 and
accel/decel attributes cannot be transmitted on this method) and `fan_max_rpm = 5400`.

## Userspace

`legion.py` converted RPM to pwm linearly through `fan1_max`, so on a level-index model a 4400 rpm preset became
level 8 (3700 rpm) and a 0 rpm point was refused by the driver. It now maps RPM to the nearest firmware level,
clamped to the point's minimum, and reads a level back as its nominal RPM. This covers `legion_cli`, the GUI and
`legiond`, which applies presets by running `legion_cli fancurve-write-preset-to-hw`.

## Verification

Balanced mode, after loading the patched module:

```text
$ D=/sys/bus/platform/drivers/legion/legion
$ cat $D/cpu_longterm_powerlimit $D/cpu_shortterm_powerlimit $D/gpu_ctgp_powerlimit $D/fan_fullspeed
70 119 55 0
$ H=$(grep -l legion_hwmon /sys/class/hwmon/hwmon*/name | xargs dirname); cat $H/fan1_max; ls $H | grep -c pwm
5400
10
```

The debugfs table shows `u` = 5 with levels 1..10 reading back as pwm 25..255. Flat-table test in custom mode
(`echo 255 > $D/powermode`), CPU idle:

| write | fans after 30 s | `Fan_Get_Table` / EC RAM 0x1F0 |
|---|---|---|
| level 9 on all ten points | **4400 / 4600 RPM** | `09` ×10, stable |
| level 10 on all ten points | **5400 / 5400 RPM** | `0a` ×10, stable |
| pwm 25 on point 10 (level 1, below its minimum 5) | unchanged | `Operation not supported`, dmesg names the attribute |
| restore 1..10, power mode back to balanced | spinning down | 1..10 |

The driver also coexists with the mainline `lenovo_wmi_*` drivers when loaded with `enable_platformprofile=0`: the
mainline drivers keep `platform_profile` and the power limits, this driver keeps the fan curve, and the mainline
`custom` profile turns out to be the same firmware mode as `powermode` 255. Both READMEs and
`doc/FEATURES_AND_TESTING.md` document that.

Gates: `tests/test_kernel_checkpath.sh` 0 errors / 0 warnings, clang-format clean, `tests/test_python.sh` 10.00/10,
`tests/test_python_cli.sh` passes, `black --check` clean.

Not included on purpose: surfacing the `Fan_Get_Table` sensor half as temperature breakpoints, since the DSDT shows
it is zero by construction on this firmware. `fan_unlock` was not exercised; the firmware's own maximum is 5400 RPM
on this model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
