### PR TITLE
fix(kernel-module): initialize ecram_read value on failure and drop dead error checks

### DIFF
--- a/kernel_module/legion-laptop.c
+++ b/kernel_module/legion-laptop.c
@@ -3137,7 +3137,7 @@ static void ecram_exit(struct ecram *ecram)
  */
 static u8 ecram_read(struct ecram *ecram, u16 ecram_offset)
 {
-	u8 value;
+	u8 value = 0;
 	int err;
 
 	err = ecram_portio_read(&ecram->portio, ecram_offset, &value);
@@ -3731,7 +3731,6 @@ static ssize_t ec_read_temperature(struct ecram *ecram,
 				   const struct model_config *model,
 				   int sensor_id, int *temperature)
 {
-	int err = 0;
 	unsigned long res;
 
 	if (sensor_id == 0) {
@@ -3742,16 +3741,14 @@ static ssize_t ec_read_temperature(struct ecram *ecram,
 		// TODO: use all correct error codes
 		return -EEXIST;
 	}
-	if (!err)
-		*temperature = res;
-	return err;
+	*temperature = res;
+	return 0;
 }
 
 static ssize_t ec_read_fanspeed(struct ecram *ecram,
 				const struct model_config *model, int fan_id,
 				int *fanspeed_rpm)
 {
-	int err = 0;
 	unsigned long res;
 
 	if (fan_id == 0) {
@@ -3768,9 +3765,8 @@ static ssize_t ec_read_fanspeed(struct ecram *ecram,
 		// TODO: use all correct error codes
 		return -EEXIST;
 	}
-	if (!err)
-		*fanspeed_rpm = res;
-	return err;
+	*fanspeed_rpm = res;
+	return 0;
 }
 
 // '\_SB.PCI0.LPC0.EC0.FANS


### PR DESCRIPTION
Closes part of #550 (the safe, behavior-preserving subset, item #1 step 1).

## What

- **`ecram_read`** now initializes `value = 0`, so an EC read failure
  (`ecram_portio_read` error) returns defined data instead of an
  uninitialized stack byte. Every hwmon read path (`sensor_show`,
  `fan1/2_input`, `fan_target`, minifancurve/fancurve reads) previously
  treated that garbage as a valid value.
- **`ec_read_temperature` / `ec_read_fanspeed`** drop the dead
  `if (!err)` branch (`err` was always 0, copy-pasted from the ACPI
  variant) and return 0 directly. No signature change, no cascade.

## Why safe

Behavior-preserving: on success, nothing changes. On failure, hwmon now
shows 0 instead of uninitialized data — and the dead checks were always
taken, so removing them cannot alter any path taken on real hardware.

The larger `ecram_read` error-propagation refactor (~68 call sites) is
left out intentionally, as its own reviewable PR per #550.

## Verification

- Build: `make CC=clang LD=ld.lld` — succeeds
- Lint: `./tests/test_kernel_checkpath.sh` — 0 errors, 0 warnings